### PR TITLE
Add from-sql-server to the Build section; fix the offline seed USE

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -246,6 +246,15 @@ title: Azure SQL Database container
     </div>
     <div class="grid-3">
       <article class="card">
+        <span class="tag">from sql server</span>
+        <h3>Already using the SQL Server image?</h3>
+        <p>Convert a project on the <code>mcr.microsoft.com/mssql/server</code> box image to the Azure SQL Database engine: swap the image, fix the connection model, and flag box-only features. Azure-faithful local dev.</p>
+        <div class="card-actions">
+          <button class="card-prompt" type="button" data-prompt="{{ '/prompts/from-sql-server.md' | relative_url }}"><span class="card-prompt-ico" aria-hidden="true"></span><span class="copy-label">Copy prompt</span></button>
+          <a class="card-view" href="{{ '/prompts/from-sql-server.md' | relative_url }}">View</a>
+        </div>
+      </article>
+      <article class="card">
         <span class="tag">local &rarr; cloud</span>
         <h3>Build locally, ship to Azure</h3>
         <p>Develop and test at local-disk speed with no cloud round trip, then deploy the same code to Azure SQL Database. Lift and shift is a connection-string change.</p>

--- a/docs/prompts/from-sql-server.md
+++ b/docs/prompts/from-sql-server.md
@@ -1,0 +1,87 @@
+# AI Prompt: Convert a SQL Server box-image setup to the Azure SQL Database container
+
+**Role:** You are an expert agent converting the current project from the SQL Server box image (`mcr.microsoft.com/mssql/server`) to the Azure SQL Database container, so local development is Azure-faithful (the same engine you run in Azure SQL Database in the cloud).
+
+**Purpose:** Detect the box image, swap it for the Azure SQL Database engine image, fix the connection model, flag features that exist only in the box product, and verify you are on the real engine.
+
+**Scope:** A project that already runs `mcr.microsoft.com/mssql/server` (a `docker run`, a `docker-compose.yml`, a Dockerfile, or a Dev Container) with an `sa` login.
+
+Read the entire instruction set before executing.
+
+---
+
+## Instructions
+
+### 1. Detect the box image
+
+Search the repo for `mcr.microsoft.com/mssql/server` (and `mssql/server`) in `docker-compose*.yml`, Dockerfiles, run scripts, CI, and `.devcontainer/`. Note where the image, the `ACCEPT_EULA`/`MSSQL_SA_PASSWORD` env, and the connection string live.
+
+### 2. Sign in to the preview registry (Path B)
+
+The engine image is in a private preview registry. Sign in with the shared, pull-only username and password requested through the early-access feedback channel (they may be rotated during the preview):
+
+```bash
+docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io -u <username>
+```
+
+### 3. Swap the image
+
+Replace `mcr.microsoft.com/mssql/server:<tag>` with the engine image:
+
+```
+sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
+```
+
+Keep `ACCEPT_EULA=Y` and the `sa` password. The image is x64 only; on a non-x64 host add `--platform linux/amd64` (Docker) or `platform: linux/amd64` (compose). In a shell snippet that adds the flag conditionally, build it as an array so it is safe in both bash and zsh:
+
+```bash
+PLATFORM=(); case "$(docker info -f '{{.Architecture}}' 2>/dev/null)" in x86_64|amd64) ;; *) PLATFORM=(--platform linux/amd64);; esac
+docker run -d --name sqldb "${PLATFORM[@]}" -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong!Passw0rd" \
+    -p 1433:1433 sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
+```
+
+### 4. Fix the connection model
+
+The Azure SQL Database engine does **not** auto-create databases, and the connection model differs from the box product. Provision the application database on a `master` connection, then point the app at that database:
+
+```bash
+docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -b \
+    -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;"
+```
+
+Re-point connection strings from `Database=master` to `Database=appdb`. Do not switch databases with `USE`: in a user-database (SDS) session `USE` returns `Msg 40508`, exactly as in Azure SQL Database in the cloud (a `master` connection is a non-SDS provisioning session where it appears to work, but `master` is for provisioning only). Select the database in the connection string.
+
+### 5. Flag box-only features to remove
+
+These exist in the SQL Server box product but **not** in Azure SQL Database; remove or replace any usage so the app works against the engine and the cloud:
+
+- SQL Server Agent jobs (`msdb.dbo.sp_add_job`, etc.)
+- FILESTREAM / FileTable
+- Full Service Broker across instances
+- Cross-server distributed transactions and linked servers
+- Windows Authentication / NTLM (use the `sa` login locally, Microsoft Entra in the cloud)
+
+### 6. Verify you are on the real engine
+
+```bash
+docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -b \
+    -d appdb -Q "SELECT SERVERPROPERTY('EngineEdition') AS EngineEdition, SERVERPROPERTY('Edition') AS Edition;"
+```
+
+Expect `EngineEdition = 5` and `Edition = SQL Azure`. The box image returns different values; if you see those, the image was not swapped.
+
+---
+
+## Validation rules
+
+- No `mcr.microsoft.com/mssql/server` remains in compose, Dockerfiles, run scripts, CI, or Dev Container.
+- `--platform linux/amd64` is added on non-x64 hosts (compose `platform:` or the array-form shell snippet).
+- `appdb` is created on a `master` connection before the app connects with `Database=appdb`; no `USE` to switch databases.
+- At least one box-only feature is flagged (or the app confirmed not to use any).
+- `EngineEdition = 5` against the running container.
+
+## Do not
+
+- Do not keep the box image or call arm64 / Apple Silicon "supported".
+- Do not develop against `master`; do real work on the user database.
+- Do not commit the SA password or the registry credentials.

--- a/docs/prompts/offline.md
+++ b/docs/prompts/offline.md
@@ -35,13 +35,9 @@ volumes:
 
 ### 2. Create the schema and seed data
 
-Create `db/seed.sql` with the schema and enough realistic rows to demo the app offline.
+Create `db/seed.sql` with the schema and enough realistic rows to demo the app offline. It targets `appdb` (selected with `-d appdb` in step 3), so it contains no `CREATE DATABASE` and no `USE`:
 
 ```sql
-IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;
-GO
-USE appdb;
-GO
 CREATE TABLE products (
     id INT IDENTITY(1,1) PRIMARY KEY,
     name NVARCHAR(200) NOT NULL,
@@ -59,13 +55,16 @@ GO
 ```bash
 docker compose up -d
 
-# Wait until the engine accepts connections, then apply the seed (it is not auto-run)
+# Wait until the engine is ready and create appdb (it is not auto-created). The -b makes a SQL
+# error set the exit code, so transient startup errors are retried, not masked.
 until docker compose exec -T sqldb /opt/mssql-tools18/bin/sqlcmd \
-    -S localhost -U sa -P "YourStrong!Passw0rd" -C -l 2 -Q "SELECT 1" >/dev/null 2>&1; do
+    -S localhost -U sa -P "YourStrong!Passw0rd" -C -b -l 2 \
+    -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;" >/dev/null 2>&1; do
   sleep 2
 done
+# Apply the schema and data to appdb. Select the database with -d; do not USE.
 docker compose exec -T sqldb /opt/mssql-tools18/bin/sqlcmd \
-    -S localhost -U sa -P "YourStrong!Passw0rd" -C -i /seed.sql
+    -S localhost -U sa -P "YourStrong!Passw0rd" -C -b -d appdb -i /seed.sql
 ```
 
 The seed runs once; the named volume keeps `appdb` and its data across restarts, so later `docker compose up -d` runs need no network and no re-seed.


### PR DESCRIPTION
Reconciles the landing page **#build** section with the new skill collection.

- Adds a **"from sql server"** card (first in the grid) + `docs/prompts/from-sql-server.md`: convert a project off the `mcr.microsoft.com/mssql/server` box image to the Azure SQL Database engine (swap image, Path B sign-in, provision `appdb`, fix the connection model, flag box-only features, verify EngineEdition=5). It is the highest-value interception scenario and was missing from the landing page.
- Fixes `offline.md`: the seed used `CREATE DATABASE` + `USE appdb` (works only from a non-SDS `master` connection). Now provisions `appdb` in the readiness loop and applies the schema with `-d appdb`, matching the skills' "select the database, never USE" pattern.

The other five prompt cards already point at the PR #15-fixed prompts and are consistent (no stale creds). Card titles/links validated; new recipe is bash-syntax clean and uses the zsh-safe array form.