### PR TITLE
Use a shell- and URL-safe sample password

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -68,14 +68,14 @@ The registry path, image tag, and credentials are provisional during Private Pre
 Start it on port `1433` with one command:
 
 ```bash
-docker run --name sqldb -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong!Passw0rd" \
+docker run --name sqldb -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd" \
     -p 1433:1433 -d sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
 ```
 
 On Apple Silicon or any other non-x64 host, copy this version instead. It adds `--platform linux/amd64` so the x64 image runs under emulation:
 
 ```bash
-docker run --platform linux/amd64 --name sqldb -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong!Passw0rd" \
+docker run --platform linux/amd64 --name sqldb -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd" \
     -p 1433:1433 -d sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
 ```
 
@@ -89,7 +89,7 @@ services:
     ports:
       - "1433:1433"
     environment:
-      MSSQL_SA_PASSWORD: "YourStrong!Passw0rd"
+      MSSQL_SA_PASSWORD: "YourStr0ng_Passw0rd"
       ACCEPT_EULA: "Y"
     volumes:
       - sqldb-data:/var/opt/mssql
@@ -100,7 +100,7 @@ volumes:
 
 </div>
 
-> **NOTE:** Replace `YourStrong!Passw0rd` with your own. The container enforces the default SQL password complexity policy: at least 8 characters, with a mix of upper, lower, numeric, and non-alphanumeric characters.
+> **NOTE:** Replace `YourStr0ng_Passw0rd` with your own. The container enforces the default SQL password complexity policy: at least 8 characters, with a mix of upper, lower, numeric, and non-alphanumeric characters.
 
 ### Step 3: verify it is running
 
@@ -121,7 +121,7 @@ The most common startup failure is a password that does not meet the complexity 
 If you have [sqlcmd](https://learn.microsoft.com/sql/tools/sqlcmd/sqlcmd-utility) installed, connect and run your first query in one command (port `1433` is published in both engines). The `-C` flag trusts the container's self-signed certificate:
 
 ```bash
-sqlcmd -S localhost,1433 -U sa -P "YourStrong!Passw0rd" -C \
+sqlcmd -S localhost,1433 -U sa -P "YourStr0ng_Passw0rd" -C \
     -Q "SELECT @@VERSION;"
 ```
 
@@ -136,7 +136,7 @@ You should see `Microsoft SQL Azure`, confirming you are on the Azure SQL Databa
 
   ```bash
   docker exec sqldb /opt/mssql-tools18/bin/sqlcmd \
-      -S localhost -U sa -P "YourStrong!Passw0rd" -C -Q "SELECT @@VERSION;"
+      -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -Q "SELECT @@VERSION;"
   ```
 
   </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -89,9 +89,9 @@ title: Azure SQL Database container
           <h3>Start the container</h3>
           <p class="qstep-desc">Run it on port 1433 with a strong SA password.</p>
           <div class="qstep-cmd">
-            <code><span class="cmd-p">$</span> docker run -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong!Passw0rd" \
+            <code><span class="cmd-p">$</span> docker run -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd" \
     -p 1433:1433 -d sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest</code>
-            <button class="copy-btn" type="button" data-copy-text="docker run -e &quot;ACCEPT_EULA=Y&quot; -e &quot;MSSQL_SA_PASSWORD=YourStrong!Passw0rd&quot; \&#10;    -p 1433:1433 -d sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest"><span class="copy-label">Copy</span></button>
+            <button class="copy-btn" type="button" data-copy-text="docker run -e &quot;ACCEPT_EULA=Y&quot; -e &quot;MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd&quot; \&#10;    -p 1433:1433 -d sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest"><span class="copy-label">Copy</span></button>
           </div>
         </div>
       </div>

--- a/docs/prompts/ai-rag.md
+++ b/docs/prompts/ai-rag.md
@@ -19,7 +19,7 @@ Read the entire instruction set before executing.
 ```bash
 # The image is in a private preview registry; sign in with the credentials requested via the early-access feedback channel (pull-only; may be rotated during the preview) first
 docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io
-docker run --name sqldb -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong!Passw0rd" \
+docker run --name sqldb -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd" \
     -p 1433:1433 -d sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
 ```
 
@@ -29,7 +29,7 @@ Wait for the engine, then create the `appdb` database. Azure SQL Database does *
 # Create appdb, retrying until it succeeds (waits out engine startup; -b makes sqlcmd return a
 # non-zero exit on a SQL error so the loop retries while the engine is still initializing).
 until docker exec sqldb /opt/mssql-tools18/bin/sqlcmd \
-    -S localhost -U sa -P "YourStrong!Passw0rd" -C -b -l 2 \
+    -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b -l 2 \
     -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;" >/dev/null 2>&1; do
   sleep 2
 done
@@ -49,7 +49,7 @@ ollama pull nomic-embed-text   # 768-dimensional embeddings, runs locally
 Create `.env` with a single connection string (swap only this value for the cloud later):
 
 ```dotenv
-SQL_CONNECTION_STRING="Server=localhost,1433;Database=appdb;Uid=sa;Pwd=YourStrong!Passw0rd;TrustServerCertificate=yes;"
+SQL_CONNECTION_STRING="Server=localhost,1433;Database=appdb;Uid=sa;Pwd=YourStr0ng_Passw0rd;TrustServerCertificate=yes;"
 ```
 
 ### 4. Create the RAG script

--- a/docs/prompts/from-sql-server.md
+++ b/docs/prompts/from-sql-server.md
@@ -36,7 +36,7 @@ Keep `ACCEPT_EULA=Y` and the `sa` password. The image is x64 only; on a non-x64 
 
 ```bash
 PLATFORM=(); case "$(docker info -f '{{.Architecture}}' 2>/dev/null)" in x86_64|amd64) ;; *) PLATFORM=(--platform linux/amd64);; esac
-docker run -d --name sqldb "${PLATFORM[@]}" -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong!Passw0rd" \
+docker run -d --name sqldb "${PLATFORM[@]}" -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd" \
     -p 1433:1433 sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
 ```
 
@@ -45,7 +45,7 @@ docker run -d --name sqldb "${PLATFORM[@]}" -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASS
 The Azure SQL Database engine does **not** auto-create databases, and the connection model differs from the box product. Provision the application database on a `master` connection, then point the app at that database:
 
 ```bash
-docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -b \
+docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b \
     -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;"
 ```
 
@@ -64,7 +64,7 @@ These exist in the SQL Server box product but **not** in Azure SQL Database; rem
 ### 6. Verify you are on the real engine
 
 ```bash
-docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -b \
+docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b \
     -d appdb -Q "SELECT SERVERPROPERTY('EngineEdition') AS EngineEdition, SERVERPROPERTY('Edition') AS Edition;"
 ```
 

--- a/docs/prompts/local-to-cloud.md
+++ b/docs/prompts/local-to-cloud.md
@@ -23,7 +23,7 @@ Run the container locally on port 1433 with a strong SA password. Set `ACCEPT_EU
 ```bash
 # The image is in a private preview registry; sign in with the credentials requested via the early-access feedback channel (pull-only; may be rotated during the preview) first
 docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io
-docker run --name sqldb -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong!Passw0rd" \
+docker run --name sqldb -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd" \
     -p 1433:1433 -d sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
 ```
 
@@ -36,7 +36,7 @@ The engine is not ready the instant `docker run` returns. Wait for it to accept 
 # brief window where the engine accepts connections but is still bringing databases online.
 # -b makes sqlcmd return a non-zero exit code on a SQL error (otherwise the loop would not retry).
 until docker exec sqldb /opt/mssql-tools18/bin/sqlcmd \
-    -S localhost -U sa -P "YourStrong!Passw0rd" -C -b -l 2 \
+    -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b -l 2 \
     -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;" >/dev/null 2>&1; do
   sleep 2
 done
@@ -56,7 +56,7 @@ Create `.env` at the project root if it does not exist. Use a single `SQL_CONNEC
 
 ```dotenv
 # Local: the Azure SQL Database container
-SQL_CONNECTION_STRING="Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true"
+SQL_CONNECTION_STRING="Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true"
 
 # Cloud (for later): Azure SQL Database. Only the server and auth change; the application does not.
 # SQL_CONNECTION_STRING="Server=tcp:<your-server>.database.windows.net,1433;Database=appdb;Authentication=Active Directory Default;Encrypt=true"

--- a/docs/prompts/offline.md
+++ b/docs/prompts/offline.md
@@ -22,7 +22,7 @@ services:
     image: sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
     container_name: sqldb
     environment:
-      MSSQL_SA_PASSWORD: "YourStrong!Passw0rd"
+      MSSQL_SA_PASSWORD: "YourStr0ng_Passw0rd"
       ACCEPT_EULA: "Y"
     ports:
       - "1433:1433"
@@ -58,13 +58,13 @@ docker compose up -d
 # Wait until the engine is ready and create appdb (it is not auto-created). The -b makes a SQL
 # error set the exit code, so transient startup errors are retried, not masked.
 until docker compose exec -T sqldb /opt/mssql-tools18/bin/sqlcmd \
-    -S localhost -U sa -P "YourStrong!Passw0rd" -C -b -l 2 \
+    -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b -l 2 \
     -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;" >/dev/null 2>&1; do
   sleep 2
 done
 # Apply the schema and data to appdb. Select the database with -d; do not USE.
 docker compose exec -T sqldb /opt/mssql-tools18/bin/sqlcmd \
-    -S localhost -U sa -P "YourStrong!Passw0rd" -C -b -d appdb -i /seed.sql
+    -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b -d appdb -i /seed.sql
 ```
 
 The seed runs once; the named volume keeps `appdb` and its data across restarts, so later `docker compose up -d` runs need no network and no re-seed.
@@ -72,7 +72,7 @@ The seed runs once; the named volume keeps `appdb` and its data across restarts,
 Set the app connection string (in `.env`, read from the environment, never hardcoded):
 
 ```dotenv
-SQL_CONNECTION_STRING="Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true"
+SQL_CONNECTION_STRING="Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true"
 ```
 
 Verify offline operation by disabling the network and confirming the app still reads and writes data.

--- a/docs/prompts/sidecar.md
+++ b/docs/prompts/sidecar.md
@@ -22,7 +22,7 @@ services:
   app:
     # ... existing config ...
     environment:
-      SQL_CONNECTION_STRING: "Server=sqldb,1433;Database=appdb;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true"
+      SQL_CONNECTION_STRING: "Server=sqldb,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true"
     depends_on:
       sqldb:
         condition: service_healthy
@@ -32,7 +32,7 @@ services:
   sqldb:
     image: sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
     environment:
-      MSSQL_SA_PASSWORD: "YourStrong!Passw0rd"
+      MSSQL_SA_PASSWORD: "YourStr0ng_Passw0rd"
       ACCEPT_EULA: "Y"
     ports:
       - "1433:1433"
@@ -55,7 +55,7 @@ services:
         condition: service_healthy
     restart: "no"
     entrypoint: ["/opt/mssql-tools18/bin/sqlcmd", "-S", "sqldb,1433", "-U", "sa",
-      "-P", "YourStrong!Passw0rd", "-C", "-Q", "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;"]
+      "-P", "YourStr0ng_Passw0rd", "-C", "-Q", "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;"]
 
 volumes:
   sqldb-data:

--- a/docs/prompts/templates.md
+++ b/docs/prompts/templates.md
@@ -29,7 +29,7 @@ services:
   sqldb:
     image: sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
     environment:
-      MSSQL_SA_PASSWORD: "YourStrong!Passw0rd"
+      MSSQL_SA_PASSWORD: "YourStr0ng_Passw0rd"
       ACCEPT_EULA: "Y"
     ports:
       - "1433:1433"
@@ -42,16 +42,16 @@ volumes:
 Add a `.env` (gitignored) with a single connection string the app reads from the environment:
 
 ```dotenv
-SQL_CONNECTION_STRING="Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true"
+SQL_CONNECTION_STRING="Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true"
 ```
 
 Some ORMs read their own variable in their own format, not the ADO string above. For the **Prisma** `sqlserver` provider (Next.js / NestJS), also add a `DATABASE_URL` in Prisma's URL form. Prisma reads `DATABASE_URL`, not `SQL_CONNECTION_STRING`:
 
 ```dotenv
-DATABASE_URL="sqlserver://localhost:1433;database=appdb;user=sa;password=YourStrong!Passw0rd;trustServerCertificate=true"
+DATABASE_URL="sqlserver://localhost:1433;database=appdb;user=sa;password=YourStr0ng_Passw0rd;trustServerCertificate=true"
 ```
 
-On Prisma 7+, the runtime client also needs a driver adapter: `npm i @prisma/adapter-mssql` and construct `PrismaClient` with the matching `PrismaMSSQL` adapter. `prisma migrate dev` creates the `appdb` database if it does not exist; for stacks whose migration tool does not (for example EF Core), first create it with `docker compose exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;"`.
+On Prisma 7+, the runtime client also needs a driver adapter: `npm i @prisma/adapter-mssql` and construct `PrismaClient` with the matching `PrismaMSSQL` adapter. `prisma migrate dev` creates the `appdb` database if it does not exist; for stacks whose migration tool does not (for example EF Core), first create it with `docker compose exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;"`.
 
 ### 3. Scaffold schema, migration, and data-access layer
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -121,9 +121,9 @@ Free port + conditional platform + ready-wait + provision `appdb`:
 HOST_PORT=1433; while lsof -nP -iTCP:"$HOST_PORT" -sTCP:LISTEN >/dev/null 2>&1; do HOST_PORT=$((HOST_PORT+1)); done
 PLATFORM=(); case "$(docker info -f '{{.Architecture}}' 2>/dev/null)" in x86_64|amd64) ;; *) PLATFORM=(--platform linux/amd64);; esac
 docker rm -f sqldb 2>/dev/null
-docker run -d --name sqldb "${PLATFORM[@]}" -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong!Passw0rd" \
+docker run -d --name sqldb "${PLATFORM[@]}" -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd" \
   -p "$HOST_PORT:1433" sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
-until docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -b -l 2 \
+until docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b -l 2 \
   -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;" >/dev/null 2>&1; do sleep 2; done
 echo "ready on localhost,$HOST_PORT"
 ```

--- a/skills/azuresql-db-ci/SKILL.md
+++ b/skills/azuresql-db-ci/SKILL.md
@@ -145,9 +145,9 @@ Free port, conditional platform, ready-wait, provision appdb in one shape:
 HOST_PORT=1433; while lsof -nP -iTCP:"$HOST_PORT" -sTCP:LISTEN >/dev/null 2>&1; do HOST_PORT=$((HOST_PORT+1)); done
 PLATFORM=(); case "$(docker info -f '{{.Architecture}}' 2>/dev/null)" in x86_64|amd64) ;; *) PLATFORM=(--platform linux/amd64);; esac
 docker rm -f sqldb 2>/dev/null
-docker run -d --name sqldb "${PLATFORM[@]}" -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong!Passw0rd" \
+docker run -d --name sqldb "${PLATFORM[@]}" -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd" \
   -p "$HOST_PORT:1433" sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
-until docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -b -l 2 \
+until docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b -l 2 \
   -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;" >/dev/null 2>&1; do sleep 2; done
 echo "ready on localhost,$HOST_PORT"
 ```

--- a/skills/azuresql-db-container/SKILL.md
+++ b/skills/azuresql-db-container/SKILL.md
@@ -61,9 +61,9 @@ the same retry loop. Full options (Podman, compose, volumes) are in
 HOST_PORT=1433; while lsof -nP -iTCP:"$HOST_PORT" -sTCP:LISTEN >/dev/null 2>&1; do HOST_PORT=$((HOST_PORT+1)); done
 PLATFORM=(); case "$(docker info -f '{{.Architecture}}' 2>/dev/null)" in x86_64|amd64) ;; *) PLATFORM=(--platform linux/amd64);; esac
 docker rm -f sqldb 2>/dev/null
-docker run -d --name sqldb "${PLATFORM[@]}" -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong!Passw0rd" \
+docker run -d --name sqldb "${PLATFORM[@]}" -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd" \
   -p "$HOST_PORT:1433" sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
-until docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -b -l 2 \
+until docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b -l 2 \
   -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;" >/dev/null 2>&1; do sleep 2; done
 echo "ready on localhost,$HOST_PORT"
 ```
@@ -83,7 +83,7 @@ After provisioning, connect to `appdb` and confirm you are on the real engine
 before doing anything else:
 
 ```bash
-docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -b \
+docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b \
   -d appdb -Q "SELECT SERVERPROPERTY('EngineEdition') AS EngineEdition, SERVERPROPERTY('Edition') AS Edition;"
 ```
 
@@ -120,7 +120,7 @@ Postgres/MySQL convention and it is not honored here, so do not rely on it. Seed
 explicitly, AFTER provisioning `appdb`:
 
 ```bash
-docker exec -i sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -b \
+docker exec -i sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b \
   -d appdb -i /path/in/container/seed.sql
 ```
 

--- a/skills/azuresql-db-container/references/connect-and-query.md
+++ b/skills/azuresql-db-container/references/connect-and-query.md
@@ -20,7 +20,7 @@ The image ships sqlcmd at `/opt/mssql-tools18/bin/sqlcmd`. Use `-C` to trust the
 self-signed certificate and `-b` so a SQL error sets the exit code.
 
 ```bash
-docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -b \
+docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b \
   -d appdb -Q "SELECT DB_NAME() AS db, SERVERPROPERTY('EngineEdition') AS EngineEdition;"
 ```
 
@@ -30,7 +30,7 @@ Use the host port chosen by the free-port loop (here shown as `1433`). The
 comma form `localhost,PORT` selects the port.
 
 ```bash
-sqlcmd -S localhost,1433 -U sa -P "YourStrong!Passw0rd" -C -b \
+sqlcmd -S localhost,1433 -U sa -P "YourStr0ng_Passw0rd" -C -b \
   -d appdb -Q "SELECT SERVERPROPERTY('Edition') AS Edition;"
 ```
 
@@ -43,7 +43,7 @@ Standardize on this shape everywhere. Use `Server=`, `Database=`, `User Id=`,
 short forms.
 
 ```
-Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true
+Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true
 ```
 
 Apps read this from a single `SQL_CONNECTION_STRING` env var (see
@@ -55,12 +55,12 @@ All target `appdb`, which must already exist.
 
 | Stack | Connection string / config |
 | --- | --- |
-| ADO.NET / EF Core (SqlClient) | `Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true` |
-| Go (microsoft/go-mssqldb) | `sqlserver://sa:YourStrong!Passw0rd@localhost:1433?database=appdb&TrustServerCertificate=true` |
-| Python (pyodbc, ODBC 18) | `Driver={ODBC Driver 18 for SQL Server};Server=localhost,1433;Database=appdb;Uid=sa;Pwd=YourStrong!Passw0rd;TrustServerCertificate=yes` |
-| Python (pymssql) | `pymssql.connect(server="localhost", port=1433, user="sa", password="YourStrong!Passw0rd", database="appdb")` |
-| Node.js (mssql / tedious) | `{ server: "localhost", port: 1433, user: "sa", password: "YourStrong!Passw0rd", database: "appdb", options: { trustServerCertificate: true } }` |
-| JDBC | `jdbc:sqlserver://localhost:1433;databaseName=appdb;user=sa;password=YourStrong!Passw0rd;trustServerCertificate=true` |
+| ADO.NET / EF Core (SqlClient) | `Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true` |
+| Go (microsoft/go-mssqldb) | `sqlserver://sa:YourStr0ng_Passw0rd@localhost:1433?database=appdb&TrustServerCertificate=true` |
+| Python (pyodbc, ODBC 18) | `Driver={ODBC Driver 18 for SQL Server};Server=localhost,1433;Database=appdb;Uid=sa;Pwd=YourStr0ng_Passw0rd;TrustServerCertificate=yes` |
+| Python (pymssql) | `pymssql.connect(server="localhost", port=1433, user="sa", password="YourStr0ng_Passw0rd", database="appdb")` |
+| Node.js (mssql / tedious) | `{ server: "localhost", port: 1433, user: "sa", password: "YourStr0ng_Passw0rd", database: "appdb", options: { trustServerCertificate: true } }` |
+| JDBC | `jdbc:sqlserver://localhost:1433;databaseName=appdb;user=sa;password=YourStr0ng_Passw0rd;trustServerCertificate=true` |
 
 Note: the ODBC keyword form genuinely uses `Uid`/`Pwd`; that is an ODBC-specific
 exception. For the .NET-style (`User Id=`/`Password=`) and the
@@ -74,7 +74,7 @@ In the MSSQL extension, add a connection with:
 - Database: `appdb`
 - Authentication: SQL Login
 - User: `sa`
-- Password: `YourStrong!Passw0rd`
+- Password: `YourStr0ng_Passw0rd`
 - Trust server certificate: enabled
 
 ## Validation rules

--- a/skills/azuresql-db-container/references/connection-model.md
+++ b/skills/azuresql-db-container/references/connection-model.md
@@ -27,7 +27,7 @@ The single most common source of failures. Read this before connecting an app.
 ### Step 1: connect to master and create the database
 
 ```bash
-docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -b \
+docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b \
   -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;"
 ```
 
@@ -37,7 +37,7 @@ that is correct here.
 ### Step 2: connect to the user database for real work
 
 ```bash
-docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -b \
+docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b \
   -d appdb -Q "SELECT DB_NAME() AS CurrentDatabase;"
 ```
 
@@ -67,7 +67,7 @@ after provisioning, and target the database with `-d appdb`, not `USE`:
 ```bash
 # 1. provision appdb on master (see Step 1)
 # 2. seed it by selecting appdb in the connection
-docker exec -i sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -b \
+docker exec -i sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b \
   -d appdb -i /path/in/container/seed.sql
 ```
 

--- a/skills/azuresql-db-container/references/environment-variables.md
+++ b/skills/azuresql-db-container/references/environment-variables.md
@@ -12,13 +12,13 @@ What the container requires at start, and the app-side convention.
 `MSSQL_SA_PASSWORD` policy: at least 8 characters and at least three of upper
 case, lower case, digits, and symbols. A weak password makes the engine fail to
 initialize (see `troubleshooting.md`). Example used throughout these docs:
-`YourStrong!Passw0rd`.
+`YourStr0ng_Passw0rd`.
 
 The engine listens on container port `1433`. Map it to a host port at run time
 (`-p HOST_PORT:1433`); see `run-the-container.md`.
 
 ```bash
-docker run -d --name sqldb -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong!Passw0rd" \
+docker run -d --name sqldb -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd" \
   -p "1433:1433" sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
 ```
 
@@ -29,7 +29,7 @@ their connection. Standardize its value on the canonical string (note `appdb`
 must already exist):
 
 ```bash
-export SQL_CONNECTION_STRING="Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true"
+export SQL_CONNECTION_STRING="Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true"
 ```
 
 In compose, pass it to the app service:
@@ -38,7 +38,7 @@ In compose, pass it to the app service:
 services:
   app:
     environment:
-      SQL_CONNECTION_STRING: "Server=sqldb,1433;Database=appdb;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true"
+      SQL_CONNECTION_STRING: "Server=sqldb,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true"
 ```
 
 Inside a compose network, use the service name (`sqldb`) as the host; from the

--- a/skills/azuresql-db-container/references/run-the-container.md
+++ b/skills/azuresql-db-container/references/run-the-container.md
@@ -25,9 +25,9 @@ waits for readiness while provisioning `appdb` in the same loop.
 HOST_PORT=1433; while lsof -nP -iTCP:"$HOST_PORT" -sTCP:LISTEN >/dev/null 2>&1; do HOST_PORT=$((HOST_PORT+1)); done
 PLATFORM=(); case "$(docker info -f '{{.Architecture}}' 2>/dev/null)" in x86_64|amd64) ;; *) PLATFORM=(--platform linux/amd64);; esac
 docker rm -f sqldb 2>/dev/null
-docker run -d --name sqldb "${PLATFORM[@]}" -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong!Passw0rd" \
+docker run -d --name sqldb "${PLATFORM[@]}" -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd" \
   -p "$HOST_PORT:1433" sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
-until docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -b -l 2 \
+until docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b -l 2 \
   -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;" >/dev/null 2>&1; do sleep 2; done
 echo "ready on localhost,$HOST_PORT"
 ```
@@ -55,7 +55,7 @@ Podman uses the same arguments. Sign in first (see `image-and-registry.md`).
 
 ```bash
 podman run -d --name sqldb --platform linux/amd64 -e "ACCEPT_EULA=Y" \
-  -e "MSSQL_SA_PASSWORD=YourStrong!Passw0rd" -p "1433:1433" \
+  -e "MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd" -p "1433:1433" \
   sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
 ```
 
@@ -73,14 +73,14 @@ services:
     platform: linux/amd64
     environment:
       ACCEPT_EULA: "Y"
-      MSSQL_SA_PASSWORD: "YourStrong!Passw0rd"
+      MSSQL_SA_PASSWORD: "YourStr0ng_Passw0rd"
     ports:
       - "1433:1433"
     volumes:
       - sqldb-data:/var/opt/mssql
     healthcheck:
       test: ["CMD", "/opt/mssql-tools18/bin/sqlcmd", "-S", "localhost", "-U", "sa",
-             "-P", "YourStrong!Passw0rd", "-C", "-b", "-l", "2", "-Q", "SELECT 1"]
+             "-P", "YourStr0ng_Passw0rd", "-C", "-b", "-l", "2", "-Q", "SELECT 1"]
       interval: 10s
       timeout: 5s
       retries: 12
@@ -93,9 +93,9 @@ Compose does not provision `appdb` for you. After the service is healthy, create
 the database and seed it:
 
 ```bash
-docker compose exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -b \
+docker compose exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b \
   -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;"
-docker compose exec -T sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -b \
+docker compose exec -T sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b \
   -d appdb -i /path/in/container/seed.sql
 ```
 

--- a/skills/azuresql-db-container/references/troubleshooting.md
+++ b/skills/azuresql-db-container/references/troubleshooting.md
@@ -26,7 +26,7 @@ the env vars and recreate:
 
 ```bash
 docker rm -f sqldb 2>/dev/null
-docker run -d --name sqldb -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong!Passw0rd" \
+docker run -d --name sqldb -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd" \
   -p "1433:1433" sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
 ```
 
@@ -54,7 +54,7 @@ manifest. Add the platform flag to run under emulation:
 
 ```bash
 docker run -d --name sqldb --platform linux/amd64 -e "ACCEPT_EULA=Y" \
-  -e "MSSQL_SA_PASSWORD=YourStrong!Passw0rd" -p "1433:1433" \
+  -e "MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd" -p "1433:1433" \
   sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
 ```
 
@@ -78,7 +78,7 @@ fails because the database does not exist, provision it on a `master`
 connection first:
 
 ```bash
-docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -b \
+docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b \
   -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;"
 ```
 
@@ -97,7 +97,7 @@ image. Stop it and start the Azure SQL Database image from
 
 ```bash
 docker rm -f sqldb 2>/dev/null
-docker run -d --name sqldb -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong!Passw0rd" \
+docker run -d --name sqldb -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd" \
   -p "1433:1433" sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
 ```
 

--- a/skills/azuresql-db-container/references/wait-until-ready.md
+++ b/skills/azuresql-db-container/references/wait-until-ready.md
@@ -11,7 +11,7 @@ Provision `appdb` inside the same loop so readiness and provisioning happen
 together:
 
 ```bash
-until docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -b -l 2 \
+until docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b -l 2 \
   -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;" >/dev/null 2>&1; do sleep 2; done
 echo "ready"
 ```
@@ -36,7 +36,7 @@ wait on `service_healthy`:
 ```yaml
 healthcheck:
   test: ["CMD", "/opt/mssql-tools18/bin/sqlcmd", "-S", "localhost", "-U", "sa",
-         "-P", "YourStrong!Passw0rd", "-C", "-b", "-l", "2", "-Q", "SELECT 1"]
+         "-P", "YourStr0ng_Passw0rd", "-C", "-b", "-l", "2", "-Q", "SELECT 1"]
   interval: 10s
   timeout: 5s
   retries: 12
@@ -47,7 +47,7 @@ The healthcheck only proves the engine answers; it does not create `appdb`.
 After the service is healthy, run the provisioning command separately:
 
 ```bash
-docker compose exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -b \
+docker compose exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b \
   -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;"
 ```
 

--- a/skills/azuresql-db-container/scripts/verify.sh
+++ b/skills/azuresql-db-container/scripts/verify.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 # Config (override via env)
 # ----------------------------------------------------------------------------
 IMAGE="${IMAGE:-sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest}"
-SA_PASSWORD="${MSSQL_SA_PASSWORD:-YourStrong!Passw0rd}"
+SA_PASSWORD="${MSSQL_SA_PASSWORD:-YourStr0ng_Passw0rd}"
 CONTAINER="${CONTAINER:-sqldb-verify}"
 SQLCMD="/opt/mssql-tools18/bin/sqlcmd"
 

--- a/skills/azuresql-db-from-sql-server/SKILL.md
+++ b/skills/azuresql-db-from-sql-server/SKILL.md
@@ -77,9 +77,9 @@ flags make a SQL error set the exit code so transient startup errors (e.g.
 HOST_PORT=1433; while lsof -nP -iTCP:"$HOST_PORT" -sTCP:LISTEN >/dev/null 2>&1; do HOST_PORT=$((HOST_PORT+1)); done
 PLATFORM=(); case "$(docker info -f '{{.Architecture}}' 2>/dev/null)" in x86_64|amd64) ;; *) PLATFORM=(--platform linux/amd64);; esac
 docker rm -f sqldb 2>/dev/null
-docker run -d --name sqldb "${PLATFORM[@]}" -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong!Passw0rd" \
+docker run -d --name sqldb "${PLATFORM[@]}" -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd" \
   -p "$HOST_PORT:1433" sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
-until docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -b -l 2 \
+until docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b -l 2 \
   -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;" >/dev/null 2>&1; do sleep 2; done
 echo "ready on localhost,$HOST_PORT"
 ```
@@ -101,7 +101,7 @@ string (`Database=appdb`, or `-d appdb` for sqlcmd). Standardize on one
 `SQL_CONNECTION_STRING` env var:
 
 ```
-Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true
+Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true
 ```
 
 Use `User Id=` / `Password=` / `Database=`, not `Uid=` / `Pwd=`. For sqlcmd use
@@ -114,7 +114,7 @@ Postgres/MySQL convention and is not honored here; do not rely on it. Seed by
 running your script against the provisioned database:
 
 ```bash
-docker exec -i sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -d appdb -i /dev/stdin < seed.sql
+docker exec -i sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -d appdb -i /dev/stdin < seed.sql
 ```
 
 ### 7. Remove box-only features
@@ -133,7 +133,7 @@ Flag and fix every hit. Full table in `references/box-vs-azure-feature-matrix.md
 Confirm you are on the Azure SQL Database engine:
 
 ```bash
-docker exec -i sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -d appdb \
+docker exec -i sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -d appdb \
   -Q "SELECT SERVERPROPERTY('EngineEdition') AS EngineEdition, SERVERPROPERTY('Edition') AS Edition;"
 ```
 

--- a/skills/azuresql-db-from-sql-server/references/migrate-compose.md
+++ b/skills/azuresql-db-from-sql-server/references/migrate-compose.md
@@ -10,13 +10,13 @@ services:
     image: mcr.microsoft.com/mssql/server:2022-latest
     environment:
       ACCEPT_EULA: "Y"
-      MSSQL_SA_PASSWORD: "YourStrong!Passw0rd"
+      MSSQL_SA_PASSWORD: "YourStr0ng_Passw0rd"
     ports:
       - "1433:1433"
   app:
     build: ./app
     environment:
-      SQL_CONNECTION_STRING: "Server=db,1433;Database=master;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true"
+      SQL_CONNECTION_STRING: "Server=db,1433;Database=master;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true"
     depends_on:
       - db
 ```
@@ -39,7 +39,7 @@ services:
     # platform: linux/amd64
     environment:
       ACCEPT_EULA: "Y"
-      MSSQL_SA_PASSWORD: "YourStrong!Passw0rd"
+      MSSQL_SA_PASSWORD: "YourStr0ng_Passw0rd"
     ports:
       - "1433:1433"
     healthcheck:
@@ -54,12 +54,12 @@ services:
       db:
         condition: service_healthy
     entrypoint: >
-      /opt/mssql-tools18/bin/sqlcmd -S db,1433 -U sa -P "YourStrong!Passw0rd" -C -b
+      /opt/mssql-tools18/bin/sqlcmd -S db,1433 -U sa -P "YourStr0ng_Passw0rd" -C -b
       -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;"
   app:
     build: ./app
     environment:
-      SQL_CONNECTION_STRING: "Server=db,1433;Database=appdb;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true"
+      SQL_CONNECTION_STRING: "Server=db,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true"
     depends_on:
       provision:
         condition: service_completed_successfully
@@ -88,7 +88,7 @@ separately after `appdb` exists:
 
 ```bash
 docker compose run --rm provision \
-  /opt/mssql-tools18/bin/sqlcmd -S db,1433 -U sa -P "YourStrong!Passw0rd" -C -d appdb -i /seed.sql
+  /opt/mssql-tools18/bin/sqlcmd -S db,1433 -U sa -P "YourStr0ng_Passw0rd" -C -d appdb -i /seed.sql
 ```
 
 ## Box-only features to remove first

--- a/skills/azuresql-db-import/SKILL.md
+++ b/skills/azuresql-db-import/SKILL.md
@@ -52,9 +52,9 @@ target database `appdb` on master in that same loop.
 HOST_PORT=1433; while lsof -nP -iTCP:"$HOST_PORT" -sTCP:LISTEN >/dev/null 2>&1; do HOST_PORT=$((HOST_PORT+1)); done
 PLATFORM=(); case "$(docker info -f '{{.Architecture}}' 2>/dev/null)" in x86_64|amd64) ;; *) PLATFORM=(--platform linux/amd64);; esac
 docker rm -f sqldb 2>/dev/null
-docker run -d --name sqldb "${PLATFORM[@]}" -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong!Passw0rd" \
+docker run -d --name sqldb "${PLATFORM[@]}" -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd" \
   -p "$HOST_PORT:1433" sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
-until docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -b -l 2 \
+until docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b -l 2 \
   -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;" >/dev/null 2>&1; do sleep 2; done
 echo "ready on localhost,$HOST_PORT"
 ```
@@ -62,7 +62,7 @@ echo "ready on localhost,$HOST_PORT"
 If the container is already running, just provision the target database on master:
 
 ```bash
-docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -b \
+docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b \
   -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;"
 ```
 
@@ -80,7 +80,7 @@ Schema + data (`.bacpac`):
 ```bash
 SqlPackage /Action:Import \
   /SourceFile:"./mydatabase.bacpac" \
-  /TargetConnectionString:"Server=localhost,$HOST_PORT;Database=appdb;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true"
+  /TargetConnectionString:"Server=localhost,$HOST_PORT;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true"
 ```
 
 Schema only (`.dacpac`) uses `/Action:Publish`, not Import:
@@ -88,7 +88,7 @@ Schema only (`.dacpac`) uses `/Action:Publish`, not Import:
 ```bash
 SqlPackage /Action:Publish \
   /SourceFile:"./myschema.dacpac" \
-  /TargetConnectionString:"Server=localhost,$HOST_PORT;Database=appdb;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true"
+  /TargetConnectionString:"Server=localhost,$HOST_PORT;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true"
 ```
 
 If SqlPackage is not installed locally, see `references/sqlpackage-import.md` for
@@ -99,7 +99,7 @@ install options and a container-based fallback.
 Confirm the engine identity and spot-check that objects landed:
 
 ```bash
-docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -b -d appdb \
+docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b -d appdb \
   -Q "SELECT SERVERPROPERTY('EngineEdition') AS EngineEdition; SELECT COUNT(*) AS Tables FROM sys.tables;"
 ```
 

--- a/skills/azuresql-db-import/references/sqlpackage-import.md
+++ b/skills/azuresql-db-import/references/sqlpackage-import.md
@@ -49,7 +49,7 @@ Always provision `appdb` on a master connection first (see SKILL.md Step 0), the
 ```bash
 SqlPackage /Action:Import \
   /SourceFile:"./mydatabase.bacpac" \
-  /TargetConnectionString:"Server=localhost,$HOST_PORT;Database=appdb;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true" \
+  /TargetConnectionString:"Server=localhost,$HOST_PORT;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true" \
   /p:CommandTimeout=0
 ```
 

--- a/skills/azuresql-db-local-to-cloud/SKILL.md
+++ b/skills/azuresql-db-local-to-cloud/SKILL.md
@@ -44,7 +44,7 @@ Standardize on `SQL_CONNECTION_STRING`. Use `User Id=` / `Password=` /
 Local (container, SA auth):
 
 ```
-Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true
+Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true
 ```
 
 Cloud (Azure SQL Database, Microsoft Entra auth):
@@ -114,9 +114,9 @@ code so the loop retries instead of masking it.
 HOST_PORT=1433; while lsof -nP -iTCP:"$HOST_PORT" -sTCP:LISTEN >/dev/null 2>&1; do HOST_PORT=$((HOST_PORT+1)); done
 PLATFORM=(); case "$(docker info -f '{{.Architecture}}' 2>/dev/null)" in x86_64|amd64) ;; *) PLATFORM=(--platform linux/amd64);; esac
 docker rm -f sqldb 2>/dev/null
-docker run -d --name sqldb "${PLATFORM[@]}" -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong!Passw0rd" \
+docker run -d --name sqldb "${PLATFORM[@]}" -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd" \
   -p "$HOST_PORT:1433" sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
-until docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -b -l 2 \
+until docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b -l 2 \
   -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;" >/dev/null 2>&1; do sleep 2; done
 echo "ready on localhost,$HOST_PORT"
 ```
@@ -124,7 +124,7 @@ echo "ready on localhost,$HOST_PORT"
 Then point the app at it (assuming the loop above settled on 1433):
 
 ```bash
-export SQL_CONNECTION_STRING="Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true"
+export SQL_CONNECTION_STRING="Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true"
 ```
 
 To run against the cloud later, change only this variable; do not touch the app.

--- a/skills/azuresql-db-local-to-cloud/references/auth-local-vs-cloud.md
+++ b/skills/azuresql-db-local-to-cloud/references/auth-local-vs-cloud.md
@@ -34,7 +34,7 @@ local choice is username/password over a trusted self-signed certificate.
 Local string:
 
 ```
-Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true
+Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true
 ```
 
 `TrustServerCertificate=true` accepts the container's self-signed cert. This is
@@ -118,7 +118,7 @@ For pyodbc, set `SQL_CONNECTION_STRING` in ODBC keyword form.
 Local:
 
 ```
-Driver={ODBC Driver 18 for SQL Server};Server=localhost,1433;Database=appdb;Uid=sa;Pwd=YourStrong!Passw0rd;TrustServerCertificate=yes
+Driver={ODBC Driver 18 for SQL Server};Server=localhost,1433;Database=appdb;Uid=sa;Pwd=YourStr0ng_Passw0rd;TrustServerCertificate=yes
 ```
 
 Cloud:

--- a/skills/azuresql-db-rag/SKILL.md
+++ b/skills/azuresql-db-rag/SKILL.md
@@ -59,7 +59,7 @@ Standard connection string (use `User Id=`/`Password=`/`Database=`, never
 `Uid=`/`Pwd=`):
 
 ```
-Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true
+Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true
 ```
 
 ## Step 1: start the container and provision appdb (fresh-container safe)
@@ -74,9 +74,9 @@ inside that loop. The `-b -l 2` flags make transient startup errors (like
 HOST_PORT=1433; while lsof -nP -iTCP:"$HOST_PORT" -sTCP:LISTEN >/dev/null 2>&1; do HOST_PORT=$((HOST_PORT+1)); done
 PLATFORM=(); case "$(docker info -f '{{.Architecture}}' 2>/dev/null)" in x86_64|amd64) ;; *) PLATFORM=(--platform linux/amd64);; esac
 docker rm -f sqldb 2>/dev/null
-docker run -d --name sqldb "${PLATFORM[@]}" -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong!Passw0rd" \
+docker run -d --name sqldb "${PLATFORM[@]}" -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd" \
   -p "$HOST_PORT:1433" sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
-until docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -b -l 2 \
+until docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b -l 2 \
   -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;" >/dev/null 2>&1; do sleep 2; done
 echo "ready on localhost,$HOST_PORT"
 ```
@@ -90,7 +90,7 @@ The dimension `n` must match your embedding model's output (for example 768 for
 the column type.
 
 ```bash
-docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -b -d appdb -Q "
+docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b -d appdb -Q "
 CREATE TABLE docs (
   id        INT IDENTITY PRIMARY KEY,
   content   NVARCHAR(MAX) NOT NULL,
@@ -133,7 +133,7 @@ string), never the dimension.
 import json, pyodbc
 
 CONN = ("Driver={ODBC Driver 18 for SQL Server};Server=localhost,1433;"
-        "Database=appdb;Uid=sa;Pwd=YourStrong!Passw0rd;TrustServerCertificate=yes")
+        "Database=appdb;Uid=sa;Pwd=YourStr0ng_Passw0rd;TrustServerCertificate=yes")
 
 def add_doc(cur, content: str):
     vec = embed(content)

--- a/skills/azuresql-db-rag/references/vector-schema.md
+++ b/skills/azuresql-db-rag/references/vector-schema.md
@@ -147,7 +147,7 @@ provisioning `appdb`:
 
 ```bash
 docker exec -i sqldb /opt/mssql-tools18/bin/sqlcmd \
-  -S localhost -U sa -P "YourStrong!Passw0rd" -C -b -d appdb -i seed.sql
+  -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b -d appdb -i seed.sql
 ```
 
 For programmatic seeding, loop over your documents in application code calling

--- a/skills/azuresql-db-scaffold/SKILL.md
+++ b/skills/azuresql-db-scaffold/SKILL.md
@@ -53,9 +53,9 @@ same retry loop). The `-b` makes a SQL error set the exit code, so transient sta
 HOST_PORT=1433; while lsof -nP -iTCP:"$HOST_PORT" -sTCP:LISTEN >/dev/null 2>&1; do HOST_PORT=$((HOST_PORT+1)); done
 PLATFORM=(); case "$(docker info -f '{{.Architecture}}' 2>/dev/null)" in x86_64|amd64) ;; *) PLATFORM=(--platform linux/amd64);; esac
 docker rm -f sqldb 2>/dev/null
-docker run -d --name sqldb "${PLATFORM[@]}" -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong!Passw0rd" \
+docker run -d --name sqldb "${PLATFORM[@]}" -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd" \
   -p "$HOST_PORT:1433" sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
-until docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -b -l 2 \
+until docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b -l 2 \
   -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;" >/dev/null 2>&1; do sleep 2; done
 echo "ready on localhost,$HOST_PORT"
 ```
@@ -68,7 +68,7 @@ symbol). The engine listens on 1433.
 Apps read **one** env var, `SQL_CONNECTION_STRING`:
 
 ```
-Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true
+Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true
 ```
 
 Use `User Id=` / `Password=` / `Database=` (NOT `Uid=` / `Pwd=`). For sqlcmd use `-C` to trust
@@ -93,7 +93,7 @@ workflow (idempotent scripts, ordering, applying inside the ready-wait loop) cro
 **azuresql-db-schema-migration** skill. Seed only AFTER appdb exists:
 
 ```bash
-docker exec -i sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -b -d appdb -i seed.sql
+docker exec -i sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b -d appdb -i seed.sql
 ```
 
 ## Vectors (if your app uses embeddings)

--- a/skills/azuresql-db-scaffold/references/scaffold-snippets.md
+++ b/skills/azuresql-db-scaffold/references/scaffold-snippets.md
@@ -27,7 +27,7 @@ services:
     # platform: linux/amd64
     environment:
       ACCEPT_EULA: "Y"
-      MSSQL_SA_PASSWORD: "YourStrong!Passw0rd"
+      MSSQL_SA_PASSWORD: "YourStr0ng_Passw0rd"
     ports:
       - "1433:1433"
     healthcheck:
@@ -43,14 +43,14 @@ services:
         condition: service_healthy
     entrypoint: ["/bin/bash", "-c"]
     command: >
-      "/opt/mssql-tools18/bin/sqlcmd -S sqldb -U sa -P 'YourStrong!Passw0rd' -C -b
+      "/opt/mssql-tools18/bin/sqlcmd -S sqldb -U sa -P 'YourStr0ng_Passw0rd' -C -b
        -Q \"IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;\""
 ```
 
 Connection string the app consumes (host side, port 1433):
 
 ```
-Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true
+Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true
 ```
 
 ## .NET Aspire (EF Core)
@@ -58,13 +58,13 @@ Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStrong!Passw0rd;Tru
 `.env` / user-secrets:
 
 ```
-SQL_CONNECTION_STRING=Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true
+SQL_CONNECTION_STRING=Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true
 ```
 
 Provision appdb (once, on master) before the first migration:
 
 ```bash
-docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -b \
+docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b \
   -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;"
 ```
 
@@ -98,13 +98,13 @@ For the migration workflow in depth, see the **azuresql-db-schema-migration** sk
 `.env`:
 
 ```
-SQL_CONNECTION_STRING=Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true
+SQL_CONNECTION_STRING=Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true
 ```
 
 Provision appdb on master before the app connects:
 
 ```bash
-docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -b \
+docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b \
   -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;"
 ```
 
@@ -153,8 +153,8 @@ Prisma needs a `sqlserver://` URL. Provide both env vars; keep them describing t
 `.env`:
 
 ```
-SQL_CONNECTION_STRING=Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true
-DATABASE_URL=sqlserver://localhost:1433;database=appdb;user=sa;password=YourStrong!Passw0rd;trustServerCertificate=true;encrypt=true
+SQL_CONNECTION_STRING=Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true
+DATABASE_URL=sqlserver://localhost:1433;database=appdb;user=sa;password=YourStr0ng_Passw0rd;trustServerCertificate=true;encrypt=true
 ```
 
 Install Prisma (pinned to v6):
@@ -179,7 +179,7 @@ datasource db {
 Provision appdb on master, THEN run the first migration (Prisma will not create the database):
 
 ```bash
-docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -b \
+docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b \
   -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;"
 npx prisma migrate dev --name init
 ```
@@ -195,14 +195,14 @@ const widgets = await prisma.widget.findMany({ where: { name } });
 `.env` (same two vars as Next.js):
 
 ```
-SQL_CONNECTION_STRING=Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true
-DATABASE_URL=sqlserver://localhost:1433;database=appdb;user=sa;password=YourStrong!Passw0rd;trustServerCertificate=true;encrypt=true
+SQL_CONNECTION_STRING=Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true
+DATABASE_URL=sqlserver://localhost:1433;database=appdb;user=sa;password=YourStr0ng_Passw0rd;trustServerCertificate=true;encrypt=true
 ```
 
 Provision appdb on master before bootstrapping:
 
 ```bash
-docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -b \
+docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b \
   -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;"
 ```
 
@@ -219,7 +219,7 @@ export const AppDataSource = new DataSource({
   host: "localhost",
   port: 1433,
   username: "sa",
-  password: process.env.MSSQL_SA_PASSWORD ?? "YourStrong!Passw0rd",
+  password: process.env.MSSQL_SA_PASSWORD ?? "YourStr0ng_Passw0rd",
   database: "appdb",                 // selected here, never via USE
   options: { trustServerCertificate: true },
   entities: [/* ... */],

--- a/skills/azuresql-db-schema-migration/SKILL.md
+++ b/skills/azuresql-db-schema-migration/SKILL.md
@@ -43,9 +43,9 @@ docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io   # pull-only creds from t
 HOST_PORT=1433; while lsof -nP -iTCP:"$HOST_PORT" -sTCP:LISTEN >/dev/null 2>&1; do HOST_PORT=$((HOST_PORT+1)); done
 PLATFORM=(); case "$(docker info -f '{{.Architecture}}' 2>/dev/null)" in x86_64|amd64) ;; *) PLATFORM=(--platform linux/amd64);; esac
 docker rm -f sqldb 2>/dev/null
-docker run -d --name sqldb "${PLATFORM[@]}" -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStrong!Passw0rd" \
+docker run -d --name sqldb "${PLATFORM[@]}" -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd" \
   -p "$HOST_PORT:1433" sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
-until docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -C -b -l 2 \
+until docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b -l 2 \
   -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;" >/dev/null 2>&1; do sleep 2; done
 echo "ready on localhost,$HOST_PORT"
 ```
@@ -60,7 +60,7 @@ poll bare `sqlcmd` without `-l`. For full lifecycle detail, see the
 Standardize on one form and read it from a single `SQL_CONNECTION_STRING` env var:
 
 ```
-Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true
+Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true
 ```
 
 - Use `User Id=` / `Password=` / `Database=`, NOT `Uid=` / `Pwd=`.
@@ -76,7 +76,7 @@ troubleshooting per tool are in `references/migration-tools.md`.
 ### EF Core (.NET)
 
 ```bash
-export SQL_CONNECTION_STRING="Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true"
+export SQL_CONNECTION_STRING="Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true"
 dotnet ef database update
 ```
 
@@ -91,7 +91,7 @@ Prisma needs the `sqlserver://` URL form in `DATABASE_URL`:
 ```bash
 npm install -D prisma@6
 npm install @prisma/client@6
-export DATABASE_URL="sqlserver://localhost:1433;database=appdb;user=sa;password=YourStrong!Passw0rd;trustServerCertificate=true"
+export DATABASE_URL="sqlserver://localhost:1433;database=appdb;user=sa;password=YourStr0ng_Passw0rd;trustServerCertificate=true"
 npx prisma migrate deploy          # apply committed migrations (CI / prod-like)
 npx prisma migrate dev --name init # author + apply a new migration (local dev)
 ```
@@ -102,7 +102,7 @@ requires a driver adapter (@prisma/adapter-mssql). See references for the adapte
 ### Alembic (Python)
 
 ```bash
-export SQL_CONNECTION_STRING="mssql+pyodbc://sa:YourStrong!Passw0rd@localhost,1433/appdb?driver=ODBC+Driver+18+for+SQL+Server&TrustServerCertificate=yes"
+export SQL_CONNECTION_STRING="mssql+pyodbc://sa:YourStr0ng_Passw0rd@localhost,1433/appdb?driver=ODBC+Driver+18+for+SQL+Server&TrustServerCertificate=yes"
 alembic upgrade head
 ```
 
@@ -111,7 +111,7 @@ alembic upgrade head
 ```bash
 sqlpackage /Action:Publish /SourceFile:./app.dacpac \
   /TargetServerName:"localhost,1433" /TargetDatabaseName:appdb \
-  /TargetUser:sa /TargetPassword:"YourStrong!Passw0rd" \
+  /TargetUser:sa /TargetPassword:"YourStr0ng_Passw0rd" \
   /TargetTrustServerCertificate:true
 ```
 
@@ -133,7 +133,7 @@ migrating:
 
 ```bash
 docker exec -i sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa \
-  -P "YourStrong!Passw0rd" -C -b -d appdb -i seed.sql
+  -P "YourStr0ng_Passw0rd" -C -b -d appdb -i seed.sql
 ```
 
 ## Validation rules

--- a/skills/azuresql-db-schema-migration/references/migration-tools.md
+++ b/skills/azuresql-db-schema-migration/references/migration-tools.md
@@ -27,7 +27,7 @@ the connection string (`Database=appdb`, or `-d appdb` for sqlcmd).
 - Image: `sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest`
   (x64 / linux/amd64 only; on a non-x64 host add `--platform linux/amd64`).
 - Canonical ADO.NET / sqlcmd connection string:
-  `Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true`
+  `Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true`
 - One env var holds it: `SQL_CONNECTION_STRING`. Apps and most tools read it.
 - Use `User Id=`/`Password=`/`Database=`, not `Uid=`/`Pwd=`.
 - If you started on a non-default host port, replace `localhost,1433` with `localhost,<HOST_PORT>`.
@@ -37,7 +37,7 @@ the connection string (`Database=appdb`, or `-d appdb` for sqlcmd).
 Point EF Core at `appdb` and apply migrations:
 
 ```bash
-export SQL_CONNECTION_STRING="Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true"
+export SQL_CONNECTION_STRING="Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true"
 dotnet ef database update
 ```
 
@@ -83,7 +83,7 @@ Prisma uses a URL-form connection string, not the ADO.NET form. Install Prisma
 ```bash
 npm install -D prisma@6
 npm install @prisma/client@6
-export DATABASE_URL="sqlserver://localhost:1433;database=appdb;user=sa;password=YourStrong!Passw0rd;trustServerCertificate=true"
+export DATABASE_URL="sqlserver://localhost:1433;database=appdb;user=sa;password=YourStr0ng_Passw0rd;trustServerCertificate=true"
 ```
 
 Pinned to Prisma 6; Prisma 7 moved the datasource `url` into a prisma.config.ts and
@@ -141,7 +141,7 @@ the runtime client.
 Alembic uses a SQLAlchemy URL. With pyodbc and ODBC Driver 18:
 
 ```bash
-export SQL_CONNECTION_STRING="mssql+pyodbc://sa:YourStrong!Passw0rd@localhost,1433/appdb?driver=ODBC+Driver+18+for+SQL+Server&TrustServerCertificate=yes"
+export SQL_CONNECTION_STRING="mssql+pyodbc://sa:YourStr0ng_Passw0rd@localhost,1433/appdb?driver=ODBC+Driver+18+for+SQL+Server&TrustServerCertificate=yes"
 alembic upgrade head
 ```
 
@@ -166,7 +166,7 @@ Publish a DACPAC to `appdb`:
 ```bash
 sqlpackage /Action:Publish /SourceFile:./app.dacpac \
   /TargetServerName:"localhost,1433" /TargetDatabaseName:appdb \
-  /TargetUser:sa /TargetPassword:"YourStrong!Passw0rd" \
+  /TargetUser:sa /TargetPassword:"YourStr0ng_Passw0rd" \
   /TargetTrustServerCertificate:true
 ```
 
@@ -177,7 +177,7 @@ Notes:
 - Extract the current schema for diffing:
   ```bash
   sqlpackage /Action:Extract /SourceServerName:"localhost,1433" \
-    /SourceDatabaseName:appdb /SourceUser:sa /SourcePassword:"YourStrong!Passw0rd" \
+    /SourceDatabaseName:appdb /SourceUser:sa /SourcePassword:"YourStr0ng_Passw0rd" \
     /SourceTrustServerCertificate:true /TargetFile:./app.dacpac
   ```
 

--- a/skills/azuresql-db-sidecar/SKILL.md
+++ b/skills/azuresql-db-sidecar/SKILL.md
@@ -38,7 +38,7 @@ one-shot that creates `appdb`, and a `depends_on` gate.
   only, not application work. Always select the target database in the connection
   string (`Database=appdb`, or `-d appdb` for sqlcmd).
 - App connection string (single `SQL_CONNECTION_STRING` env var, service name host):
-  `Server=sqldb,1433;Database=appdb;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true`
+  `Server=sqldb,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true`
   (use `User Id=`/`Password=`/`Database=`, not `Uid=`/`Pwd=`).
 - The image does **NOT** auto-run `/docker-entrypoint-initdb.d/*.sql` (a
   Postgres/MySQL convention, not honored here). Seed in the init one-shot with
@@ -61,7 +61,7 @@ services:
     platform: linux/amd64        # x64-only image; required on a non-x64 host
     environment:
       ACCEPT_EULA: "Y"
-      MSSQL_SA_PASSWORD: "YourStrong!Passw0rd"
+      MSSQL_SA_PASSWORD: "YourStr0ng_Passw0rd"
     ports:
       - "1433:1433"              # optional; only to reach it from the host
     healthcheck:
@@ -82,7 +82,7 @@ services:
       sqldb:
         condition: service_healthy
     environment:
-      MSSQL_SA_PASSWORD: "YourStrong!Passw0rd"
+      MSSQL_SA_PASSWORD: "YourStr0ng_Passw0rd"
     # If you have seed.sql, mount it and add: -i /seed/seed.sql on a -d appdb call.
     # volumes:
     #   - ./seed.sql:/seed/seed.sql:ro
@@ -102,7 +102,7 @@ services:
         condition: service_completed_successfully
     environment:
       # Host is the SERVICE NAME sqldb, not localhost.
-      SQL_CONNECTION_STRING: "Server=sqldb,1433;Database=appdb;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true"
+      SQL_CONNECTION_STRING: "Server=sqldb,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true"
 ```
 
 Bring it up (after `docker login`, see above):
@@ -139,7 +139,7 @@ Use Docker Compose as the Dev Container backend so the same `sqldb` +
   "workspaceFolder": "/workspace",
   "runServices": ["sqldb", "sqldb-init"],
   "remoteEnv": {
-    "SQL_CONNECTION_STRING": "Server=sqldb,1433;Database=appdb;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true"
+    "SQL_CONNECTION_STRING": "Server=sqldb,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true"
   }
 }
 ```


### PR DESCRIPTION
The sample password `YourStrong!Passw0rd` can trip *interactive* bash's history expansion on the `!`. It is also embedded in URL-form connection strings (`mssql+pyodbc://sa:...@host`, `sqlserver://sa:...@host`), which rules out `@` (splits userinfo from host) and `$` (expands inside bash and PowerShell double quotes).

Switches all 135 occurrences across 31 files to **`YourStr0ng_Passw0rd`**. `_` is URL-unreserved and inert in bash, zsh, PowerShell, cmd, ADO.NET/ODBC connection strings, and YAML, and the password still satisfies the SQL complexity policy (upper + lower + digit + symbol). Jekyll build is clean.