### PR TITLE
Retitle the skills README around the container

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,8 +1,8 @@
-# Azure SQL Database Skills
+# Azure SQL Database container - Agent skills
 
-The Azure SQL Database container is the Azure SQL Database engine, running locally. It is for the developer who wants a local database that behaves like Azure SQL Database in the Microsoft Azure cloud, with no Azure subscription, no shared instance, and no credit card required. The container runs the same engine that powers Azure SQL Database in the cloud: the T-SQL dialect, the system views, the connection protocol, the driver behavior, and the AI-native capabilities are the same as in the cloud. The connection string changes; the application does not.
+These skills teach an AI coding agent to use the **Azure SQL Database container** the right way. The Azure SQL Database container is the Azure SQL Database engine, running locally. It is for the developer who wants a local database that behaves like Azure SQL Database in the Microsoft Azure cloud, with no Azure subscription, no shared instance, and no credit card required. The container runs the same engine that powers Azure SQL Database in the cloud: the T-SQL dialect, the system views, the connection protocol, the driver behavior, and the AI-native capabilities are the same as in the cloud. The connection string changes; the application does not.
 
-These skills teach an AI coding agent to use it the right way. You can prove the identity from any connection:
+You can prove the identity from any connection:
 
 ```sql
 SELECT SERVERPROPERTY('EngineEdition');  -- 5


### PR DESCRIPTION
Positions the collection for the **Azure SQL Database container** (the local engine), not the Azure SQL Database cloud service. Title is now "Azure SQL Database container - Agent skills" and the intro leads with what the skills teach the agent to use.