### PR TITLE
Improve issue/discussion templates, reframe llms.txt, add Code of Conduct

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -6,9 +6,9 @@ body:
       value: |
         Ask a "how do I" question about the Azure SQL Database container. Before posting, scan the existing Q&A and the docs:
 
-        - [Prerequisites](../../docs/prerequisites.md)
-        - [Getting Started](../../docs/getting-started.md)
-        - [Known limitations](../../docs/known-limitations.md)
+        - [Prerequisites](https://microsoft.github.io/azure-sql-database-container/prerequisites.html)
+        - [Getting Started](https://microsoft.github.io/azure-sql-database-container/getting-started.html)
+        - [Known limitations](https://microsoft.github.io/azure-sql-database-container/known-limitations.html)
 
   - type: textarea
     id: question

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,21 +1,19 @@
 name: Bug report
 description: Report a bug, regression, or unexpected behavior in the Azure SQL Database container.
 title: "[Bug]: "
-labels: ["bug", "needs-triage"]
+type: Bug
+labels: ["bug", "needs-triage", "User-filled"]
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to file a bug. Please fill every field. The more complete the report, the faster the triage.
-
-        Before filing, please scan the [open issues](../../issues) for a duplicate and read [Known limitations](../../docs/known-limitations.md). If your bug is a known limitation, comment on the tracking issue with your scenario instead of opening a new one.
+        Thanks for filing a bug. Before you do, scan the [open issues](../../issues) and [Known limitations](https://microsoft.github.io/azure-sql-database-container/known-limitations.html) — if it is a known limitation, comment there instead.
 
   - type: input
     id: image-tag
     attributes:
       label: Container image tag
-      description: The exact image tag you pulled.
-      placeholder: "mcr.microsoft.com/azure-sql-database/container:preview"
+      placeholder: "sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest"
     validations:
       required: true
 
@@ -27,62 +25,35 @@ body:
         - macOS (x86_64 / Intel)
         - Linux (x86_64)
         - Windows 11 (x86_64)
-        - Other (describe in repro)
+        - Other (describe below)
     validations:
       required: true
 
-  - type: dropdown
+  - type: input
     id: runtime
     attributes:
-      label: Container runtime
-      options:
-        - Docker
-        - Podman
-        - Rancher Desktop
-        - containerd / nerdctl
-        - Other (describe in repro)
+      label: Container runtime and version
+      placeholder: "Docker 27.0.3 / Podman 5.0 / Rancher Desktop 1.13"
     validations:
       required: true
 
-  - type: input
-    id: runtime-version
+  - type: textarea
+    id: description
     attributes:
-      label: Runtime version
-      placeholder: "Docker 27.0.3"
+      label: What happened
+      description: What you expected versus what actually happened. Include error messages and `docker logs sqldb`.
     validations:
       required: true
-
-  - type: input
-    id: driver-orm
-    attributes:
-      label: Driver / ORM
-      description: If applicable.
-      placeholder: "Prisma 5.18 / mssql-python 1.0 / EF Core 9.0"
 
   - type: textarea
     id: repro
     attributes:
-      label: Reproduction steps
-      description: Step-by-step. Include the docker compose file or run command if relevant.
+      label: Steps to reproduce
+      description: Include the `docker run` command or `docker-compose.yml` if relevant.
       placeholder: |
-        1. Run `docker compose up -d` with the attached `docker-compose.yml`.
+        1. Start the container with ...
         2. Connect with `sqlcmd -S localhost,1433 -U sa -P ... -C`.
-        3. Run query: ...
-    validations:
-      required: true
-
-  - type: textarea
-    id: expected
-    attributes:
-      label: Expected behavior
-    validations:
-      required: true
-
-  - type: textarea
-    id: actual
-    attributes:
-      label: Actual behavior
-      description: Include error messages, stack traces, and `docker logs sqldb` output.
+        3. Run query / observe ...
     validations:
       required: true
 
@@ -90,14 +61,12 @@ body:
     id: additional
     attributes:
       label: Additional context
-      description: Anything else relevant. Screenshots, related issues, links.
+      description: Driver/ORM and version, screenshots, related issues. Optional.
 
   - type: checkboxes
     id: confirm
     attributes:
       label: Confirmation
       options:
-        - label: I have scanned open issues for duplicates.
-          required: true
-        - label: I have read the Known limitations doc.
+        - label: I scanned open issues and Known limitations for a duplicate.
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,14 +1,14 @@
 blank_issues_enabled: false
 contact_links:
   - name: Ask a question
-    url: ../../discussions/categories/q-a
+    url: https://github.com/microsoft/azure-sql-database-container/discussions/categories/q-a
     about: For "how do I" questions, use GitHub Discussions Q&A.
   - name: Share what you built
-    url: ../../discussions/categories/show-and-tell
+    url: https://github.com/microsoft/azure-sql-database-container/discussions/categories/show-and-tell
     about: Show & Tell category in GitHub Discussions.
   - name: Suggest an idea or direction
-    url: ../../discussions/categories/ideas
+    url: https://github.com/microsoft/azure-sql-database-container/discussions/categories/ideas
     about: For open-ended ideas and direction proposals, use Discussions Ideas.
   - name: Read the Private Preview docs
-    url: ../../docs/feedback-and-how-to-engage.md
+    url: https://microsoft.github.io/azure-sql-database-container/feedback-and-how-to-engage.html
     about: Pick the right channel for your question.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,8 @@
 name: Feature request
 description: Request a new capability, a behavior change, or an extension to the Azure SQL Database container.
 title: "[Feature]: "
-labels: ["enhancement", "needs-triage"]
+type: Feature
+labels: ["enhancement", "needs-triage", "User-filled"]
 body:
   - type: markdown
     attributes:
@@ -21,9 +22,7 @@ body:
     id: current-workaround
     attributes:
       label: Current workaround
-      description: How are you handling this today? "No workaround" is a valid answer.
-    validations:
-      required: true
+      description: How are you handling this today? "No workaround" is a valid answer. Optional.
 
   - type: textarea
     id: proposed

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+# Microsoft Open Source Code of Conduct
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+
+Resources:
+
+- [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/)
+- [Microsoft Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+- Contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with questions or concerns

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -10,12 +10,14 @@
 - [Known limitations](https://microsoft.github.io/azure-sql-database-container/known-limitations.html): current gaps and workarounds.
 - [Feedback and how to engage](https://microsoft.github.io/azure-sql-database-container/feedback-and-how-to-engage.html): GitHub Issues and Discussions, the team email, and office hours.
 
-## Samples
-- [Node.js + Prisma](https://github.com/microsoft/azure-sql-database-container/tree/main/samples/nodejs-prisma)
-- [Python + SQLAlchemy](https://github.com/microsoft/azure-sql-database-container/tree/main/samples/python-sqlalchemy)
-- [AI / RAG with vector search](https://github.com/microsoft/azure-sql-database-container/tree/main/samples/ai-rag)
-- [.NET Aspire](https://github.com/microsoft/azure-sql-database-container/tree/main/samples/dotnet-aspire)
-- [CLI quickstart](https://github.com/microsoft/azure-sql-database-container/tree/main/samples/cli)
+## Build prompts
+Copy-and-run prompts to hand your AI coding agent, each building a scenario against the container:
+- [Build locally, ship to Azure (Node.js)](https://github.com/microsoft/azure-sql-database-container/blob/main/docs/prompts/local-to-cloud.md)
+- [Prototype AI / RAG with vector search (Python + Ollama)](https://github.com/microsoft/azure-sql-database-container/blob/main/docs/prompts/ai-rag.md)
+- [Run integration tests in CI](https://github.com/microsoft/azure-sql-database-container/blob/main/docs/prompts/ci.md)
+- [Develop offline](https://github.com/microsoft/azure-sql-database-container/blob/main/docs/prompts/offline.md)
+- [Drop in as a sidecar](https://github.com/microsoft/azure-sql-database-container/blob/main/docs/prompts/sidecar.md)
+- [Scaffold a new project](https://github.com/microsoft/azure-sql-database-container/blob/main/docs/prompts/templates.md)
 - [Agent skills for Claude Code, GitHub Copilot, Codex, and Cursor](https://github.com/microsoft/azure-sql-database-container/tree/main/skills)
 
 ## Key facts


### PR DESCRIPTION
## Changes

**Issue templates**
- **bug_report.yml**: trimmed 103 → 72 lines (merged Expected/Actual into one *What happened*, combined runtime + version, single confirmation). Added GitHub issue **`type: Bug`** and a **`User-filled`** label. Fixed the wrong image-tag placeholder (was `mcr.microsoft.com/azure-sql-database/container:preview` → the real image).
- **feature_request.yml**: added **`type: Feature`** and **`User-filled`**; relaxed *current workaround* to optional.
- **config.yml**: relative `../../discussions/...` links → absolute URLs (GitHub contact links need full URLs).

**Discussions**
- **q-a.yml**: relative `../../docs/*` links → absolute Pages URLs so they resolve from the discussion form. (ideas/show-and-tell were already fine.)

**llms.txt**: replaced the "Samples" section (empty `samples/` app folders) with the **build prompts** (`docs/prompts`) + agent skills.

**Community health**: added **`CODE_OF_CONDUCT.md`** (standard Microsoft Open Source CoC) — it was missing.

**Labels**: created the missing labels the templates reference — `User-filled`, `needs-triage`, `idea`, `show-and-tell`.

> Note: `type: Bug`/`type: Feature` require the org-level issue Types to exist (they do in the `microsoft` org); if absent, GitHub ignores the key.