### PR TITLE
Link the MSSQL Copilot docs and sync tooling claims repo-wide

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -110,7 +110,7 @@ You should see `Microsoft SQL Azure`, confirming you are on the Azure SQL Databa
 
 - **Already have [sqlcmd](https://learn.microsoft.com/sql/tools/sqlcmd/sqlcmd-utility) on the host?** Connect directly: `sqlcmd -S localhost,1433 -U sa -P "YourStr0ng_Passw0rd" -C -Q "SELECT @@VERSION;"`.
 - **Ask your AI agent, no T-SQL required.** With the [container skill](prerequisites.md#agent-skill) installed, ask in plain English, for example: *"Connect to my local Azure SQL Database and show the version and edition."* It already knows the connection details and runs the query for you.
-- **Use the VS Code MSSQL extension with GitHub Copilot.** Its Copilot integration works against the container today, for example writing SQL from natural language or opening the schema designer. Connect with server `localhost,1433`, SQL Login, user `sa`, your password, and **Trust server certificate: Yes**. The extension's graphical UI is not yet fully compatible with the container, so some UI features may error; see [known limitations](known-limitations.md).
+- **Use the VS Code MSSQL extension with GitHub Copilot.** Its [GitHub Copilot integration](https://aka.ms/vscode-mssql-copilot-docs) works against the container today, for example writing SQL from natural language or opening the schema designer. Connect with server `localhost,1433`, SQL Login, user `sa`, your password, and **Trust server certificate: Yes**. The extension's graphical UI is not yet fully compatible with the container, so some UI features may error; see [known limitations](known-limitations.md).
 
 ### Stop and clean up
 

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -54,7 +54,7 @@ Two-step provisioning is a current limitation: you provision a database on a mas
 
 Graphical tools are not yet 100% compatible with the container. The [VS Code MSSQL extension](https://marketplace.visualstudio.com/items?itemName=ms-mssql.mssql) and SQL Server Management Studio (SSMS) can throw UI errors against it. We are actively working on full compatibility.
 
-**Workaround:** Query with `sqlcmd` (on the host or the copy bundled in the container, via `docker exec`), or with any driver or ORM. These all work today. The MSSQL extension's GitHub Copilot integration also works now, for example opening the schema designer or writing SQL from natural language.
+**Workaround:** Query with `sqlcmd` (on the host or the copy bundled in the container, via `docker exec`), or with any driver or ORM. These all work today. The MSSQL extension's [GitHub Copilot integration](https://aka.ms/vscode-mssql-copilot-docs) also works now, for example opening the schema designer or writing SQL from natural language.
 
 ## Known behavior gaps
 

--- a/docs/what-is-the-container.md
+++ b/docs/what-is-the-container.md
@@ -25,7 +25,7 @@ The container is the **Azure SQL Database engine** itself, running locally. Thre
 
 1. **The same engine as the cloud.** The container runs the same engine, the same defaults, and the same T-SQL as Azure SQL Database. Features that are cloud-only in the box SQL Server product (Always Encrypted with secure enclaves, ledger, some DMVs) work locally the same way they work in the cloud.
 2. **No Azure subscription, no credit card required.** The container runs entirely on the developer machine or in CI. No service principal, no credit card, no shared instance. Free for local development and CI.
-3. **Works with the drivers, ORMs, and editors you already use.** Everything that talks to Azure SQL Database talks to the container without changes: node-mssql, mssql-python, pyodbc, and mssql-jdbc; Prisma, SQLAlchemy, EF Core, Django, and TypeORM; sqlcmd, the MSSQL extension for VS Code, and SSMS.
+3. **Works with the drivers, ORMs, and editors you already use.** Everything that talks to Azure SQL Database talks to the container without changes: node-mssql, mssql-python, pyodbc, and mssql-jdbc; Prisma, SQLAlchemy, EF Core, Django, and TypeORM; sqlcmd, and VS Code with the MSSQL extension's GitHub Copilot integration. (Graphical tooling like the full MSSQL extension UI and SSMS is not yet 100% compatible; see [known limitations](known-limitations.md).)
 
 ## Engine surface
 

--- a/skills/azuresql-db-container/references/connect-and-query.md
+++ b/skills/azuresql-db-container/references/connect-and-query.md
@@ -70,7 +70,11 @@ exception. For the .NET-style (`User Id=`/`Password=`) and the
 
 ## VS Code MSSQL
 
-In the MSSQL extension, add a connection with:
+The MSSQL extension's GitHub Copilot integration works against the container
+today (for example writing SQL from natural language or opening the schema
+designer): https://aka.ms/vscode-mssql-copilot-docs. The extension's graphical
+UI is not yet fully compatible with the container and some UI features may
+error; prefer sqlcmd or a driver for non-Copilot work. Add a connection with:
 
 - Server: `localhost,1433`
 - Database: `appdb`


### PR DESCRIPTION
Adds the [GitHub Copilot + MSSQL docs](https://aka.ms/vscode-mssql-copilot-docs) link wherever the working Copilot integration is mentioned, and brings the rest of the repo in sync with the new GUI-tooling limitation.

- **Link added:** getting-started, known-limitations, and the container skill's connect-and-query reference.
- **Sync:** `what-is-the-container` listed the full MSSQL extension UI and SSMS as working "without changes" — now scoped to the Copilot integration with a pointer to known limitations. The skill's *VS Code MSSQL* section now carries the same caveat (UI not yet fully compatible; Copilot integration works) instead of unconditionally walking the UI.

Jekyll build clean, no em-dashes.