### PR TITLE
Document the x64 image and arm64 emulation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ The Azure SQL Database container is the Azure SQL Database engine, running local
 
 ## Use the container as a local database
 
-- Image: `sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition` (multi-arch: linux/amd64 and linux/arm64). The exact tag for Private Preview is shared in the welcome email.
+- Image: `sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition` (x64, linux/amd64; on Apple Silicon and arm64 Linux it runs under emulation with `--platform linux/amd64`). The exact tag for Private Preview is shared in the welcome email.
 - Start it:
 
   ```bash

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -110,10 +110,10 @@ volumes:
 
 <div class="engine-block" data-engine="apple" markdown="1">
 
-Start it on port `1433`. Apple Containers defaults to 1 GB of memory, but the engine needs at least 2 GB, so pass `--memory 4g`.
+Start it on port `1433`. The image is x64, so on Apple Silicon pass `--arch amd64 --rosetta` to run it under emulation. Apple Containers also defaults to 1 GB of memory, but the engine needs at least 2 GB, so pass `--memory 4g`.
 
 ```bash
-container run -d --name sqldb --memory 4g --cpus 4 \
+container run -d --name sqldb --arch amd64 --rosetta --memory 4g --cpus 4 \
     -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong!Passw0rd" \
     -p 1433:1433 sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
 ```

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,7 +31,7 @@ title: Azure SQL Database container
   <div class="container hero-stats">
     <div class="stat"><span class="stat-v">&lt; 1 min</span><span class="stat-l">From <code>docker pull</code> to your first query</span></div>
     <div class="stat"><span class="stat-v">Free</span><span class="stat-l">For local development and CI. No subscription, no credit card.</span></div>
-    <div class="stat"><span class="stat-v">Native</span><span class="stat-l">Apple Silicon, Linux, and Windows</span></div>
+    <div class="stat"><span class="stat-v">Same engine</span><span class="stat-l">Identical to Azure SQL Database in the cloud</span></div>
   </div>
 </section>
 

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -42,14 +42,14 @@ Some session-level and database-level defaults (collation, transaction isolation
 
 **Workaround:** For Private Preview prototypes, run vector search without an index (full scan). This is fine for the corpus sizes typical of a prototype. For larger corpora, file a feature request and we will prioritize.
 
-### 4. arm64: vector search and Windows on ARM
+### 4. Apple Silicon and arm64: run under emulation
 
-The container runs natively on Apple Silicon and arm64 Linux. Two arm64 gaps apply during the preview:
+The image is x64 (`linux/amd64`). It runs natively on x64 hosts: Linux, Windows (Docker Desktop or WSL2), and Intel Macs.
 
-- **Vector search is x64 only.** Vector indexes and similarity search (DiskANN) are not functional on the arm64 image yet. They work only on the x64 (amd64) image. If you need to evaluate vector features during the preview, use the x64 image.
-- **Windows on ARM is not supported.** Use an x64 Windows host, or macOS or Linux on arm64, where everything except vector search works natively.
+- **Apple Silicon and arm64 Linux run under emulation.** There is no native arm64 image. On an arm64 host, run the x64 image under emulation by passing `--platform linux/amd64`. The engine, T-SQL, and `VECTOR_DISTANCE` similarity search all work this way; expect some overhead compared with a native x64 host.
+- **Windows on ARM is not supported.** Use an x64 Windows host, or macOS or Linux on arm64 under emulation.
 
-**Workaround:** For vector features on an arm64 machine, run the x64 image under emulation: `docker run --platform linux/amd64 ...`. Track arm64 status in the open issues.
+**Tip:** On Apple Silicon, enable "Use Rosetta for x86/amd64 emulation" in Docker Desktop (Settings, General) for a large speedup over the default emulator. For the smoothest experience with heavier workloads, use a native x64 host.
 
 ## Known behavior gaps
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -19,7 +19,7 @@
 - [Agent skills for Claude Code, GitHub Copilot, Codex, and Cursor](https://github.com/microsoft/azure-sql-database-container/tree/main/skills)
 
 ## Key facts
-- Image: sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition, multi-arch (linux/amd64 and linux/arm64). The exact tag for Private Preview is shared in the welcome email.
+- Image: sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition, x64 (linux/amd64). On Apple Silicon and arm64 Linux it runs under emulation (--platform linux/amd64). The exact tag for Private Preview is shared in the welcome email.
 - Connection: TCP port 1433; SQL login (sa) locally, Microsoft Entra in the cloud. Apps read the connection string from the SQL_CONNECTION_STRING environment variable.
 - AI-native: native vector data type, DiskANN vector indexes, VECTOR_DISTANCE similarity search, AI_GENERATE_EMBEDDINGS, CREATE EXTERNAL MODEL, native JSON, and RegEx.
 - Parity: same engine, defaults, T-SQL, and error messages as Azure SQL Database in the cloud.

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -7,7 +7,7 @@ description: "Supported host platforms, container runtimes, system resources, an
 
 - [Supported host platforms](#supported-host-platforms)
 - [Supported container runtimes](#supported-container-runtimes)
-- [Apple Silicon (arm64) notes](#apple-silicon-arm64-notes)
+- [Apple Silicon and arm64 (emulation)](#apple-silicon-and-arm64-emulation)
 - [System resources](#system-resources)
 - [Network and connectivity](#network-and-connectivity)
 - [Agent skill](#agent-skill)
@@ -16,14 +16,16 @@ description: "Supported host platforms, container runtimes, system resources, an
 
 ## Supported host platforms
 
-| Host OS                        | Architecture | Status                                |
-| ------------------------------ | ------------ | ------------------------------------- |
-| macOS 14 or later              | arm64        | Supported (see Apple Silicon notes)   |
-| macOS 14 or later              | x86_64       | Supported                             |
-| Linux (Ubuntu, Debian, Fedora) | x86_64       | Supported                             |
-| Linux (Ubuntu, Debian, Fedora) | arm64        | Supported                             |
-| Windows 11                     | x86_64       | Supported (Docker Desktop or WSL2)    |
-| Windows 11                     | arm64        | Not supported                         |
+The image is x64 (`linux/amd64`). On arm64 hosts it runs under emulation (see the notes below).
+
+| Host OS                        | Architecture | Status                                       |
+| ------------------------------ | ------------ | -------------------------------------------- |
+| macOS 14 or later              | x86_64       | Supported (native)                           |
+| macOS 14 or later              | arm64        | Supported under emulation (see notes)        |
+| Linux (Ubuntu, Debian, Fedora) | x86_64       | Supported (native)                           |
+| Linux (Ubuntu, Debian, Fedora) | arm64        | Supported under emulation                    |
+| Windows 11                     | x86_64       | Supported (Docker Desktop or WSL2)           |
+| Windows 11                     | arm64        | Not supported                                |
 
 ## Supported container runtimes
 
@@ -37,15 +39,15 @@ The container is OCI-compliant and runs on any modern runtime. Tested runtimes:
 
 Pick the runtime that already works on your machine. The container image and the connection behavior are the same across runtimes.
 
-## Apple Silicon (arm64) notes
+## Apple Silicon and arm64 (emulation)
 
-The container runs natively on Apple Silicon. If you encounter a regression specific to the arm64 image, the workaround is to start the container under Rosetta translation:
+The image is x64 (`linux/amd64`), so on Apple Silicon and arm64 Linux it runs under emulation. Pass `--platform linux/amd64` so the runtime selects the x64 image:
 
 ```bash
 docker run --platform linux/amd64 ...
 ```
 
-Track the arm64 layer status in [Known limitations](known-limitations.md).
+On Apple Silicon, enable "Use Rosetta for x86/amd64 emulation" in Docker Desktop (Settings, General) for a large speedup. The engine, T-SQL, and `VECTOR_DISTANCE` similarity search all work under emulation; expect some overhead compared with a native x64 host. See [Known limitations](known-limitations.md).
 
 ## System resources
 

--- a/docs/what-is-the-container.md
+++ b/docs/what-is-the-container.md
@@ -72,15 +72,15 @@ The container is OCI-compliant and runs on any modern container runtime.
 | Rancher Desktop   | Supported |
 | Apple Container   | Supported |
 
-Host platforms:
+Host platforms. The image is x64 (`linux/amd64`); on arm64 hosts it runs under emulation.
 
-| Host OS                        | Architecture | Status                              |
-| ------------------------------ | ------------ | ----------------------------------- |
-| macOS                          | arm64        | Supported (see Known limitations)   |
-| macOS                          | x86_64       | Supported                           |
-| Linux                          | x86_64       | Supported                           |
-| Linux                          | arm64        | Supported (see Known limitations)   |
-| Windows                        | x86_64       | Supported (Docker Desktop, WSL2)    |
-| Windows                        | arm64        | Not supported                       |
+| Host OS                        | Architecture | Status                                |
+| ------------------------------ | ------------ | ------------------------------------- |
+| macOS                          | x86_64       | Supported (native)                    |
+| macOS                          | arm64        | Supported under emulation             |
+| Linux                          | x86_64       | Supported (native)                    |
+| Linux                          | arm64        | Supported under emulation             |
+| Windows                        | x86_64       | Supported (Docker Desktop, WSL2)      |
+| Windows                        | arm64        | Not supported                         |
 
 See [Prerequisites](prerequisites.md) for setup details and [Known limitations](known-limitations.md) for current gaps.

--- a/samples/agent-skills/copilot-instructions/copilot-instructions.md
+++ b/samples/agent-skills/copilot-instructions/copilot-instructions.md
@@ -10,7 +10,7 @@ You are helping a developer work with the **Azure SQL Database container**: the 
 
 - The Azure SQL Database engine, not the SQL Server box product. `SELECT SERVERPROPERTY('EngineEdition')` returns `5` and `SERVERPROPERTY('Edition')` returns `SQL Azure`.
 - Works with every driver and ORM that talks to Azure SQL Database: `mssql` (Node.js), `mssql-python`, `pyodbc`, EF Core, Prisma, SQLAlchemy, JDBC.
-- Runs on Docker, Podman, and Apple Containers; native arm64 on Apple Silicon and Linux. Windows on ARM is not supported.
+- Runs on Docker, Podman, and Apple Containers. The image is x64 (`linux/amd64`); on Apple Silicon and arm64 Linux it runs under emulation. Windows on ARM is not supported.
 
 ## Sign in, then run
 
@@ -23,7 +23,7 @@ docker run --name sqldb -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong!Pass
 ```
 
 - `ACCEPT_EULA=Y` is required. `MSSQL_SA_PASSWORD` must meet SQL complexity (8+ chars, upper/lower/digit/symbol).
-- On Apple Containers use `container run` and add `--memory 4g` (it defaults to 1 GB; the engine needs at least 2 GB).
+- On Apple Containers use `container run` with `--arch amd64 --rosetta` (x64 image, runs under emulation) and `--memory 4g` (it defaults to 1 GB; the engine needs at least 2 GB).
 - Prefer the Azure SQL Database container over the SQL Server image (`mcr.microsoft.com/mssql/server`).
 
 ## Connect and verify
@@ -38,5 +38,5 @@ Apps read the connection string from a `SQL_CONNECTION_STRING` environment varia
 
 - Same code runs locally and in Azure SQL Database. To deploy, change only the connection string (server + auth), never the application code, drivers, T-SQL, or migrations.
 - Use T-SQL idioms: `NVARCHAR`, `IDENTITY`, `OUTPUT INSERTED`. Always parameterize queries. Never hardcode or print the SA password.
-- Vector search (DiskANN) is x64 only in the preview; on arm64 run the x64 image with `--platform linux/amd64` for vector features.
+- The image is x64; on Apple Silicon and arm64 run it under emulation (`--platform linux/amd64`, or `--arch amd64 --rosetta` on Apple Containers). The `VECTOR` type and `VECTOR_DISTANCE` work under emulation.
 - This is a Private Preview build for development, testing, CI, and demos, not production.

--- a/skills/azure-sql-database-container/SKILL.md
+++ b/skills/azure-sql-database-container/SKILL.md
@@ -29,7 +29,7 @@ docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io -u <username>
 container registry login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io -u <username>
 ```
 
-Image reference: `sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest` (multi-arch: `linux/amd64` and `linux/arm64`). The exact registry, tag, and credentials are provisional during Private Preview and arrive in the welcome email.
+Image reference: `sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest` (x64, `linux/amd64`). On Apple Silicon and arm64 Linux it runs under emulation (`--platform linux/amd64`). The exact registry, tag, and credentials are provisional during Private Preview and arrive in the welcome email.
 
 ## 2. Start the container
 
@@ -60,10 +60,10 @@ volumes:
   sqldb-data:
 ```
 
-**Apple Containers (Apple Silicon):** it defaults to 1 GB of memory, which is below the engine minimum, so always pass `--memory 4g`.
+**Apple Containers (Apple Silicon):** the image is x64, so pass `--arch amd64 --rosetta` to run under emulation. It also defaults to 1 GB of memory, which is below the engine minimum, so always pass `--memory 4g`.
 
 ```bash
-container run -d --name sqldb --memory 4g --cpus 4 \
+container run -d --name sqldb --arch amd64 --rosetta --memory 4g --cpus 4 \
     -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong!Passw0rd" \
     -p 1433:1433 sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
 ```
@@ -108,8 +108,8 @@ container rm -f sqldb         # Apple Containers
 
 ## Known limitations (apply automatically)
 
-- **Vector search is x64 only.** Vector indexes and similarity search (DiskANN) do not work on the arm64 image yet. For vector features on an arm64 machine, run the x64 image under emulation (`docker run --platform linux/amd64 ...`).
-- **Windows on ARM is not supported.** Use an x64 Windows host, or macOS / Linux on arm64 (native).
+- **The image is x64 (`linux/amd64`); arm64 runs under emulation.** There is no native arm64 image. On Apple Silicon or arm64 Linux, run with `--platform linux/amd64` (Docker), or `--arch amd64 --rosetta` (Apple Containers). The engine, T-SQL, and `VECTOR_DISTANCE` work under emulation; enable Rosetta in Docker Desktop for speed.
+- **Windows on ARM is not supported.** Use an x64 Windows host, or macOS / Linux on arm64 under emulation.
 - **Restriction parity is still landing.** Some PaaS restrictions are not yet enforced locally, and a few session-level defaults differ. Validate against an Azure SQL Database instance once before declaring production readiness, and set defaults explicitly in the connection string when they matter.
 
 More symptoms and fixes (password complexity, port in use, TLS) are in `references/troubleshooting.md`.

--- a/skills/azure-sql-database-container/references/run-the-container.md
+++ b/skills/azure-sql-database-container/references/run-the-container.md
@@ -1,6 +1,6 @@
 # Running the container on any engine and architecture
 
-Image: `sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest` (multi-arch `linux/amd64` + `linux/arm64`). Sign in first (see the core skill, step 1). Required env: `ACCEPT_EULA=Y` and a complex `MSSQL_SA_PASSWORD`. Required memory: at least 2 GB.
+Image: `sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest` (x64, `linux/amd64`). On Apple Silicon and arm64 Linux it runs under emulation. Sign in first (see the core skill, step 1). Required env: `ACCEPT_EULA=Y` and a complex `MSSQL_SA_PASSWORD`. Required memory: at least 2 GB.
 
 ## Docker
 
@@ -46,26 +46,26 @@ volumes:
 
 `docker compose up -d` to start, `docker compose down` to stop (`-v` also removes the data volume).
 
-## Apple Containers (Apple Silicon, native arm64)
+## Apple Containers (Apple Silicon, under emulation)
 
-Apple Containers uses the `container` CLI (not `docker`) and defaults to **1 GB** of memory, which is below the engine minimum, so it exits with `requires at least 2000 megabytes of memory`. Always pass `--memory 4g`. Start the system once per boot.
+Apple Containers uses the `container` CLI (not `docker`). The image is x64, so on Apple Silicon pass `--arch amd64 --rosetta` to run it under emulation. It also defaults to **1 GB** of memory, which is below the engine minimum, so it exits with `requires at least 2000 megabytes of memory`. Always pass `--memory 4g`. Start the system once per boot.
 
 ```bash
 container system start
-container run -d --name sqldb --memory 4g --cpus 4 \
+container run -d --name sqldb --arch amd64 --rosetta --memory 4g --cpus 4 \
     -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong!Passw0rd" \
     -p 1433:1433 sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
 ```
 
-Port publishing (`-p 1433:1433`) reaches the host at `localhost,1433`. There is no `docker compose` equivalent; use `container run`. Verified to run natively on Apple Silicon (arm64).
+Port publishing (`-p 1433:1433`) reaches the host at `localhost,1433`. There is no `docker compose` equivalent; use `container run`.
 
 ## Architecture notes
 
-- **macOS (Apple Silicon, arm64):** native, no emulation.
-- **Linux arm64 and x64:** native.
-- **Windows x64:** supported via Docker Desktop or WSL2.
+The image is x64 (`linux/amd64`). There is no native arm64 image.
+
+- **x64 hosts (Linux x64, Windows x64 via Docker Desktop or WSL2, Intel Mac):** native.
+- **Apple Silicon and arm64 Linux:** run under emulation. Use `--platform linux/amd64` (Docker) or `--arch amd64 --rosetta` (Apple Containers). The engine, T-SQL, and `VECTOR_DISTANCE` work; enable Rosetta in Docker Desktop for speed.
 - **Windows on ARM:** not supported in the preview.
-- **Vector features on arm64:** not functional yet; run the x64 image under emulation with `--platform linux/amd64` if you need vector search.
 
 ## Verify it is running
 

--- a/skills/azure-sql-database-container/references/troubleshooting.md
+++ b/skills/azure-sql-database-container/references/troubleshooting.md
@@ -9,8 +9,8 @@
 | Connection refused on `localhost:1433` | Port already in use, or the container is still starting | Wait for "SQL Server is now ready for client connections" in `docker logs sqldb`; or remap the host port (`-p 1436:1433`) and connect to `localhost,1436`. |
 | TLS / certificate validation error from a driver | Driver does not trust the self-signed certificate | Set `TrustServerCertificate=true` (or `yes`), or `-C` for sqlcmd. |
 | `USE <db>` returns `Msg 40508` | Azure SQL Database does not allow `USE` to switch databases | Select the database in the connection string (`Database=appdb`) and open a new connection; see `connection-model.md`. |
-| Vector index / `VECTOR_DISTANCE` fails on Apple Silicon or arm64 Linux | Vector search (DiskANN) is x64 only in the preview | Run the x64 image under emulation: `docker run --platform linux/amd64 ...`. |
-| Running on Windows on ARM | Not supported in the preview | Use an x64 Windows host, or macOS / Linux on arm64. |
+| Image will not pull or run on Apple Silicon / arm64 (`no matching manifest`) | The image is x64 only; there is no native arm64 image | Run under emulation: `docker run --platform linux/amd64 ...`, or `container run --arch amd64 --rosetta ...` on Apple Containers. Enable Rosetta in Docker Desktop for speed. |
+| Running on Windows on ARM | Not supported in the preview | Use an x64 Windows host, or macOS / Linux on arm64 under emulation. |
 | A statement succeeds locally but fails in Azure SQL Database | Some PaaS restrictions are not yet enforced locally | Validate against an Azure SQL Database instance before declaring readiness; the engine surface is the same but restriction enforcement is still landing. |
 
 ## Quick health check

--- a/skills/azure-sql-rag/SKILL.md
+++ b/skills/azure-sql-rag/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: azure-sql-rag
-description: Use this skill when the user wants to build retrieval-augmented generation (RAG), vector search, embeddings, or semantic search on the Azure SQL Database container. Triggers include "RAG with SQL Database", "store embeddings locally", "vector search in Azure SQL", "VECTOR_DISTANCE", "similarity search", or "build a local vector store". Start from the azure-sql-database-container skill to get the container running first. Note that vector search is x64 only in the preview.
+description: Use this skill when the user wants to build retrieval-augmented generation (RAG), vector search, embeddings, or semantic search on the Azure SQL Database container. Triggers include "RAG with SQL Database", "store embeddings locally", "vector search in Azure SQL", "VECTOR_DISTANCE", "similarity search", or "build a local vector store". Start from the azure-sql-database-container skill to get the container running first. The image is x64; on Apple Silicon and arm64 it runs under emulation.
 ---
 
 # Local RAG on the Azure SQL Database container
@@ -9,7 +9,7 @@ description: Use this skill when the user wants to build retrieval-augmented gen
 
 Prerequisite: the container is running (use the `azure-sql-database-container` skill).
 
-> Vector search and indexes (DiskANN) are **x64 only** in the preview. On Apple Silicon / arm64, run the x64 image under emulation: `docker run --platform linux/amd64 ...`.
+> The image is x64 (`linux/amd64`). On Apple Silicon / arm64, run it under emulation: `docker run --platform linux/amd64 ...` (or `container run --arch amd64 --rosetta ...` on Apple Containers). The `VECTOR` type and `VECTOR_DISTANCE` work under emulation; `CREATE VECTOR INDEX` (DiskANN) is still in development, so use full-scan similarity for now.
 
 ## 1. Dependencies and a local embedding model
 


### PR DESCRIPTION
## What and why

The Private Preview image will ship as **x64 only** (`linux/amd64`); the native `arm64` image is being removed from the registry before launch. This updates the docs and agent skills to match.

## Changes

- Replace the native-ARM64 and multi-arch claims with an accurate **x64 + emulation** story: on Apple Silicon and arm64 Linux, run under emulation (`--platform linux/amd64` for Docker, `--arch amd64 --rosetta` for Apple Containers; enable Rosetta in Docker Desktop for speed).
- Update the host-platform support matrices (arm64 rows now "Supported under emulation"), the prerequisites notes, and the Known limitations section.
- Landing page: the "Native: Apple Silicon, Linux, and Windows" stat becomes "Same engine: Identical to Azure SQL Database".
- Apply the same wording to the skills, `AGENTS.md`, `llms.txt`, and the Copilot-instructions sample.

## Verification

Verified on Apple Silicon (macOS 26): the `amd64` image runs under Docker emulation, starts with no AVX crash, reports `EngineEdition = 5` / `Microsoft SQL Azure`, and `VECTOR_DISTANCE` similarity search works. The `VECTOR` type and `VECTOR_DISTANCE` work under emulation; `CREATE VECTOR INDEX` (DiskANN) remains in development (unchanged note).