### PR TITLE
Present the agent skills as a card grid, not a table

### DIFF
--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -413,12 +413,17 @@ section[id] { scroll-margin-top: 84px; }
 .install-foot a:hover { text-decoration: none; opacity: .85; }
 
 /* ---------- "what the skills do" table in #ai-agents ---------- */
-.skill-table-lead { color: var(--muted); font-size: 1.05rem; max-width: 760px; margin: 36px 0 14px; }
-.skill-table { width: 100%; border-collapse: collapse; margin: 0 0 8px; font-size: .95rem; }
-.skill-table th, .skill-table td { text-align: left; padding: 11px 14px; border-bottom: 1px solid var(--line); vertical-align: top; }
-.skill-table thead th { font-family: var(--font-display); font-size: .8rem; letter-spacing: .04em; text-transform: uppercase; color: var(--muted); }
-.skill-table tbody td:first-child { font-weight: 600; color: var(--ink); white-space: nowrap; }
-.skill-table code { font-size: .85em; }
+.skill-cards-title { font-size: 1.35rem; margin: 40px 0 8px; }
+.skill-lead { color: var(--muted); font-size: 1.05rem; max-width: 760px; margin: 0 0 22px; }
+.skill-cards { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; margin: 0 0 8px; }
+.skill-card { display: block; background: var(--white); border: 1px solid var(--line); border-radius: var(--radius); padding: 22px; box-shadow: var(--shadow); color: inherit; transition: transform .18s ease, box-shadow .18s ease, border-color .18s ease; }
+.skill-card:hover { transform: translateY(-3px); box-shadow: var(--shadow-lg); border-color: #c6d6ee; text-decoration: none; }
+.skill-card h4 { font-size: 1rem; margin-bottom: 8px; display: flex; align-items: baseline; justify-content: space-between; gap: 10px; transition: color .15s ease; }
+.skill-card:hover h4 { color: var(--azure); }
+.skill-card h4 .arrow { color: var(--muted); font-weight: 400; transition: transform .18s ease, color .15s ease; }
+.skill-card:hover h4 .arrow { color: var(--azure); transform: translateX(3px); }
+.skill-card p { color: var(--muted); font-size: .86rem; line-height: 1.5; }
+.skill-card code { font-size: .82em; }
 
 /* ---------- quickstart: numbered steps with full-width command bars ---------- */
 .qsteps { display: flex; flex-direction: column; gap: 18px; max-width: 940px; }
@@ -461,6 +466,7 @@ section[id] { scroll-margin-top: 84px; }
   .grid-3 { grid-template-columns: repeat(2, 1fr); }
   .grid-4 { grid-template-columns: repeat(2, 1fr); }
   .agents { grid-template-columns: repeat(2, 1fr); }
+  .skill-cards { grid-template-columns: repeat(2, 1fr); }
   .codeflow { grid-template-columns: 1fr; }
   .footer-grid { grid-template-columns: 1fr 1fr; }
 
@@ -487,6 +493,7 @@ section[id] { scroll-margin-top: 84px; }
   .stat:first-child { padding-top: 0; }
   .stat + .stat { border-left: 0; border-top: 1px solid var(--line-dark); }
   .grid-3, .grid-4 { grid-template-columns: 1fr; }
+  .skill-cards { grid-template-columns: 1fr; }
   .split-cols { grid-template-columns: 1fr; }
   .skill-cmd { flex-wrap: wrap; }
   .skill-cmd code { white-space: pre-wrap; word-break: break-all; }

--- a/docs/index.html
+++ b/docs/index.html
@@ -144,29 +144,54 @@ title: Azure SQL Database container
     </div>
 
     <div class="skill">
-      <p class="skill-line">Install the skill once. It works across Claude Code, GitHub Copilot, Codex, and Cursor, then you just ask your agent in plain English.</p>
+      <p class="skill-line">Install the agent skills once. They work across Claude Code, GitHub Copilot, Codex, and Cursor, then you just ask your agent in plain English.</p>
       <div class="skill-cmd">
         <code><span class="cmd-p">$</span> npx skills add microsoft/azure-sql-database-container</code>
         <button class="copy-btn" type="button" data-copy-text="npx skills add microsoft/azure-sql-database-container"><span class="copy-label">Copy</span></button>
       </div>
-      <a class="skill-link" href="{{ site.repo }}/tree/main/skills" rel="noopener">Browse the skill on GitHub &rarr;</a>
+      <a class="skill-link" href="{{ site.repo }}/tree/main/skills" rel="noopener">Browse the agent skills on GitHub &rarr;</a>
     </div>
 
-    <p class="skill-table-lead">A collection of skills your agent loads on demand. Each one teaches it to use the engine the right way, so it does not reach for the SQL Server box image or invent behavior the engine does not have:</p>
-    <table class="skill-table">
-      <thead><tr><th>Skill</th><th>What it does for your agent</th></tr></thead>
-      <tbody>
-        <tr><td>Start the engine</td><td>Free host port, <code>--platform linux/amd64</code> on non-x64 hosts, a ready-wait loop, and <code>CREATE DATABASE appdb</code> (the engine does not auto-create databases).</td></tr>
-        <tr><td>Convert from SQL Server</td><td>Move a project off the <code>mcr.microsoft.com/mssql/server</code> box image to the real Azure SQL Database engine.</td></tr>
-        <tr><td>Local to cloud</td><td>Ship the same code to Azure SQL Database in the cloud; only the connection string changes.</td></tr>
-        <tr><td>Schema migrations</td><td>Apply EF Core, Prisma, Alembic, or SqlPackage migrations against the user database.</td></tr>
-        <tr><td>Import a database</td><td>Load an existing <code>.bacpac</code> / <code>.dacpac</code> into the container with SqlPackage.</td></tr>
-        <tr><td>RAG and vector search</td><td>Native <code>VECTOR</code> type and <code>VECTOR_DISTANCE</code>, with a local embedding model.</td></tr>
-        <tr><td>CI</td><td>Run the engine as a service in GitHub Actions, with the right readiness and provisioning.</td></tr>
-        <tr><td>Sidecar</td><td>Add it to a docker compose stack or Dev Container, wired by service name.</td></tr>
-        <tr><td>Scaffold</td><td>Bootstrap a new app with the container as the default local database.</td></tr>
-      </tbody>
-    </table>
+    <h3 class="skill-cards-title">Agent skills</h3>
+    <p class="skill-lead">A collection of skills your agent loads on demand. Each one teaches it to use the engine the right way, so it does not reach for the SQL Server box image or invent behavior the engine does not have.</p>
+    <div class="skill-cards">
+      <a class="skill-card" href="{{ site.repo }}/tree/main/skills/azuresql-db-container" rel="noopener">
+        <h4>Start the engine <span class="arrow">&rarr;</span></h4>
+        <p>Free host port, <code>--platform linux/amd64</code> on non-x64 hosts, a ready-wait loop, and <code>CREATE DATABASE appdb</code> (the engine does not auto-create databases).</p>
+      </a>
+      <a class="skill-card" href="{{ site.repo }}/tree/main/skills/azuresql-db-from-sql-server" rel="noopener">
+        <h4>Convert from SQL Server <span class="arrow">&rarr;</span></h4>
+        <p>Move a project off the <code>mcr.microsoft.com/mssql/server</code> box image to the real Azure SQL Database engine.</p>
+      </a>
+      <a class="skill-card" href="{{ site.repo }}/tree/main/skills/azuresql-db-local-to-cloud" rel="noopener">
+        <h4>Local to cloud <span class="arrow">&rarr;</span></h4>
+        <p>Ship the same code to Azure SQL Database in the cloud; only the connection string changes.</p>
+      </a>
+      <a class="skill-card" href="{{ site.repo }}/tree/main/skills/azuresql-db-schema-migration" rel="noopener">
+        <h4>Schema migrations <span class="arrow">&rarr;</span></h4>
+        <p>Apply EF Core, Prisma, Alembic, or SqlPackage migrations against the user database.</p>
+      </a>
+      <a class="skill-card" href="{{ site.repo }}/tree/main/skills/azuresql-db-import" rel="noopener">
+        <h4>Import a database <span class="arrow">&rarr;</span></h4>
+        <p>Load an existing <code>.bacpac</code> / <code>.dacpac</code> into the container with SqlPackage.</p>
+      </a>
+      <a class="skill-card" href="{{ site.repo }}/tree/main/skills/azuresql-db-rag" rel="noopener">
+        <h4>RAG and vector search <span class="arrow">&rarr;</span></h4>
+        <p>Native <code>VECTOR</code> type and <code>VECTOR_DISTANCE</code>, with a local embedding model.</p>
+      </a>
+      <a class="skill-card" href="{{ site.repo }}/tree/main/skills/azuresql-db-ci" rel="noopener">
+        <h4>CI <span class="arrow">&rarr;</span></h4>
+        <p>Run the engine as a service in GitHub Actions, with the right readiness and provisioning.</p>
+      </a>
+      <a class="skill-card" href="{{ site.repo }}/tree/main/skills/azuresql-db-sidecar" rel="noopener">
+        <h4>Sidecar <span class="arrow">&rarr;</span></h4>
+        <p>Add it to a docker compose stack or Dev Container, wired by service name.</p>
+      </a>
+      <a class="skill-card" href="{{ site.repo }}/tree/main/skills/azuresql-db-scaffold" rel="noopener">
+        <h4>Scaffold <span class="arrow">&rarr;</span></h4>
+        <p>Bootstrap a new app with the container as the default local database.</p>
+      </a>
+    </div>
   </div>
 </section>
 


### PR DESCRIPTION
The `#ai-agents` section listed the skills in a flat two-column table that read as old-school.

- **Card grid:** replaced the table with a responsive three-column grid of cards, reusing the existing agent-card style (hover lift, same border/shadow tokens) so it is visually consistent with the agent grid above. Each card links to that skill on GitHub and shows the friendly title plus a one-line description. Responsive: 3 columns, 2 at <=960px, 1 at <=620px.
- **"Agent skills":** labeled the section *Agent skills* and used that term in the install copy and the GitHub link, matching how Neon and Supabase name the same concept.

Jekyll build is clean; all 9 cards render and the SCSS compiles.