### PR TITLE
Make the footer Documentation column mirror the navbar

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -11,11 +11,11 @@
 
     <div class="footer-col">
       <h4>Documentation</h4>
-      <a href="{{ '/what-is-the-container.html' | relative_url }}">What is the container</a>
-      <a href="{{ '/goals-of-the-private-preview.html' | relative_url }}">Goals of the preview</a>
+      <a href="{{ '/what-is-the-container.html' | relative_url }}">Overview</a>
       <a href="{{ '/prerequisites.html' | relative_url }}">Prerequisites</a>
-      <a href="{{ '/getting-started.html' | relative_url }}">Getting started</a>
-      <a href="{{ '/known-limitations.html' | relative_url }}">Known limitations</a>
+      <a href="{{ '/getting-started.html' | relative_url }}">Get started</a>
+      <a href="{{ '/#build' | relative_url }}">Build</a>
+      <a href="{{ '/known-limitations.html' | relative_url }}">Limitations</a>
     </div>
 
     <div class="footer-col">


### PR DESCRIPTION
The footer's Documentation column still linked **Goals of the preview** (removed from the nav when Goals was merged into Overview, PR #14) and labeled the overview page **What is the container**. Align it with the navbar: **Overview, Prerequisites, Get started, Build, Limitations** (matching labels and order). Goals stays reachable via the README TOC; Feedback/engage links remain in the Engage column.