### PR TITLE
Set honest expectations for GUI tooling (MSSQL extension, SSMS)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -110,7 +110,7 @@ You should see `Microsoft SQL Azure`, confirming you are on the Azure SQL Databa
 
 - **Already have [sqlcmd](https://learn.microsoft.com/sql/tools/sqlcmd/sqlcmd-utility) on the host?** Connect directly: `sqlcmd -S localhost,1433 -U sa -P "YourStr0ng_Passw0rd" -C -Q "SELECT @@VERSION;"`.
 - **Ask your AI agent, no T-SQL required.** With the [container skill](prerequisites.md#agent-skill) installed, ask in plain English, for example: *"Connect to my local Azure SQL Database and show the version and edition."* It already knows the connection details and runs the query for you.
-- **Use the VS Code MSSQL extension, with Copilot.** Install the [MSSQL extension](https://marketplace.visualstudio.com/items?itemName=ms-mssql.mssql), click **Add Connection**, and connect with server `localhost,1433`, SQL Login, user `sa`, your password, and **Trust server certificate: Yes**. Open a `.sql` file to run queries, and use the extension's inline GitHub Copilot assistance to write SQL from natural language.
+- **Use the VS Code MSSQL extension with GitHub Copilot.** Its Copilot integration works against the container today, for example writing SQL from natural language or opening the schema designer. Connect with server `localhost,1433`, SQL Login, user `sa`, your password, and **Trust server certificate: Yes**. The extension's graphical UI is not yet fully compatible with the container, so some UI features may error; see [known limitations](known-limitations.md).
 
 ### Stop and clean up
 

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -22,7 +22,7 @@ If you hit a limitation that is not on this page, please file a [GitHub issue](h
 
 ## Active issues we are fixing
 
-The following five issues are the ones we are actively fixing.
+The following issues are the ones we are actively fixing.
 
 ### 1. Restriction enforcement gaps
 
@@ -49,6 +49,12 @@ The image is x64 (`linux/amd64`); on a non-x64 host, add `--platform linux/amd64
 ### 5. Two-step provisioning
 
 Two-step provisioning is a current limitation: you provision a database on a master connection, then reconnect directly to it. Public preview will let the container set a default startup database (for example `MSSQL_DB=appdb`) so you connect straight into an Azure-faithful (SDS) session without going through master.
+
+### 6. GUI tooling compatibility (MSSQL extension and SSMS)
+
+Graphical tools are not yet 100% compatible with the container. The [VS Code MSSQL extension](https://marketplace.visualstudio.com/items?itemName=ms-mssql.mssql) and SQL Server Management Studio (SSMS) can throw UI errors against it. We are actively working on full compatibility.
+
+**Workaround:** Query with `sqlcmd` (on the host or the copy bundled in the container, via `docker exec`), or with any driver or ORM. These all work today. The MSSQL extension's GitHub Copilot integration also works now, for example opening the schema designer or writing SQL from natural language.
 
 ## Known behavior gaps
 

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -64,8 +64,7 @@ It works across Claude Code, GitHub Copilot, Codex, and Cursor. Browse the skill
 
 Recommended developer tooling for working with the container:
 
-- **VS Code** with the [MSSQL extension](https://marketplace.visualstudio.com/items?itemName=ms-mssql.mssql) for query authoring, schema browsing, and inline AI assistance.
-- **sqlcmd** (the modern Go-based `sqlcmd`) or **mssql-cli** for terminal access.
+- **sqlcmd** (the modern Go-based `sqlcmd`) or **mssql-cli** for terminal access. The container also bundles `sqlcmd`, so you can query it with `docker exec` and no host install.
 - **A driver or ORM for your stack.** Any driver that talks to Azure SQL Database works with the container without changes: `mssql` (Node.js), `mssql-python`, `pyodbc`, EF Core, Prisma, SQLAlchemy, JDBC.
 
 ## Azure account (optional, for local-to-cloud)


### PR DESCRIPTION
Bug-bash feedback: the VS Code MSSQL extension reads as "half baked" because its graphical UI is not yet fully compatible with the container (UI errors). But its GitHub Copilot integration does work (e.g., schema designer, natural-language SQL). The docs were recommending the extension for query authoring and schema browsing, which oversold it.

- **prerequisites:** removed the MSSQL extension from recommended tooling; the list now leads with sqlcmd (host or the bundled copy via `docker exec`) and drivers/ORMs, which work today.
- **known-limitations:** added an *active issues we are fixing* entry stating the MSSQL extension and **SSMS** are not yet 100% compatible and can throw UI errors, with sqlcmd / drivers / the working Copilot integration as the workaround.
- **getting-started:** scoped the MSSQL bullet to the Copilot integration that works and linked the limitation, instead of walking through the not-yet-stable connection UI.

Keeps the genuinely-working path discoverable while setting correct expectations. Jekyll build is clean.