### PR TITLE
Align docs/HTML/llms content after a cross-file audit

### DIFF
--- a/docs/feedback-and-how-to-engage.md
+++ b/docs/feedback-and-how-to-engage.md
@@ -23,8 +23,8 @@ description: "Pick the right channel for your question: GitHub Issues, Discussio
 | Suggest a direction or pitch an idea                       | [GitHub Discussions: Ideas](https://github.com/microsoft/azure-sql-database-container/discussions/categories/ideas) |
 | Email the team directly                                    | [azuresqldb-container@microsoft.com](mailto:azuresqldb-container@microsoft.com) |
 | Book live time with the team                               | [Connect with the team](https://aka.ms/azuresql-container-meet) |
-| Talk to the team in real time                              | Private Teams channel (link in the welcome email) |
-| Demo, ask questions live, hear roadmap updates             | Office hours (calendar invite in the welcome email) |
+| Talk to the team in real time                              | Private Teams channel (link shared via the early-access feedback channel) |
+| Demo, ask questions live, hear roadmap updates             | Office hours (calendar invite shared via the early-access feedback channel) |
 
 ## GitHub Issues
 

--- a/docs/goals-of-the-private-preview.md
+++ b/docs/goals-of-the-private-preview.md
@@ -31,7 +31,7 @@ This Private Preview is the first time the container is in the hands of real dev
 - **Try the ready-made prompts.** Point your AI agent at the container with the [agent skill](https://github.com/microsoft/azure-sql-database-container/tree/main/skills) and a prompt from [docs/prompts](https://github.com/microsoft/azure-sql-database-container/tree/main/docs/prompts), and tell us where the seams are.
 - **Build something real, however small.** A demo, a learning project, a feature in an existing application. The closer to your actual workflow, the better the feedback.
 - **File issues for everything that surprises you.** Performance, behavior, ergonomics, documentation. Use [GitHub Issues](https://github.com/microsoft/azure-sql-database-container/issues) for bugs and feature requests.
-- **Show up to office hours.** A weekly slot for live questions, demos, and feedback. See the welcome email for the calendar invite.
+- **Show up to office hours.** A weekly slot for live questions, demos, and feedback. The calendar invite is shared via the early-access feedback channel.
 
 ## What you get from us
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -15,6 +15,7 @@ Copy-and-run prompts to hand your AI coding agent, each building a scenario agai
 - [Build locally, ship to Azure (Node.js)](https://github.com/microsoft/azure-sql-database-container/blob/main/docs/prompts/local-to-cloud.md)
 - [Prototype AI / RAG with vector search (Python + Ollama)](https://github.com/microsoft/azure-sql-database-container/blob/main/docs/prompts/ai-rag.md)
 - [Run integration tests in CI](https://github.com/microsoft/azure-sql-database-container/blob/main/docs/prompts/ci.md)
+- [Convert from the SQL Server box image](https://github.com/microsoft/azure-sql-database-container/blob/main/docs/prompts/from-sql-server.md)
 - [Develop offline](https://github.com/microsoft/azure-sql-database-container/blob/main/docs/prompts/offline.md)
 - [Drop in as a sidecar](https://github.com/microsoft/azure-sql-database-container/blob/main/docs/prompts/sidecar.md)
 - [Scaffold a new project](https://github.com/microsoft/azure-sql-database-container/blob/main/docs/prompts/templates.md)

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -55,7 +55,7 @@ If your container runtime's VM is set lower than this, the container may fail to
 If you are driving the container with an AI coding agent (Claude Code, Codex, GitHub Copilot, or Cursor) or from the CLI, install the container skill first. For that workflow it is a hard requirement, more important than any individual tool below: the skill teaches your agent the registry sign-in, image name, ports, connection string, and the local-to-cloud handoff, so a single plain-English prompt is enough.
 
 ```bash
-npx skills add azuresql-db-container
+npx skills add microsoft/azure-sql-database-container
 ```
 
 It works across Claude Code, GitHub Copilot, Codex, and Cursor. Browse the skill and ready-made prompts in [agent skills](https://github.com/microsoft/azure-sql-database-container/tree/main/skills). Without it, the agent will not know how to sign in to the registry, which image to run, or how to connect.

--- a/docs/prompts/ci.md
+++ b/docs/prompts/ci.md
@@ -43,7 +43,7 @@ jobs:
         # The runner has no sqlcmd; let the service report readiness with a health check
         # that runs sqlcmd INSIDE the container. Actions blocks the job's steps until it passes.
         options: >-
-          --health-cmd="/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P \"$MSSQL_SA_PASSWORD\" -C -l 2 -Q 'SELECT 1'"
+          --health-cmd="/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P \"$MSSQL_SA_PASSWORD\" -C -b -l 2 -Q 'SELECT 1'"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=12

--- a/docs/prompts/sidecar.md
+++ b/docs/prompts/sidecar.md
@@ -41,7 +41,7 @@ services:
     volumes:
       - sqldb-data:/var/opt/mssql
     healthcheck:
-      test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -S localhost,1433 -U sa -P \"$$MSSQL_SA_PASSWORD\" -C -Q 'SELECT 1' || exit 1"]
+      test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -S localhost,1433 -U sa -P \"$$MSSQL_SA_PASSWORD\" -C -b -l 2 -Q 'SELECT 1' || exit 1"]
       interval: 10s
       timeout: 10s
       retries: 12

--- a/docs/what-is-the-container.md
+++ b/docs/what-is-the-container.md
@@ -41,7 +41,7 @@ The container exposes the same engine surface as Azure SQL Database:
 The container supports the same AI-native capabilities as Azure SQL Database:
 
 - **Native vector type.** Store embeddings in a native `vector` column, with the same type and storage as the cloud.
-- **DiskANN vector indexes.** Build approximate-nearest-neighbor indexes with `CREATE VECTOR INDEX` for fast similarity search at scale.
+- **DiskANN vector indexes (in development).** `CREATE VECTOR INDEX` for approximate-nearest-neighbor search at scale is in active development; run full-scan `VECTOR_DISTANCE` queries today. See [Known limitations](known-limitations.md).
 - **Vector search.** Run similarity search with `VECTOR_DISTANCE` (cosine, euclidean, and dot product).
 - **In-database embeddings and models.** Generate embeddings with `AI_GENERATE_EMBEDDINGS` and bind an embedding endpoint with `CREATE EXTERNAL MODEL`. Use a local model (Ollama) while you build, then switch to Azure OpenAI in the cloud.
 - **REST from T-SQL.** Call external services with `sp_invoke_external_rest_endpoint`.
@@ -100,7 +100,7 @@ This is the first time the container is in the hands of developers building real
 - **Try the ready-made prompts.** Point your AI agent at the container with the [agent skill](https://github.com/microsoft/azure-sql-database-container/tree/main/skills) and a prompt from [docs/prompts](https://github.com/microsoft/azure-sql-database-container/tree/main/docs/prompts), and tell us where the seams are.
 - **Build something real, however small.** A demo, a learning project, or a feature in an existing application. The closer to your actual workflow, the better the feedback.
 - **File issues for everything that surprises you.** Performance, behavior, ergonomics, documentation. Use [GitHub Issues](https://github.com/microsoft/azure-sql-database-container/issues) for bugs and feature requests.
-- **Show up to office hours.** A weekly slot for live questions, demos, and feedback. See the welcome email for the calendar invite.
+- **Show up to office hours.** A weekly slot for live questions, demos, and feedback. The calendar invite is shared via the early-access feedback channel.
 
 ### What you get from us
 

--- a/skills/azuresql-db-container/SKILL.md
+++ b/skills/azuresql-db-container/SKILL.md
@@ -151,8 +151,8 @@ docker volume rm sqldb-data   # only if you created a named volume and want a cl
   See `references/paas-parity-checklist.md`.
 - It does **not** auto-create databases and does **not** auto-run a seed
   directory.
-- arm64/Apple Silicon is not a supported architecture; on a non-x64 host run
-  under emulation by adding `--platform linux/amd64`.
+- The image is x64 only (`linux/amd64`). On a non-x64 host, add
+  `--platform linux/amd64` to run under emulation.
 
 ## Hand off to a task skill
 


### PR DESCRIPTION
Deep alignment audit (a deterministic invariant sweep plus three parallel reviewers over the docs pages, the build prompts, and the skills) against the canonical facts. Findings, all fixed:

- **Stale "welcome email"** in the office-hours / Teams-channel lines of `what-is-the-container.md`, `goals-of-the-private-preview.md`, and `feedback-and-how-to-engage.md` -> early-access feedback channel.
- **`prerequisites.md`** install command -> `npx skills add microsoft/azure-sql-database-container` (matches landing page + getting-started).
- **`what-is-the-container.md`** listed `CREATE VECTOR INDEX` as a working capability -> caveated as in-development, consistent with `known-limitations.md`.
- **`ci.md` / `sidecar.md`** service healthchecks were missing `-b` (and `-l 2`) -> added, matching the canonical ready-wait flags.
- **`llms.txt`** listed 6 of 7 build prompts -> added `from-sql-server`.
- **container `SKILL.md`** arm64 note -> canonical "x64 only" phrasing.

Confirmed: the FAQ skill card is on the landing page (#ai-agents). Sweep clean on old password, em-dashes, "backups work" claims, unwrapped VECTOR casts; 10/10 skill frontmatter valid; Jekyll build clean.