### PR TITLE
Reframe x64-only: clean up llms.txt and code-comment residuals

### DIFF
--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -412,7 +412,7 @@ section[id] { scroll-margin-top: 84px; }
 .install-foot a { color: var(--vector); }
 .install-foot a:hover { text-decoration: none; opacity: .85; }
 
-/* ---------- engine pivot (Docker vs Apple Containers) in docs ---------- */
+/* ---------- engine pivot in docs ---------- */
 .pivot { display: inline-flex; gap: 4px; background: var(--mist); border: 1px solid var(--line); border-radius: 10px; padding: 4px; margin: 0 0 16px; }
 .pivot-btn { font-family: var(--font-display); font-weight: 600; font-size: .88rem; color: var(--muted); background: transparent; border: 0; border-radius: 7px; padding: 7px 16px; cursor: pointer; transition: background .15s ease, color .15s ease, box-shadow .15s ease; }
 .pivot-btn.is-active { background: var(--white); color: var(--ink); box-shadow: var(--shadow); }

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -37,7 +37,7 @@
     });
   });
 
-  // engine pivot (Docker / Apple Containers), page-level and persisted
+  // engine pivot, page-level and persisted
   (function () {
     var btns = document.querySelectorAll(".pivot-btn");
     if (!btns.length) return;

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -19,7 +19,7 @@
 - [Agent skills for Claude Code, GitHub Copilot, Codex, and Cursor](https://github.com/microsoft/azure-sql-database-container/tree/main/skills)
 
 ## Key facts
-- Image: sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition, x64 (linux/amd64). On Apple Silicon and arm64 Linux it runs under emulation (--platform linux/amd64). The exact tag for Private Preview is shared in the welcome email.
+- Image: sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition, x64 (linux/amd64); on a non-x64 host, add --platform linux/amd64. The exact tag for Private Preview is shared in the welcome email.
 - Connection: TCP port 1433; SQL login (sa) locally, Microsoft Entra in the cloud. Apps read the connection string from the SQL_CONNECTION_STRING environment variable.
 - AI-native: native vector data type, DiskANN vector indexes, VECTOR_DISTANCE similarity search, AI_GENERATE_EMBEDDINGS, CREATE EXTERNAL MODEL, native JSON, and RegEx.
 - Parity: same engine, defaults, T-SQL, and error messages as Azure SQL Database in the cloud.


### PR DESCRIPTION
Follow-up to #16. The earlier sweep was scoped to .md/.html/.yml and missed three non-markdown spots: `docs/llms.txt` (the agent-facing key-facts line still framed "Apple Silicon and arm64 Linux runs under emulation") and the engine-pivot comments in `main.scss` / `main.js` that named Apple Containers. All reframed to the neutral x64 note. Verified zero arm64/Apple/Rosetta/Docker-Desktop residuals across all file types (the unrelated Azure Resource Manager "ARM" reference is untouched).