### PR TITLE
Header nav stays in the same tab; replace P0 jargon with plain language

### DIFF
--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -69,10 +69,11 @@
     setEnv("local");
   }
 
-  // ---- open off-page links in a new tab (in-page #anchors scroll in place) ----
+  // ---- open off-page links in a new tab (header nav and in-page #anchors stay in place) ----
   document.querySelectorAll("a[href]").forEach(function (a) {
     var href = a.getAttribute("href");
-    if (href && href.charAt(0) !== "#") {
+    var inNav = a.closest && a.closest(".nav");
+    if (href && href.charAt(0) !== "#" && !inNav) {
       a.setAttribute("target", "_blank");
       a.setAttribute("rel", "noopener noreferrer");
     }

--- a/docs/goals-of-the-private-preview.md
+++ b/docs/goals-of-the-private-preview.md
@@ -36,7 +36,7 @@ This Private Preview is the first time the container is in the hands of real dev
 
 ## What you get from us
 
-- **Direct engineering channel.** The triage rotation is a named engineer per week. Bugs are acknowledged within one business day; P0 issues get an acknowledgement plus a plan within two business days.
+- **Direct engineering channel.** The triage rotation is a named engineer per week. Bugs are acknowledged within one business day; critical issues get an acknowledgement plus a plan within two business days.
 - **Working samples across stacks.** Node.js + Prisma, Python + SQLAlchemy, AI / RAG, .NET Aspire, CLI. Each sample is tested end to end and includes the local-to-cloud deployment leg.
 - **Container-specialized agent skills.** Loadable by any AI agent (Claude, Codex, GitHub Copilot) so the agent understands prerequisites, parameters, connection, common errors, and the local-to-cloud handoff.
 - **Private Teams channel for real-time conversation.** Customers are under NDA; the channel is private and access-controlled.

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -6,7 +6,7 @@ description: "Current gaps and rough edges in the Private Preview, with workarou
 ## Table of Contents
 
 - [How to read this page](#how-to-read-this-page)
-- [Current P0 issues](#current-p0-issues)
+- [Active issues we are fixing](#active-issues-we-are-fixing)
 - [Known behavior gaps](#known-behavior-gaps)
 - [Out of scope by design](#out-of-scope-by-design)
 - [Where to find live status](#where-to-find-live-status)
@@ -15,14 +15,14 @@ description: "Current gaps and rough edges in the Private Preview, with workarou
 
 This page lists the limitations we know about as of the version date above. Two categories matter:
 
-- **Current P0 issues** are blockers we are actively working on. If you hit one, the workaround is listed inline and the upstream fix is tracked.
+- **Active issues we are fixing** are blockers we are working on now. If you hit one, the workaround is listed inline and the fix is tracked.
 - **Known behavior gaps** are functional differences from Azure SQL Database in the cloud. They may close, or they may not, depending on Private Preview feedback.
 
 If you hit a limitation that is not on this page, please file a [GitHub issue](https://github.com/microsoft/azure-sql-database-container/issues/new?template=bug_report.yml) so we can either add it here or fix it.
 
-## Current P0 issues
+## Active issues we are fixing
 
-The following four issues are P0 blockers that we are actively tracking.
+The following four issues are the ones we are actively fixing.
 
 ### 1. Restriction enforcement gaps
 


### PR DESCRIPTION
Two small fixes.

## 1. Header links should not open in a new tab
The blanket new-tab rule was applying to the header nav too. The new-tab JS now skips links inside `.nav` (and in-page `#` anchors). Content and external links (GitHub, samples, agent installs) still open in a new tab.

## 2. Plain language instead of internal severity jargon
Customers do not know what P0 means. In the docs:
- `Current P0 issues` -> `Active issues we are fixing` (heading, table of contents, and category description).
- The engagement SLA note now says `critical issues` instead of `P0 issues`.

## After merge
Pages rebuilds; both go live.