### PR TITLE
Make copied commands paste-safe on every shell

### DIFF
--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -14,6 +14,25 @@
     }, 1600);
   }
 
+  // Make a copied command paste-safe on every shell. The display keeps the
+  // readable multi-line form with a trailing "\", but bash/zsh use "\" for line
+  // continuation while PowerShell uses "`" and cmd uses "^", so a copied
+  // multi-line block breaks on Windows. Joining the continuations into one line
+  // produces a command that runs verbatim in bash, PowerShell, and cmd. We also
+  // drop comment-only lines ("#" is not a comment in cmd or PowerShell either).
+  // Quotes, "!", and every other character are preserved exactly; indentation
+  // on non-continued lines (YAML, code) is left untouched.
+  function normalizeCommand(text) {
+    return text
+      .replace(/[ \t]*\\[ \t]*\r?\n[ \t]*/g, " ") // join "\" line-continuations
+      .split(/\r?\n/)
+      .filter(function (line) { return !/^[ \t]*#/.test(line); }) // drop comment-only lines
+      .join("\n")
+      .replace(/\n{2,}/g, "\n") // collapse blank lines left by removed comments
+      .replace(/^\n+/, "")
+      .replace(/\n+$/, "");
+  }
+
   function copyText(text, btn) {
     if (navigator.clipboard && navigator.clipboard.writeText) {
       navigator.clipboard.writeText(text).then(function () { flash(btn); }, function () {});
@@ -33,7 +52,7 @@
         var target = document.querySelector(btn.getAttribute("data-copy"));
         text = target ? target.innerText : "";
       }
-      copyText(text, btn);
+      copyText(normalizeCommand(text), btn);
     });
   });
 
@@ -46,7 +65,7 @@
     btn.innerHTML = '<span class="copy-label">Copy</span>';
     btn.addEventListener("click", function () {
       var code = pre.querySelector("code") || pre;
-      copyText(code.innerText, btn);
+      copyText(normalizeCommand(code.innerText), btn);
     });
     pre.appendChild(btn);
   });

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -68,12 +68,18 @@ The registry path, image tag, and credentials are provisional during Private Pre
 Start it on port `1433` with one command:
 
 ```bash
-# on a non-x64 host, add --platform linux/amd64
 docker run --name sqldb -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong!Passw0rd" \
     -p 1433:1433 -d sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
 ```
 
-Or use `docker compose`. Create a `docker-compose.yml`, then run `docker compose up -d`.
+On Apple Silicon or any other non-x64 host, copy this version instead. It adds `--platform linux/amd64` so the x64 image runs under emulation:
+
+```bash
+docker run --platform linux/amd64 --name sqldb -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong!Passw0rd" \
+    -p 1433:1433 -d sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
+```
+
+Or use `docker compose`. Create a `docker-compose.yml`, then run `docker compose up -d`. On a non-x64 host, add `platform: linux/amd64` under the `sqldb` service.
 
 ```yaml
 services:


### PR DESCRIPTION
## Problem
The site shows multi-line commands with a trailing `\`. That backslash is bash/zsh line-continuation only: PowerShell uses a backtick, cmd uses a caret. So Windows users who copied a multi-line block got a broken paste (reported in bug bash).

## Fix
The Copy button now normalizes the command before it hits the clipboard:
- joins `\` line-continuations into one line that runs verbatim in **bash, PowerShell, and cmd**;
- drops comment-only lines (`#` is not a comment in cmd or PowerShell either);
- preserves quotes, `!`, and indentation (YAML/code untouched).

The display is unchanged, so the on-screen formatting stays readable. No per-shell toggle, no per-shell variants to maintain.

Because the `--platform linux/amd64` hint previously lived in a comment (now stripped on copy), getting-started Step 2 gains a directly copyable non-x64 command with the flag baked in, plus a compose note.

## Tests
Unit-tested the actual shipped `normalizeCommand` (extracted from `main.js`) over 14 cases: docker run / sqlcmd backslash joins, quotes + `!` preserved, comment stripping, YAML indentation preserved, separate commands kept separate, JS preserved, and the landing-page hero value. All pass. Jekyll build is clean and `normalizeCommand` ships in the built JS.