### PR TITLE
Fix validation bugs in build prompts and skills

### DIFF
--- a/docs/prompts/ai-rag.md
+++ b/docs/prompts/ai-rag.md
@@ -19,7 +19,9 @@ Read the entire instruction set before executing.
 ```bash
 # The image is in a private preview registry; sign in with the credentials requested via the early-access feedback channel (pull-only; may be rotated during the preview) first
 docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io
-docker run --name sqldb -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd" \
+# The image is x64-only; on a non-x64 host (Apple Silicon) this adds --platform linux/amd64 to run it under emulation.
+PLATFORM=(); case "$(docker info -f '{{.Architecture}}' 2>/dev/null)" in x86_64|amd64) ;; *) PLATFORM=(--platform linux/amd64);; esac
+docker run --name sqldb "${PLATFORM[@]}" -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd" \
     -p 1433:1433 -d sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
 ```
 
@@ -89,8 +91,10 @@ chunks = [
 ]
 for c in chunks:
     cur.execute(
-        # VECTOR's dimension must be a literal, not a bind parameter, so inline DIM
-        f"INSERT INTO documents (content, embedding) VALUES (?, CAST(? AS VECTOR({DIM})));",
+        # VECTOR's dimension must be a literal (inline DIM), not a bind parameter. The bound JSON
+        # string must be cast to NVARCHAR(MAX) first: a long embedding is otherwise sent as ntext
+        # and fails with "Explicit conversion from data type ntext to vector is not allowed" (529).
+        f"INSERT INTO documents (content, embedding) VALUES (?, CAST(CAST(? AS NVARCHAR(MAX)) AS VECTOR({DIM})));",
         c, embed(c),
     )
 conn.commit()
@@ -100,7 +104,7 @@ query = "How do I run vector search locally?"
 cur.execute(
     f"""
     SELECT TOP 3 content,
-        VECTOR_DISTANCE('cosine', embedding, CAST(? AS VECTOR({DIM}))) AS distance
+        VECTOR_DISTANCE('cosine', embedding, CAST(CAST(? AS NVARCHAR(MAX)) AS VECTOR({DIM}))) AS distance
     FROM documents
     ORDER BY distance;
     """,
@@ -124,7 +128,7 @@ python rag.py
 
 ## Validation rules
 
-- The `embedding` column is a native `VECTOR(768)`; vectors are inserted as JSON arrays cast with `CAST(? AS VECTOR(768))`.
+- The `embedding` column is a native `VECTOR(768)`; vectors are inserted as JSON arrays with `CAST(CAST(? AS NVARCHAR(MAX)) AS VECTOR(768))` (the inner `NVARCHAR(MAX)` keeps a long embedding from being sent as ntext, which fails with error 529).
 - Retrieval uses `VECTOR_DISTANCE('cosine', ...)` and orders ascending (smaller distance = closer match).
 - The embedding dimension is consistent between insert and query.
 - The connection string is read from the environment; queries are parameterized with `?`.

--- a/docs/prompts/ci.md
+++ b/docs/prompts/ci.md
@@ -29,6 +29,12 @@ jobs:
     services:
       sqldb:
         image: sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
+        # The image is in a private registry, so the service needs pull credentials.
+        # ACR_USERNAME / ACR_PASSWORD are the pull-only registry credentials provided to
+        # Private Preview cohort participants via the early-access feedback channel.
+        credentials:
+          username: ${{ secrets.ACR_USERNAME }}
+          password: ${{ secrets.ACR_PASSWORD }}
         env:
           ACCEPT_EULA: "Y"
           MSSQL_SA_PASSWORD: ${{ secrets.SQL_SA_PASSWORD }}
@@ -52,7 +58,7 @@ jobs:
       - name: Create the application database
         run: |
           docker exec "${{ job.services.sqldb.id }}" /opt/mssql-tools18/bin/sqlcmd \
-            -S localhost -U sa -P "${{ secrets.SQL_SA_PASSWORD }}" -C \
+            -S localhost -U sa -P "${{ secrets.SQL_SA_PASSWORD }}" -C -b -l 2 \
             -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;"
 
       # Replace with your stack's setup and test commands:
@@ -62,13 +68,16 @@ jobs:
       - run: npm test    # tests read SQL_CONNECTION_STRING from the environment
 ```
 
-### 2. Add the SA password as a repository secret
+### 2. Add the repository secrets
 
-Add a strong password as the `SQL_SA_PASSWORD` secret under repository Settings → Secrets and variables → Actions. Do not commit it.
+Under repository Settings → Secrets and variables → Actions, add:
+
+- `SQL_SA_PASSWORD`: a strong SA password that meets the complexity policy. Do not commit it.
+- `ACR_USERNAME` and `ACR_PASSWORD`: the pull-only registry credentials provided to Private Preview cohort participants via the early-access feedback channel. The service container uses them to pull the private image.
 
 ### 3. Make the test suite use the environment connection string
 
-Ensure tests read `process.env.SQL_CONNECTION_STRING` (Node) or the equivalent, and create/drop their own schema or a throwaway database so runs are isolated.
+Ensure tests read `process.env.SQL_CONNECTION_STRING` (Node) or the equivalent, and isolate each run with its own schema or a unique table prefix on the `appdb` connection. If you want a throwaway *database* instead, create and drop it on a separate `master` connection: `CREATE DATABASE` / `DROP DATABASE` are not allowed on a user-database (SDS) connection like `appdb`.
 
 ---
 

--- a/docs/prompts/from-sql-server.md
+++ b/docs/prompts/from-sql-server.md
@@ -45,8 +45,12 @@ docker run -d --name sqldb "${PLATFORM[@]}" -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASS
 The Azure SQL Database engine does **not** auto-create databases, and the connection model differs from the box product. Provision the application database on a `master` connection, then point the app at that database:
 
 ```bash
-docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b \
-    -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;"
+# The engine is not ready the instant docker run returns; retry until it accepts connections.
+# -b makes a SQL error set the exit code so a transient startup error (Msg 913) is retried, not masked.
+until docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b -l 2 \
+    -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;" >/dev/null 2>&1; do
+  sleep 2
+done
 ```
 
 Re-point connection strings from `Database=master` to `Database=appdb`. Do not switch databases with `USE`: in a user-database (SDS) session `USE` returns `Msg 40508`, exactly as in Azure SQL Database in the cloud (a `master` connection is a non-SDS provisioning session where it appears to work, but `master` is for provisioning only). Select the database in the connection string.

--- a/docs/prompts/local-to-cloud.md
+++ b/docs/prompts/local-to-cloud.md
@@ -23,7 +23,9 @@ Run the container locally on port 1433 with a strong SA password. Set `ACCEPT_EU
 ```bash
 # The image is in a private preview registry; sign in with the credentials requested via the early-access feedback channel (pull-only; may be rotated during the preview) first
 docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io
-docker run --name sqldb -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd" \
+# The image is x64-only; on a non-x64 host (Apple Silicon) this adds --platform linux/amd64 to run it under emulation.
+PLATFORM=(); case "$(docker info -f '{{.Architecture}}' 2>/dev/null)" in x86_64|amd64) ;; *) PLATFORM=(--platform linux/amd64);; esac
+docker run --name sqldb "${PLATFORM[@]}" -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd" \
     -p 1433:1433 -d sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
 ```
 

--- a/docs/prompts/offline.md
+++ b/docs/prompts/offline.md
@@ -20,6 +20,9 @@ Create `docker-compose.yml`. The Azure SQL Database engine does not auto-run mou
 services:
   sqldb:
     image: sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
+    # The image is x64-only. platform: linux/amd64 pins it so it runs on a non-x64 host
+    # (Apple Silicon) under emulation; on an x64 host it is a no-op.
+    platform: linux/amd64
     container_name: sqldb
     environment:
       MSSQL_SA_PASSWORD: "YourStr0ng_Passw0rd"

--- a/docs/prompts/sidecar.md
+++ b/docs/prompts/sidecar.md
@@ -31,6 +31,8 @@ services:
 
   sqldb:
     image: sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
+    # x64-only image; platform: linux/amd64 lets it run on a non-x64 host (Apple Silicon), no-op on x64.
+    platform: linux/amd64
     environment:
       MSSQL_SA_PASSWORD: "YourStr0ng_Passw0rd"
       ACCEPT_EULA: "Y"
@@ -50,12 +52,15 @@ services:
   # target database (appdb) must be provisioned before the app starts.
   sqldb-init:
     image: sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
+    platform: linux/amd64
     depends_on:
       sqldb:
         condition: service_healthy
     restart: "no"
+    # -b makes a SQL error set a non-zero exit, so a failed CREATE DATABASE fails the one-shot
+    # instead of reporting service_completed_successfully without provisioning appdb.
     entrypoint: ["/opt/mssql-tools18/bin/sqlcmd", "-S", "sqldb,1433", "-U", "sa",
-      "-P", "YourStr0ng_Passw0rd", "-C", "-Q", "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;"]
+      "-P", "YourStr0ng_Passw0rd", "-C", "-b", "-l", "2", "-Q", "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;"]
 
 volumes:
   sqldb-data:

--- a/docs/prompts/templates.md
+++ b/docs/prompts/templates.md
@@ -28,6 +28,8 @@ Add a `docker-compose.yml` with the container so the database starts with one co
 services:
   sqldb:
     image: sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
+    # x64-only image; platform: linux/amd64 lets it run on a non-x64 host (Apple Silicon), no-op on x64.
+    platform: linux/amd64
     environment:
       MSSQL_SA_PASSWORD: "YourStr0ng_Passw0rd"
       ACCEPT_EULA: "Y"
@@ -51,7 +53,15 @@ Some ORMs read their own variable in their own format, not the ADO string above.
 DATABASE_URL="sqlserver://localhost:1433;database=appdb;user=sa;password=YourStr0ng_Passw0rd;trustServerCertificate=true"
 ```
 
-On Prisma 7+, the runtime client also needs a driver adapter: `npm i @prisma/adapter-mssql` and construct `PrismaClient` with the matching `PrismaMSSQL` adapter. `prisma migrate dev` creates the `appdb` database if it does not exist; for stacks whose migration tool does not (for example EF Core), first create it with `docker compose exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;"`.
+On Prisma 7+, the runtime client also needs a driver adapter: `npm i @prisma/adapter-mssql` and construct `PrismaClient` with the matching `PrismaMSSQL` adapter. `prisma migrate dev` creates the `appdb` database if it does not exist. Most other stacks (EF Core, FastAPI with SQLAlchemy/Alembic, raw `mssql-python`) do **not** create the database, so provision it first: the engine does not auto-create databases. `appdb` is an example name; use your own if you prefer. Wait for the engine, then create it with the ready-wait loop (`-b` makes a SQL error set the exit code so a transient startup error is retried, not masked):
+
+```bash
+until docker compose exec -T sqldb /opt/mssql-tools18/bin/sqlcmd \
+    -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b -l 2 \
+    -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;" >/dev/null 2>&1; do
+  sleep 2
+done
+```
 
 ### 3. Scaffold schema, migration, and data-access layer
 
@@ -63,11 +73,12 @@ For the chosen stack:
 
 ### 4. Verify
 
-Bring up the database, run the migration, run the app, and confirm a create/list round-trip works.
+Bring up the database, ensure `appdb` exists (the ready-wait loop in step 2, unless your migration tool creates the database itself like `prisma migrate dev`), run the migration, run the app, and confirm a create/list round-trip works.
 
 ```bash
 docker compose up -d
-# run the stack's migration command, then start the app
+# provision appdb with the ready-wait loop from step 2 (skip if the migration tool creates it),
+# then run the stack's migration command and start the app
 ```
 
 ---

--- a/skills/azuresql-db-container/SKILL.md
+++ b/skills/azuresql-db-container/SKILL.md
@@ -71,8 +71,8 @@ echo "ready on localhost,$HOST_PORT"
 ### 3. Required environment variables
 
 - `ACCEPT_EULA=Y` (required).
-- `MSSQL_SA_PASSWORD` (required, complex: 8+ chars with upper, lower, digit, and
-  symbol). The engine listens on container port `1433`.
+- `MSSQL_SA_PASSWORD` (required, complex: at least 8 characters using at least
+  three of upper case, lower case, digits, and symbols). The engine listens on container port `1433`.
 - App convention: apps read one `SQL_CONNECTION_STRING` env var.
 
 Details: `references/environment-variables.md`.

--- a/skills/azuresql-db-local-to-cloud/SKILL.md
+++ b/skills/azuresql-db-local-to-cloud/SKILL.md
@@ -121,10 +121,10 @@ until docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "You
 echo "ready on localhost,$HOST_PORT"
 ```
 
-Then point the app at it (assuming the loop above settled on 1433):
+Then point the app at it, using the `HOST_PORT` the loop settled on:
 
 ```bash
-export SQL_CONNECTION_STRING="Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true"
+export SQL_CONNECTION_STRING="Server=localhost,$HOST_PORT;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true"
 ```
 
 To run against the cloud later, change only this variable; do not touch the app.
@@ -139,7 +139,7 @@ then again with the cloud string: identical code, identical result.
 ### Node (mssql)
 
 ```js
-// app.js  ->  node app.js
+// app.mjs  ->  node app.mjs  (ESM: use the .mjs extension, or set "type":"module" in package.json)
 import sql from 'mssql';
 
 const pool = await sql.connect(process.env.SQL_CONNECTION_STRING);

--- a/skills/azuresql-db-scaffold/SKILL.md
+++ b/skills/azuresql-db-scaffold/SKILL.md
@@ -60,12 +60,12 @@ until docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "You
 echo "ready on localhost,$HOST_PORT"
 ```
 
-Required env: `ACCEPT_EULA=Y` and a complex `MSSQL_SA_PASSWORD` (8+ chars, upper/lower/digit/
-symbol). The engine listens on 1433.
+Required env: `ACCEPT_EULA=Y` and a complex `MSSQL_SA_PASSWORD` (at least 8 characters using at
+least three of upper case, lower case, digits, and symbols). The engine listens on 1433.
 
 ## Step 2: the canonical connection string
 
-Apps read **one** env var, `SQL_CONNECTION_STRING`:
+Apps read **one** env var, `SQL_CONNECTION_STRING` (replace `1433` with the `HOST_PORT` Step 1 chose if 1433 was occupied):
 
 ```
 Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true

--- a/skills/azuresql-db-scaffold/references/scaffold-snippets.md
+++ b/skills/azuresql-db-scaffold/references/scaffold-snippets.md
@@ -192,11 +192,12 @@ const widgets = await prisma.widget.findMany({ where: { name } });
 
 ## NestJS (Prisma or TypeORM)
 
-`.env` (same two vars as Next.js):
+`.env` (the same vars as Next.js; the TypeORM DataSource below also reads `MSSQL_SA_PASSWORD`):
 
 ```
 SQL_CONNECTION_STRING=Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true
 DATABASE_URL=sqlserver://localhost:1433;database=appdb;user=sa;password=YourStr0ng_Passw0rd;trustServerCertificate=true;encrypt=true
+MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd
 ```
 
 Provision appdb on master before bootstrapping:
@@ -230,8 +231,10 @@ export const AppDataSource = new DataSource({
 First migration:
 
 ```bash
-npm run typeorm migration:generate -- -n Init
-npm run typeorm migration:run
+# TypeORM 0.3+: the name is a positional path and the data source is passed with -d
+# (the legacy -n flag was removed). Adjust paths to your project layout.
+npm run typeorm -- migration:generate ./src/migrations/Init -d ./src/AppDataSource.ts
+npm run typeorm -- migration:run -d ./src/AppDataSource.ts
 ```
 
 Typed, parameterized data access (TypeORM binds parameters):


### PR DESCRIPTION
A re-validation pass over all 9 skills and 7 build prompts: **16 parallel static reviewers** (one per artifact) plus a **live container battery** on this arm64 host. The build prompts (never validated before) carried the real bugs; the skills were nearly clean.

## Live validation (against a real container, new password)
All PASS: container provision + ready-wait (auth via new password), host TCP auth, pyodbc connect, **URL-form password round-trips intact**, `EngineEdition=5`/`Edition='SQL Azure'`, `USE`→Msg 40508 on the SDS session (works on master), VECTOR literal + parameterized distance, and the unwrapped `CAST(? AS VECTOR)` is **live-rejected with ntext error 529** (confirming the ai-rag blocker). The new password is validated end-to-end.

## Blockers fixed
- **ai-rag.md**: parameterized VECTOR casts (insert + query) were missing the inner `NVARCHAR(MAX)` → ntext error 529 (live-confirmed). Now `CAST(CAST(? AS NVARCHAR(MAX)) AS VECTOR(DIM))`.
- **ci.md**: the GitHub Actions service container had no `credentials:` block for the private ACR, so the job dies before any step. Added `ACR_USERNAME`/`ACR_PASSWORD` (documented as the cohort registry creds).

## Majors fixed
- Missing x64 platform handling in ai-rag, local-to-cloud (array form) and offline, sidecar, templates (compose `platform: linux/amd64`).
- Missing ready-wait loop on appdb provisioning in from-sql-server and templates.

## Minors fixed
SA password-policy wording (≥3 of 4 classes, not all 4); local-to-cloud hardcoded port → `HOST_PORT` and Node `app.js`→`app.mjs`; scaffold hardcoded port note, NestJS TypeORM undefined env var + legacy `-n` flag; ci `-b` + throwaway-DB-on-master guidance; sidecar init `-b`.

Note: the sidecar **compose** live run was inconclusive (the engine crashed under arm64 emulation + container-churn pressure on this 2-container host, not a pattern defect); the engine and provisioning are confirmed live in the engine battery.