### PR TITLE
Clarify that appdb is an example name, not a requirement

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,7 +36,7 @@ Then ask your agent in plain English, for example:
 
 > Add a local Azure SQL Database to this project, then scaffold the schema, migrations, and data-access layer for my stack.
 
-**Why use the skills?** They already know the private preview registry, the x64 image, the connection model (the engine does not auto-create databases, so they provision `appdb` first), the readiness wait, and the local-to-cloud story. So your agent stands up a real Azure SQL Database the right way the first time, instead of reaching for the SQL Server box image (`mcr.microsoft.com/mssql/server`) or inventing behavior the engine does not have. Browse the [skills on GitHub](https://github.com/microsoft/azure-sql-database-container/tree/main/skills).
+**Why use the skills?** They already know the private preview registry, the x64 image, the connection model (the engine does not auto-create databases, so they provision a database first, named `appdb` in these examples or whatever name you choose), the readiness wait, and the local-to-cloud story. So your agent stands up a real Azure SQL Database the right way the first time, instead of reaching for the SQL Server box image (`mcr.microsoft.com/mssql/server`) or inventing behavior the engine does not have. Browse the [skills on GitHub](https://github.com/microsoft/azure-sql-database-container/tree/main/skills).
 
 ## Option B: set it up yourself
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -86,7 +86,7 @@ The image is x64 only; there is no arm64 image. On a non-x64 host, add `--platfo
 
 ### Connection model (three facts that bite)
 
-1. The engine does **not** auto-create databases on connect. Run `CREATE DATABASE appdb` on a **master** connection before connecting with `Database=appdb`.
+1. The engine does **not** auto-create databases on connect. Run `CREATE DATABASE appdb` on a **master** connection before connecting with `Database=appdb`. `appdb` is just the example name used throughout these skills; the name is yours to choose, so substitute your project's database name in a real project.
 2. Avoid `USE` to switch databases. In a user-database (SDS) session (the Azure-faithful context where you develop), `USE` returns `Msg 40508`, exactly as in Azure SQL Database in the cloud. A `master` connection is a non-SDS provisioning session where the Azure statement filter is not enforced, so `USE` (and `BACKUP`/`RESTORE`) appear to work there, but `master` is for provisioning only, not application work. Always select the target database in the connection string (`Database=appdb`, or `-d appdb` for sqlcmd).
 3. A `master` connection is for provisioning only. Do real work on the user database.
 

--- a/skills/azuresql-db-container/SKILL.md
+++ b/skills/azuresql-db-container/SKILL.md
@@ -97,7 +97,11 @@ These bite every newcomer. Full workflow in `references/connection-model.md`.
 
 1. **The engine does NOT auto-create databases on connect.** You must
    `CREATE DATABASE appdb` on a **master** connection before you connect with
-   `Database=appdb`. Connecting to a database that does not exist fails.
+   `Database=appdb`. Connecting to a database that does not exist fails. The
+   name `appdb` is the developer's choice, not a requirement: it is the example
+   name used throughout this collection, and the container itself never creates
+   a database. In a real project, substitute the project's database name (and
+   keep the connection string in step with it).
 2. **Select the database in the connection string, not with `USE`.** Avoid
    `USE` to switch databases. In a user-database (SDS) session (the
    Azure-faithful context where you develop), `USE` returns `Msg 40508`, exactly


### PR DESCRIPTION
The skills use `appdb` as the working-database name in every example. That consistency is good, but nothing told the reader (or the agent) that the name is theirs to choose, so it read as if `appdb` were required or auto-created.

This adds an authoritative clarity note (no mass rename, examples stay on `appdb`):
- **azuresql-db-container/SKILL.md** (the foundation every other skill builds on): `appdb` is the developer's choice, the container itself never creates a database, and a real project should substitute its own database name.
- **skills/README.md** and **getting-started.md**: a one-line version of the same point.

Also corrects a common misconception: the container image does not auto-create any database; `appdb` exists only because the setup step runs `CREATE DATABASE appdb`.