### PR TITLE
Fix the build prompts so they work end-to-end against the container

### DIFF
--- a/docs/prompts/ai-rag.md
+++ b/docs/prompts/ai-rag.md
@@ -19,11 +19,25 @@ Read the entire instruction set before executing.
 ```bash
 # The image is in a private preview registry; sign in with the credentials from the welcome email first
 docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io
-docker run -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong!Passw0rd" \
+docker run --name sqldb -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong!Passw0rd" \
     -p 1433:1433 -d sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
 ```
 
+Wait for the engine, then create the `appdb` database. Azure SQL Database does **not** create databases automatically on connect, so `appdb` must exist before `rag.py` connects:
+
+```bash
+# Create appdb, retrying until it succeeds (waits out engine startup; -b makes sqlcmd return a
+# non-zero exit on a SQL error so the loop retries while the engine is still initializing).
+until docker exec sqldb /opt/mssql-tools18/bin/sqlcmd \
+    -S localhost -U sa -P "YourStrong!Passw0rd" -C -b -l 2 \
+    -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;" >/dev/null 2>&1; do
+  sleep 2
+done
+```
+
 ### 2. Install dependencies and a local embedding model
+
+`mssql-python` requires **Python 3.10 or newer** (there is no distribution for 3.9). Use a 3.10+ interpreter or virtual environment.
 
 ```bash
 pip install mssql-python ollama python-dotenv
@@ -75,21 +89,22 @@ chunks = [
 ]
 for c in chunks:
     cur.execute(
-        "INSERT INTO documents (content, embedding) VALUES (?, CAST(? AS VECTOR(?)));",
-        c, embed(c), DIM,
+        # VECTOR's dimension must be a literal, not a bind parameter, so inline DIM
+        f"INSERT INTO documents (content, embedding) VALUES (?, CAST(? AS VECTOR({DIM})));",
+        c, embed(c),
     )
 conn.commit()
 
 # Retrieve: top-k nearest neighbours by cosine distance
 query = "How do I run vector search locally?"
 cur.execute(
-    """
+    f"""
     SELECT TOP 3 content,
-        VECTOR_DISTANCE('cosine', embedding, CAST(? AS VECTOR(?))) AS distance
+        VECTOR_DISTANCE('cosine', embedding, CAST(? AS VECTOR({DIM}))) AS distance
     FROM documents
     ORDER BY distance;
     """,
-    embed(query), DIM,
+    embed(query),
 )
 print(f"Query: {query}\n")
 for content, distance in cur.fetchall():

--- a/docs/prompts/ci.md
+++ b/docs/prompts/ci.md
@@ -34,20 +34,26 @@ jobs:
           MSSQL_SA_PASSWORD: ${{ secrets.SQL_SA_PASSWORD }}
         ports:
           - 1433:1433
+        # The runner has no sqlcmd; let the service report readiness with a health check
+        # that runs sqlcmd INSIDE the container. Actions blocks the job's steps until it passes.
+        options: >-
+          --health-cmd="/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P \"$MSSQL_SA_PASSWORD\" -C -l 2 -Q 'SELECT 1'"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=12
+          --health-start-period=30s
     env:
-      SQL_CONNECTION_STRING: "Server=localhost,1433;Database=master;User Id=sa;Password=${{ secrets.SQL_SA_PASSWORD }};TrustServerCertificate=true"
+      SQL_CONNECTION_STRING: "Server=localhost,1433;Database=appdb;User Id=sa;Password=${{ secrets.SQL_SA_PASSWORD }};TrustServerCertificate=true"
     steps:
       - uses: actions/checkout@v4
 
-      - name: Wait for SQL to accept connections
+      # The engine does not auto-create databases. Provision appdb once (sqlcmd lives in the
+      # service container, so exec into it rather than relying on sqlcmd on the runner).
+      - name: Create the application database
         run: |
-          for i in $(seq 1 30); do
-            if /opt/mssql-tools18/bin/sqlcmd -S localhost,1433 -U sa -P "${{ secrets.SQL_SA_PASSWORD }}" -C -Q "SELECT 1" >/dev/null 2>&1; then
-              echo "ready"; exit 0
-            fi
-            echo "waiting ($i)"; sleep 3
-          done
-          echo "database did not become ready"; exit 1
+          docker exec "${{ job.services.sqldb.id }}" /opt/mssql-tools18/bin/sqlcmd \
+            -S localhost -U sa -P "${{ secrets.SQL_SA_PASSWORD }}" -C \
+            -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;"
 
       # Replace with your stack's setup and test commands:
       - uses: actions/setup-node@v4

--- a/docs/prompts/local-to-cloud.md
+++ b/docs/prompts/local-to-cloud.md
@@ -23,11 +23,24 @@ Run the container locally on port 1433 with a strong SA password. Set `ACCEPT_EU
 ```bash
 # The image is in a private preview registry; sign in with the credentials from the welcome email first
 docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io
-docker run -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong!Passw0rd" \
+docker run --name sqldb -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong!Passw0rd" \
     -p 1433:1433 -d sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
 ```
 
 The registry path and image tag are provisional during Private Preview; use the exact values from the welcome email if different.
+
+The engine is not ready the instant `docker run` returns. Wait for it to accept connections, then create the `appdb` database. Azure SQL Database does **not** create databases automatically on connect, so the application database must exist before the app connects:
+
+```bash
+# Create appdb, retrying until it succeeds. This both waits out engine startup and survives the
+# brief window where the engine accepts connections but is still bringing databases online.
+# -b makes sqlcmd return a non-zero exit code on a SQL error (otherwise the loop would not retry).
+until docker exec sqldb /opt/mssql-tools18/bin/sqlcmd \
+    -S localhost -U sa -P "YourStrong!Passw0rd" -C -b -l 2 \
+    -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;" >/dev/null 2>&1; do
+  sleep 2
+done
+```
 
 ### 2. Install the driver and configure the project
 
@@ -49,7 +62,7 @@ SQL_CONNECTION_STRING="Server=localhost,1433;Database=appdb;User Id=sa;Password=
 # SQL_CONNECTION_STRING="Server=tcp:<your-server>.database.windows.net,1433;Database=appdb;Authentication=Active Directory Default;Encrypt=true"
 ```
 
-Add `.env` to `.gitignore`. The container creates `appdb` on first connect if it does not exist (or create it explicitly with a one-time `CREATE DATABASE appdb`).
+Add `.env` to `.gitignore`. The `appdb` database was created in step 1; the app connects to it directly (the engine does not create databases on connect).
 
 ### 4. Create an example script with a CRUD transaction
 

--- a/docs/prompts/offline.md
+++ b/docs/prompts/offline.md
@@ -14,7 +14,7 @@ Read the entire instruction set before executing.
 
 ### 1. Add a docker compose service with a persistent volume and a seed script
 
-Create `docker-compose.yml`. The container runs initialization `.sql` files mounted at `/docker-entrypoint-initdb.d/` on first start, which is how the seed data loads with no network.
+Create `docker-compose.yml`. The Azure SQL Database engine does not auto-run mounted `.sql` files, so the seed is mounted into the container and applied with one explicit command in step 3 (still fully offline — no network needed).
 
 ```yaml
 services:
@@ -28,7 +28,7 @@ services:
       - "1433:1433"
     volumes:
       - sqldb-data:/var/opt/mssql
-      - ./db/seed.sql:/docker-entrypoint-initdb.d/seed.sql:ro
+      - ./db/seed.sql:/seed.sql:ro
 volumes:
   sqldb-data:
 ```
@@ -54,11 +54,21 @@ INSERT INTO products (name, price) VALUES
 GO
 ```
 
-### 3. Start it and point the app at it
+### 3. Start it and load the seed
 
 ```bash
 docker compose up -d
+
+# Wait until the engine accepts connections, then apply the seed (it is not auto-run)
+until docker compose exec -T sqldb /opt/mssql-tools18/bin/sqlcmd \
+    -S localhost -U sa -P "YourStrong!Passw0rd" -C -l 2 -Q "SELECT 1" >/dev/null 2>&1; do
+  sleep 2
+done
+docker compose exec -T sqldb /opt/mssql-tools18/bin/sqlcmd \
+    -S localhost -U sa -P "YourStrong!Passw0rd" -C -i /seed.sql
 ```
+
+The seed runs once; the named volume keeps `appdb` and its data across restarts, so later `docker compose up -d` runs need no network and no re-seed.
 
 Set the app connection string (in `.env`, read from the environment, never hardcoded):
 

--- a/docs/prompts/sidecar.md
+++ b/docs/prompts/sidecar.md
@@ -26,6 +26,8 @@ services:
     depends_on:
       sqldb:
         condition: service_healthy
+      sqldb-init:
+        condition: service_completed_successfully
 
   sqldb:
     image: sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
@@ -39,15 +41,27 @@ services:
     healthcheck:
       test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -S localhost,1433 -U sa -P \"$$MSSQL_SA_PASSWORD\" -C -Q 'SELECT 1' || exit 1"]
       interval: 10s
-      timeout: 5s
-      retries: 10
-      start_period: 30s
+      timeout: 10s
+      retries: 12
+      start_period: 45s
+
+  # One-shot: create the application database once the engine is healthy.
+  # Azure SQL Database does not create databases automatically, so the app's
+  # target database (appdb) must be provisioned before the app starts.
+  sqldb-init:
+    image: sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
+    depends_on:
+      sqldb:
+        condition: service_healthy
+    restart: "no"
+    entrypoint: ["/opt/mssql-tools18/bin/sqlcmd", "-S", "sqldb,1433", "-U", "sa",
+      "-P", "YourStrong!Passw0rd", "-C", "-Q", "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;"]
 
 volumes:
   sqldb-data:
 ```
 
-Note: inside the compose network the app reaches the database at host `sqldb` (the service name), not `localhost`.
+Note: inside the compose network the app reaches the database at host `sqldb` (the service name), not `localhost`. The app waits for both the database to be healthy and `sqldb-init` to finish creating `appdb`.
 
 ### 2. Mirror it in the Dev Container (if present)
 
@@ -66,6 +80,7 @@ docker compose up
 ## Validation rules
 
 - The app uses `depends_on: condition: service_healthy` so it does not start before the database is ready.
+- The application database (`appdb`) is created by a one-shot init service before the app starts; the engine does not create it automatically.
 - Inside the compose network the connection host is the service name (`sqldb`), not `localhost`.
 - The connection string is provided via the environment, not hardcoded in app code.
 - `ACCEPT_EULA` is set to `Y`; the container requires it.

--- a/docs/prompts/templates.md
+++ b/docs/prompts/templates.md
@@ -45,6 +45,14 @@ Add a `.env` (gitignored) with a single connection string the app reads from the
 SQL_CONNECTION_STRING="Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true"
 ```
 
+Some ORMs read their own variable in their own format, not the ADO string above. For the **Prisma** `sqlserver` provider (Next.js / NestJS), also add a `DATABASE_URL` in Prisma's URL form — Prisma reads `DATABASE_URL`, not `SQL_CONNECTION_STRING`:
+
+```dotenv
+DATABASE_URL="sqlserver://localhost:1433;database=appdb;user=sa;password=YourStrong!Passw0rd;trustServerCertificate=true"
+```
+
+On Prisma 7+, the runtime client also needs a driver adapter: `npm i @prisma/adapter-mssql` and construct `PrismaClient` with the matching `PrismaMSSQL` adapter. `prisma migrate dev` creates the `appdb` database if it does not exist; for stacks whose migration tool does not (for example EF Core), first create it with `docker compose exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;"`.
+
 ### 3. Scaffold schema, migration, and data-access layer
 
 For the chosen stack:


### PR DESCRIPTION
## What and why

A reusable validation harness ran each `docs/prompts/*.md` "build" prompt faithfully (exactly as written) against the local Azure SQL Database container. Five of six failed end-to-end; this fixes them. All six now pass.

## Defects fixed

- **local-to-cloud, ai-rag** — the prompts assumed the engine auto-creates `appdb` on connect (it does not), so connections failed with "Cannot open database 'appdb'". Added a readiness + `CREATE DATABASE appdb` retry loop (`sqlcmd -b` so a transient `Msg 913` during startup isn't masked) and removed the false "creates appdb on first connect" claim.
- **ai-rag** — `CAST(? AS VECTOR(?))` is invalid (a VECTOR dimension cannot be a bind parameter → "Incorrect syntax near '@P3'"); inlined the literal `VECTOR(768)`. Also noted the Python 3.10+ requirement for `mssql-python`.
- **offline** — relied on `/docker-entrypoint-initdb.d` auto-run, which the mssql image does not do, so the seed never loaded. Mount the seed to a neutral path and apply it explicitly after a readiness wait.
- **sidecar** — `appdb` was never created. Added a one-shot init service that creates it once the engine is healthy (`service_completed_successfully` gate).
- **templates** — Prisma needs a `sqlserver://` `DATABASE_URL`, not the ADO `SQL_CONNECTION_STRING`; documented that plus the Prisma 7 `@prisma/adapter-mssql` adapter.
- **ci** — the wait loop invoked the container's `sqlcmd` path on the runner (which has none) and tested against `master`. Switched to the service health check, provision `appdb` via `docker exec` into the service, and target `appdb`.

## Verification

Each prompt was executed end-to-end against the container until green (e.g. ai-rag returns ranked `VECTOR_DISTANCE` rows; offline returns the 5 seeded rows and persists across restart). 6/6 pass.