### PR TITLE
Show the skill install command before the skills table

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -143,6 +143,15 @@ title: Azure SQL Database container
       </a>
     </div>
 
+    <div class="skill">
+      <p class="skill-line">Install the skill once. It works across Claude Code, GitHub Copilot, Codex, and Cursor, then you just ask your agent in plain English.</p>
+      <div class="skill-cmd">
+        <code><span class="cmd-p">$</span> npx skills add microsoft/azure-sql-database-container</code>
+        <button class="copy-btn" type="button" data-copy-text="npx skills add microsoft/azure-sql-database-container"><span class="copy-label">Copy</span></button>
+      </div>
+      <a class="skill-link" href="{{ site.repo }}/tree/main/skills" rel="noopener">Browse the skill on GitHub &rarr;</a>
+    </div>
+
     <p class="skill-table-lead">A collection of skills your agent loads on demand. Each one teaches it to use the engine the right way, so it does not reach for the SQL Server box image or invent behavior the engine does not have:</p>
     <table class="skill-table">
       <thead><tr><th>Skill</th><th>What it does for your agent</th></tr></thead>
@@ -158,15 +167,6 @@ title: Azure SQL Database container
         <tr><td>Scaffold</td><td>Bootstrap a new app with the container as the default local database.</td></tr>
       </tbody>
     </table>
-
-    <div class="skill">
-      <p class="skill-line">Install the skill once. It works across Claude Code, GitHub Copilot, Codex, and Cursor, then you just ask your agent in plain English.</p>
-      <div class="skill-cmd">
-        <code><span class="cmd-p">$</span> npx skills add microsoft/azure-sql-database-container</code>
-        <button class="copy-btn" type="button" data-copy-text="npx skills add microsoft/azure-sql-database-container"><span class="copy-label">Copy</span></button>
-      </div>
-      <a class="skill-link" href="{{ site.repo }}/tree/main/skills" rel="noopener">Browse the skill on GitHub &rarr;</a>
-    </div>
   </div>
 </section>
 


### PR DESCRIPTION
On the landing page `#ai-agents` section, the install line and `npx skills add` command now sit right after the agent grid and before the what-you-get table, so the reader sees how to install before the per-skill detail.