### PR TITLE
Polish skills content and AI-agents/getting-started pages

### DIFF
--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -412,12 +412,13 @@ section[id] { scroll-margin-top: 84px; }
 .install-foot a { color: var(--vector); }
 .install-foot a:hover { text-decoration: none; opacity: .85; }
 
-/* ---------- engine pivot in docs ---------- */
-.pivot { display: inline-flex; gap: 4px; background: var(--mist); border: 1px solid var(--line); border-radius: 10px; padding: 4px; margin: 0 0 16px; }
-.pivot-btn { font-family: var(--font-display); font-weight: 600; font-size: .88rem; color: var(--muted); background: transparent; border: 0; border-radius: 7px; padding: 7px 16px; cursor: pointer; transition: background .15s ease, color .15s ease, box-shadow .15s ease; }
-.pivot-btn.is-active { background: var(--white); color: var(--ink); box-shadow: var(--shadow); }
-.pivot-btn:hover:not(.is-active) { color: var(--ink); }
-.engine-block[hidden] { display: none; }
+/* ---------- "what the skills do" table in #ai-agents ---------- */
+.skill-table-lead { color: var(--muted); font-size: 1.05rem; max-width: 760px; margin: 36px 0 14px; }
+.skill-table { width: 100%; border-collapse: collapse; margin: 0 0 8px; font-size: .95rem; }
+.skill-table th, .skill-table td { text-align: left; padding: 11px 14px; border-bottom: 1px solid var(--line); vertical-align: top; }
+.skill-table thead th { font-family: var(--font-display); font-size: .8rem; letter-spacing: .04em; text-transform: uppercase; color: var(--muted); }
+.skill-table tbody td:first-child { font-weight: 600; color: var(--ink); white-space: nowrap; }
+.skill-table code { font-size: .85em; }
 
 /* ---------- quickstart: numbered steps with full-width command bars ---------- */
 .qsteps { display: flex; flex-direction: column; gap: 18px; max-width: 940px; }

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -37,29 +37,6 @@
     });
   });
 
-  // engine pivot, page-level and persisted
-  (function () {
-    var btns = document.querySelectorAll(".pivot-btn");
-    if (!btns.length) return;
-    function setEngine(engine) {
-      document.querySelectorAll(".pivot-btn").forEach(function (b) {
-        var on = b.getAttribute("data-engine") === engine;
-        b.classList.toggle("is-active", on);
-        b.setAttribute("aria-selected", on ? "true" : "false");
-      });
-      document.querySelectorAll(".engine-block").forEach(function (el) {
-        el.hidden = el.getAttribute("data-engine") !== engine;
-      });
-      try { localStorage.setItem("asdb-engine", engine); } catch (e) {}
-    }
-    btns.forEach(function (b) {
-      b.addEventListener("click", function () { setEngine(b.getAttribute("data-engine")); });
-    });
-    var saved = "docker";
-    try { saved = localStorage.getItem("asdb-engine") || "docker"; } catch (e) {}
-    setEngine(saved);
-  })();
-
   // add a copy button to every code block in the docs
   document.querySelectorAll(".prose pre").forEach(function (pre) {
     var btn = document.createElement("button");

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,29 +26,27 @@ Everything below works the same on macOS, Linux, and Windows.
 
 ## Option A: let an AI coding agent do it
 
-The fastest path is to let your AI coding agent set everything up. Install the container skill once. It works across Claude Code, GitHub Copilot, Codex, and Cursor.
+The fastest path is to let your AI coding agent set everything up. Install the skill collection once. It works across Claude Code, GitHub Copilot (VS Code and CLI), Codex, and Cursor.
 
 ```bash
-npx skills add azuresql-db-container
+npx skills add microsoft/azure-sql-database-container
 ```
 
 Then ask your agent in plain English, for example:
 
 > Add a local Azure SQL Database to this project, then scaffold the schema, migrations, and data-access layer for my stack.
 
-The skill teaches your agent the registry, image, ports, and connection string, so it can sign in, start the container, and wire your app to it. Browse the skill and more ready-made prompts in [agent skills](https://github.com/microsoft/azure-sql-database-container/tree/main/skills).
+**Why use the skills?** They already know the private preview registry, the x64 image, the connection model (the engine does not auto-create databases, so they provision `appdb` first), the readiness wait, and the local-to-cloud story. So your agent stands up a real Azure SQL Database the right way the first time, instead of reaching for the SQL Server box image (`mcr.microsoft.com/mssql/server`) or inventing behavior the engine does not have. Browse the [skills on GitHub](https://github.com/microsoft/azure-sql-database-container/tree/main/skills).
 
 ## Option B: set it up yourself
 
-Prefer to run the commands yourself? Pick your container engine and follow the steps. Everything works the same on macOS, Linux, and Windows.
-
-<div class="pivot" role="tablist" aria-label="Container engine">
-  <button class="pivot-btn" type="button" data-engine="docker" role="tab">Docker / Podman</button>
-</div>
+Prefer to run the commands yourself? Follow the steps below with Docker or Podman. Everything works the same on macOS, Linux, and Windows.
 
 ### Step 1: sign in and pull the image
 
-The preview image is served from a private registry. Sign in with the username and password, requested via the early-access feedback channel (pull-only; may be rotated during the preview), then pull the image.
+The preview image is served from a private registry. Sign in, then pull the image.
+
+> **Note:** the registry username and password are **provided to Private Preview cohort participants**. Request them via the early-access feedback channel. They are shared and pull-only, must be treated as secrets, and may be rotated during the preview.
 
 <div class="engine-block" data-engine="docker" markdown="1">
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -143,11 +143,27 @@ title: Azure SQL Database container
       </a>
     </div>
 
+    <p class="skill-table-lead">A collection of skills your agent loads on demand. Each one teaches it to use the engine the right way, so it does not reach for the SQL Server box image or invent behavior the engine does not have:</p>
+    <table class="skill-table">
+      <thead><tr><th>Skill</th><th>What it does for your agent</th></tr></thead>
+      <tbody>
+        <tr><td>Start the engine</td><td>Free host port, <code>--platform linux/amd64</code> on non-x64 hosts, a ready-wait loop, and <code>CREATE DATABASE appdb</code> (the engine does not auto-create databases).</td></tr>
+        <tr><td>Convert from SQL Server</td><td>Move a project off the <code>mcr.microsoft.com/mssql/server</code> box image to the real Azure SQL Database engine.</td></tr>
+        <tr><td>Local to cloud</td><td>Ship the same code to Azure SQL Database in the cloud; only the connection string changes.</td></tr>
+        <tr><td>Schema migrations</td><td>Apply EF Core, Prisma, Alembic, or SqlPackage migrations against the user database.</td></tr>
+        <tr><td>Import a database</td><td>Load an existing <code>.bacpac</code> / <code>.dacpac</code> into the container with SqlPackage.</td></tr>
+        <tr><td>RAG and vector search</td><td>Native <code>VECTOR</code> type and <code>VECTOR_DISTANCE</code>, with a local embedding model.</td></tr>
+        <tr><td>CI</td><td>Run the engine as a service in GitHub Actions, with the right readiness and provisioning.</td></tr>
+        <tr><td>Sidecar</td><td>Add it to a docker compose stack or Dev Container, wired by service name.</td></tr>
+        <tr><td>Scaffold</td><td>Bootstrap a new app with the container as the default local database.</td></tr>
+      </tbody>
+    </table>
+
     <div class="skill">
       <p class="skill-line">Install the skill once. It works across Claude Code, GitHub Copilot, Codex, and Cursor, then you just ask your agent in plain English.</p>
       <div class="skill-cmd">
-        <code><span class="cmd-p">$</span> npx skills add azure-sql-database-container</code>
-        <button class="copy-btn" type="button" data-copy-text="npx skills add azure-sql-database-container"><span class="copy-label">Copy</span></button>
+        <code><span class="cmd-p">$</span> npx skills add microsoft/azure-sql-database-container</code>
+        <button class="copy-btn" type="button" data-copy-text="npx skills add microsoft/azure-sql-database-container"><span class="copy-label">Copy</span></button>
       </div>
       <a class="skill-link" href="{{ site.repo }}/tree/main/skills" rel="noopener">Browse the skill on GitHub &rarr;</a>
     </div>

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,8 +1,8 @@
 # Azure SQL Database Skills (azuresql-db-*)
 
-**This is the actual Azure SQL Database engine running locally, with cloud parity.** Not an emulator, not a look-alike, not the SQL Server box image. It is the same managed cloud engine you run in Azure, packaged as a container for local development. **No competitor runs the managed cloud engine locally.**
+The Azure SQL Database container is the Azure SQL Database engine, running locally. It is for the developer who wants a local database that behaves like Azure SQL Database in the Microsoft Azure cloud, with no Azure subscription, no shared instance, and no credit card required. The container runs the same engine that powers Azure SQL Database in the cloud: the T-SQL dialect, the system views, the connection protocol, the driver behavior, and the AI-native capabilities are the same as in the cloud. The connection string changes; the application does not.
 
-You can prove the identity from any connection:
+These skills teach an AI coding agent to use it the right way. You can prove the identity from any connection:
 
 ```sql
 SELECT SERVERPROPERTY('EngineEdition');  -- 5
@@ -60,11 +60,9 @@ Same skills, per-agent install location (mirrors how Google, Supabase, and Neon 
 | Agent | Install location |
 | --- | --- |
 | Claude Code | `.claude/skills/` (project) or `~/.claude/skills/` (global) |
-| Claude Desktop | `~/Library/Application Support/Claude/skills/` |
-| Cursor | `.cursor/skills/` (project) |
-| GitHub Copilot in VS Code | `.github/skills/` |
+| GitHub Copilot (VS Code + CLI) | `.github/skills/` (the VS Code extension and the Copilot CLI both read it) |
 | Codex | `~/.codex/skills/` |
-| Gemini CLI | `~/.gemini/skills/` |
+| Cursor | `.cursor/skills/` (project) |
 
 `npx skills add` targets the active agent automatically; the table above is for manual placement.
 
@@ -74,7 +72,9 @@ Same skills, per-agent install location (mirrors how Google, Supabase, and Neon 
 
 Every skill in this collection holds these facts true. If a generated workflow contradicts any of them, it is wrong.
 
-- **Image:** `sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest` (x64 / linux/amd64, private preview registry). Sign in first: `docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io -u <username>` (enter the password when prompted). The shared, pull-only credentials are not in any doc; request them through the early-access feedback channel. Treat them as secrets and do not redistribute; they are pull-only and may rotate during the preview. It is **not** `mcr.microsoft.com/mssql/server`.
+- **Image:** `sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest` (x64 / linux/amd64, private preview registry). Sign in first: `docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io -u <username>` (enter the password when prompted). It is **not** `mcr.microsoft.com/mssql/server`.
+
+  > **Note:** the registry username and password are **provided to Private Preview cohort participants**. Request them via the early-access feedback channel. They are shared and pull-only, must be treated as secrets (do not redistribute), and may be rotated during the preview.
 - **EULA:** `ACCEPT_EULA=Y` is required.
 - **Password:** a complex `MSSQL_SA_PASSWORD` (8+ chars, upper/lower/digit/symbol) is required.
 - **Port:** the engine listens on **1433**.
@@ -82,7 +82,7 @@ Every skill in this collection holds these facts true. If a generated workflow c
 
 ### Platform
 
-The image is x64 only; there is no arm64 image. On a non-x64 host, add `--platform linux/amd64` (Docker) or `platform: linux/amd64` (compose). Apple Silicon / arm64 is not "supported"; it runs only under x64 emulation.
+The image is x64 only; there is no arm64 image. On a non-x64 host, add `--platform linux/amd64` (Docker) or `platform: linux/amd64` (compose) to run it under x64 emulation.
 
 ### Connection model (three facts that bite)
 

--- a/skills/azuresql-db-ci/SKILL.md
+++ b/skills/azuresql-db-ci/SKILL.md
@@ -123,7 +123,7 @@ jobs:
 
 | Secret | Purpose |
 | --- | --- |
-| `ACR_USERNAME` | Private preview registry sign-in (welcome-email credentials) |
+| `ACR_USERNAME` | Private preview registry sign-in (using the shared pull-only credentials provided to the Private Preview cohort; request them via the early-access feedback channel; they may rotate) |
 | `ACR_PASSWORD` | Private preview registry sign-in |
 | `MSSQL_SA_PASSWORD` | sa password for the engine; complex, 8+ chars |
 

--- a/skills/azuresql-db-container/references/image-and-registry.md
+++ b/skills/azuresql-db-container/references/image-and-registry.md
@@ -29,9 +29,10 @@ The external access path pulls from the preview registry
 `mssql-server/sqldb-dev-edition`, rolling tag `latest`) using a shared,
 pull-only username and password.
 
-The credentials are not in any doc: request them through the early-access
-feedback channel. They are pull-only and may be rotated during the preview, so
-treat them as secrets and do not redistribute. Sign in and enter the password
+The credentials are provided to Private Preview cohort participants: request
+them through the early-access feedback channel. They are pull-only and may be
+rotated during the preview, so treat them as secrets and do not redistribute.
+Sign in and enter the password
 when prompted:
 
 ```bash

--- a/skills/azuresql-db-container/references/paas-parity-checklist.md
+++ b/skills/azuresql-db-container/references/paas-parity-checklist.md
@@ -26,9 +26,11 @@ before declaring readiness.
 ## Vectors: present, with one caveat
 
 - `VECTOR(n)` column type and `VECTOR_DISTANCE('cosine', a, b)` are available.
-- Insert with `CAST(? AS VECTOR(n))` where **n is a literal dimension, never a
-  bind parameter**. A parameterized dimension fails with "Incorrect syntax near
-  '@P3'".
+- Insert with `CAST(CAST(? AS NVARCHAR(MAX)) AS VECTOR(n))` where **n is a
+  literal dimension, never a bind parameter**. A parameterized dimension fails
+  with "Incorrect syntax near '@P3'". The inner `CAST(? AS NVARCHAR(MAX))` keeps
+  a real embedding's JSON (which exceeds the driver's 4000-char threshold) from
+  being sent as ntext, which the engine rejects (error 529).
 - `CREATE VECTOR INDEX` (DiskANN) is still in development. For now, use a
   full-scan top-k query with `VECTOR_DISTANCE` instead of an index.
 

--- a/skills/azuresql-db-from-sql-server/SKILL.md
+++ b/skills/azuresql-db-from-sql-server/SKILL.md
@@ -142,7 +142,7 @@ Expect `EngineEdition = 5` and `Edition = SQL Azure`.
 ## Vectors (if the project uses embeddings)
 
 The Azure SQL Database engine has a native `VECTOR(n)` type and
-`VECTOR_DISTANCE('cosine', a, b)`. Insert with `CAST(? AS VECTOR(n))` where **n
+`VECTOR_DISTANCE('cosine', a, b)`. Insert with `CAST(CAST(? AS NVARCHAR(MAX)) AS VECTOR(n))` where **n
 is a LITERAL, never a bind parameter** (a parameter dimension fails with
 "Incorrect syntax near '@P3'"). `CREATE VECTOR INDEX` (DiskANN) is still in
 development; use a full-scan top-k query for now.

--- a/skills/azuresql-db-from-sql-server/references/box-vs-azure-feature-matrix.md
+++ b/skills/azuresql-db-from-sql-server/references/box-vs-azure-feature-matrix.md
@@ -59,7 +59,7 @@ remove or replace every usage.
 ## New capabilities
 
 - Native `VECTOR(n)` column type and `VECTOR_DISTANCE('cosine', a, b)` for
-  embedding search. Insert with `CAST(? AS VECTOR(n))` where `n` is a literal,
+  embedding search. Insert with `CAST(CAST(? AS NVARCHAR(MAX)) AS VECTOR(n))` where `n` is a literal,
   never a bind parameter. `CREATE VECTOR INDEX` (DiskANN) is still in
   development; use a full-scan top-k query for now.
 - Behavior matches Azure SQL Database, so local dev catches Azure-specific

--- a/skills/azuresql-db-local-to-cloud/SKILL.md
+++ b/skills/azuresql-db-local-to-cloud/SKILL.md
@@ -83,8 +83,10 @@ Just enough to run the examples on a fresh container. For full detail see the
 
 - Image: `sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest`
   (x64, `linux/amd64`). Private preview registry: run
-  `docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io` first with your
-  welcome-email credentials. Registry and tag are provisional during Private Preview.
+  `docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io` first using the shared
+  pull-only credentials provided to the Private Preview cohort (request them via
+  the early-access feedback channel; they may rotate). Registry and tag are
+  provisional during Private Preview.
 - On a non-x64 host, add `--platform linux/amd64`.
 - Required env: `ACCEPT_EULA=Y` and a complex `MSSQL_SA_PASSWORD`
   (8+ chars, upper/lower/digit/symbol). Engine listens on 1433.

--- a/skills/azuresql-db-rag/SKILL.md
+++ b/skills/azuresql-db-rag/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   documents", chatbot memory, or semantic lookup against a local SQL database.
   Use this instead of pgvector, FAISS, Chroma, Pinecone, or a separate vector
   store when the data already lives in (or can live in) Azure SQL. Covers the
-  VECTOR(n) column type, inserting embeddings with CAST(? AS VECTOR(n)) where the
+  VECTOR(n) column type, inserting embeddings with CAST(CAST(? AS NVARCHAR(MAX)) AS VECTOR(n)) where the
   dimension is a literal, a pluggable embed() so only the endpoint changes for
   cloud, and the honest current state of CREATE VECTOR INDEX. Provisions appdb on
   master first so every script runs on a fresh container.
@@ -124,7 +124,7 @@ def embed(text: str) -> list[float]:
 
 ## Step 4: insert embeddings (dimension is a LITERAL)
 
-Critical: in `CAST(? AS VECTOR(n))`, `n` must be a **literal** baked into the SQL
+Critical: in `CAST(CAST(? AS NVARCHAR(MAX)) AS VECTOR(n))`, `n` must be a **literal** baked into the SQL
 string. Passing the dimension as a bind parameter fails with
 `Incorrect syntax near '@P3'`. Bind the embedding **value** (as a JSON array
 string), never the dimension.
@@ -196,7 +196,7 @@ the same; you just add the index.
 - `SERVERPROPERTY('EngineEdition')` returns `5`. If not, you are on the wrong
   image.
 - `appdb` exists before any vector script connects (Step 1 guarantees this).
-- The dimension in `VECTOR(n)` and `CAST(? AS VECTOR(n))` is a literal integer,
+- The dimension in `VECTOR(n)` and `CAST(CAST(? AS NVARCHAR(MAX)) AS VECTOR(n))` is a literal integer,
   identical to `len(embed(text))`.
 - Smaller cosine distance means more similar; results are `ORDER BY distance ASC`.
 

--- a/skills/azuresql-db-rag/references/vector-schema.md
+++ b/skills/azuresql-db-rag/references/vector-schema.md
@@ -35,7 +35,7 @@ embedding model returns. Common values:
 | many cloud text models | 1536      |
 
 If you change models, the dimension usually changes; the column type, the
-`CAST(? AS VECTOR(n))` literal, and `EMBED_DIM` in code must all move together.
+`CAST(CAST(? AS NVARCHAR(MAX)) AS VECTOR(n))` literal, and `EMBED_DIM` in code must all move together.
 
 ## Table shapes
 

--- a/skills/azuresql-db-scaffold/SKILL.md
+++ b/skills/azuresql-db-scaffold/SKILL.md
@@ -19,7 +19,9 @@ local database. This is the **Azure SQL engine**, not the SQL Server box image.
 - Image is x64 only. On a non-x64 host add `--platform linux/amd64` (Docker) or
   `platform: linux/amd64` (compose).
 - Registry is private (Private Preview): sign in first with
-  `docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io` using your welcome-email credentials.
+  `docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io` using the shared pull-only credentials
+  provided to the Private Preview cohort (request them via the early-access feedback channel; they
+  may rotate).
   Registry and tag are provisional during Private Preview.
 
 For full engine detail (readiness, vectors, troubleshooting) see the **azuresql-db-container** skill.
@@ -97,7 +99,7 @@ docker exec -i sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourSt
 ## Vectors (if your app uses embeddings)
 
 Native `VECTOR(n)` column type and `VECTOR_DISTANCE('cosine', a, b)`. Insert with
-`CAST(? AS VECTOR(n))` where **n is a LITERAL, never a bind parameter** (a parameter dimension
+`CAST(CAST(? AS NVARCHAR(MAX)) AS VECTOR(n))` where **n is a LITERAL, never a bind parameter** (a parameter dimension
 fails with "Incorrect syntax near '@P3'"). `CREATE VECTOR INDEX` (DiskANN) is still in
 development; use full-scan top-k for now.
 

--- a/skills/azuresql-db-scaffold/references/scaffold-snippets.md
+++ b/skills/azuresql-db-scaffold/references/scaffold-snippets.md
@@ -141,7 +141,7 @@ Vector insert (dimension is a LITERAL in the SQL text, value is bound):
 
 ```python
 cx.execute(
-    text("INSERT INTO dbo.docs (embedding) VALUES (CAST(:v AS VECTOR(1536)))"),
+    text("INSERT INTO dbo.docs (embedding) VALUES (CAST(CAST(:v AS NVARCHAR(MAX)) AS VECTOR(1536)))"),
     {"v": "[0.1, 0.2, 0.3]"},   # 1536 is literal; do NOT bind it as a parameter
 )
 ```

--- a/skills/azuresql-db-schema-migration/SKILL.md
+++ b/skills/azuresql-db-schema-migration/SKILL.md
@@ -37,7 +37,7 @@ recipe adds `--platform linux/amd64` automatically. The registry is private duri
 Private Preview, so sign in first.
 
 ```bash
-docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io   # welcome-email credentials
+docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io   # pull-only creds from the Private Preview cohort (feedback channel)
 
 # Pick a free host port and add the platform flag only on a non-x64 host (works in bash and zsh).
 HOST_PORT=1433; while lsof -nP -iTCP:"$HOST_PORT" -sTCP:LISTEN >/dev/null 2>&1; do HOST_PORT=$((HOST_PORT+1)); done
@@ -119,8 +119,10 @@ sqlpackage /Action:Publish /SourceFile:./app.dacpac \
 
 The engine has a native `VECTOR(n)` column type and `VECTOR_DISTANCE('cosine', a, b)`.
 In a migration, the dimension `n` is a **literal** in DDL (`embedding VECTOR(1536)`).
-When inserting via `CAST(? AS VECTOR(n))`, `n` must be a literal, never a bind
-parameter (a parameter dimension fails with "Incorrect syntax near '@P3'").
+When inserting via `CAST(CAST(? AS NVARCHAR(MAX)) AS VECTOR(n))`, `n` must be a
+literal, never a bind parameter (a parameter dimension fails with "Incorrect
+syntax near '@P3'"); the inner `NVARCHAR(MAX)` cast keeps a real embedding's
+JSON from being sent as ntext, which the engine rejects (error 529).
 `CREATE VECTOR INDEX` (DiskANN) is still in development; use full-scan top-k for now.
 
 ## Seeding after migration

--- a/skills/azuresql-db-schema-migration/references/migration-tools.md
+++ b/skills/azuresql-db-schema-migration/references/migration-tools.md
@@ -193,7 +193,7 @@ Notes:
 - `Msg 913` / connection refused right after `docker run`: the engine was not
   ready. Run the ready-wait loop with `-b -l` before migrating.
 - "Incorrect syntax near '@P3'" on a vector insert: the `VECTOR(n)` dimension was
-  passed as a bind parameter. Make `n` a literal in `CAST(? AS VECTOR(n))`.
+  passed as a bind parameter. Make `n` a literal in `CAST(CAST(? AS NVARCHAR(MAX)) AS VECTOR(n))`.
 - Login/cert errors with ODBC Driver 18 or sqlcmd: add `TrustServerCertificate`
   (`=yes` for ODBC URLs, `=true` for ADO.NET, `-C` for sqlcmd).
 - Tool points at `mcr.microsoft.com/mssql/server`: wrong image. Use

--- a/skills/azuresql-db-sidecar/SKILL.md
+++ b/skills/azuresql-db-sidecar/SKILL.md
@@ -20,7 +20,9 @@ one-shot that creates `appdb`, and a `depends_on` gate.
   (x64, `linux/amd64`). Registry and tag are provisional during Private Preview.
 - Registry credentials: the image lives in a private preview registry. Sign in
   first with `docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io` using the
-  welcome-email credentials before `docker compose up` or building the Dev Container.
+  shared pull-only credentials provided to the Private Preview cohort (request
+  them via the early-access feedback channel; they may rotate) before
+  `docker compose up` or building the Dev Container.
 - Platform: x64 only; there is no arm64 image. The compose snippets below set
   `platform: linux/amd64` so the service starts on a non-x64 host.
 - Required env: `ACCEPT_EULA=Y` and a complex `MSSQL_SA_PASSWORD` (8+ chars,
@@ -106,7 +108,7 @@ services:
 Bring it up (after `docker login`, see above):
 
 ```bash
-docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io   # welcome-email creds
+docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io   # pull-only creds from the Private Preview cohort (feedback channel)
 docker compose up -d
 ```
 
@@ -145,7 +147,7 @@ Use Docker Compose as the Dev Container backend so the same `sqldb` +
 Sign in to the registry on the host before "Reopen in Container":
 
 ```bash
-docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io   # welcome-email creds
+docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io   # pull-only creds from the Private Preview cohort (feedback channel)
 ```
 
 The app container reaches the database at `sqldb,1433` over the compose network.


### PR DESCRIPTION
Polishes the `azuresql-db-*` skills collection and two GitHub Pages sections.

## skills/README.md
- Value prop copied from the canonical container overview (engine running locally, no subscription / shared instance / credit card; the connection string changes, the application does not).
- Install matrix narrowed to the four supported agents: Claude Code, GitHub Copilot (VS Code + CLI), Codex, and Cursor (matches the landing page).
- Platform note reworded without scare-quotes: x64-only image, add `--platform linux/amd64` to run under emulation on a non-x64 host.

## Skills content accuracy
- Registry credentials are now described consistently as **provided to Private Preview cohort participants** (requested via the early-access feedback channel; pull-only; may rotate), replacing the old "welcome email" wording.
- Every VECTOR insert example uses `CAST(CAST(? AS NVARCHAR(MAX)) AS VECTOR(n))` so a real embedding's JSON is not sent as ntext (error 529); `n` stays a literal.

## Pages: #ai-agents
- Adds a compact "what you get" table mapping each scenario to what the skill does.
- Uses the `microsoft/azure-sql-database-container` install command for consistency.

## Pages: getting-started
- Option B setup steps are always visible (removed the single-tab Docker/Podman pivot that required a click).
- Option A now explains what the skills do for the reader.
- Adds a Note callout that the registry username/password are given to Private Preview cohort participants.
- Removes the now-dead pivot CSS and JS.

Verified with a Docker Jekyll build: site builds clean, Option B steps render without a click, the #ai-agents table and credentials Note render, and the dead pivot assets are gone.