### PR TITLE
Polish the loop diagram copy and note styling

### DIFF
--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -271,8 +271,8 @@ section[id] { scroll-margin-top: 84px; }
 .loop-arrow::before { content: ""; flex: 1; width: 2px; background: linear-gradient(var(--vector), var(--azure)); border-radius: 2px; }
 .loop-arrow::after { content: ""; flex: 1; width: 2px; background: linear-gradient(var(--vector), var(--azure)); border-radius: 2px; }
 .loop-arrow-label { font-family: var(--font-mono); font-size: .72rem; color: var(--muted); text-align: center; line-height: 1.5; }
-.loop-note { max-width: 820px; font-size: .98rem; color: var(--text); background: var(--tint); border: 1px solid var(--line); border-left: 3px solid var(--azure); border-radius: var(--radius-sm); padding: 14px 18px; }
-.loop-note strong { color: var(--ink); }
+.loop-note { max-width: 720px; margin: 10px auto 0; text-align: center; font-size: .95rem; line-height: 1.6; color: var(--muted); }
+.loop-note strong { display: block; margin-bottom: 3px; color: var(--ink); font-family: var(--font-display); font-weight: 600; font-size: 1.06rem; }
 
 /* personas */
 .persona { background: var(--white); border: 1px solid var(--line); border-radius: var(--radius); padding: 26px; border-top: 3px solid var(--azure); }

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@ title: Azure SQL Database container
       <div class="loop-stage">
         <span class="loop-tag">Inner loop &middot; local</span>
         <h3>Develop on your machine</h3>
-        <p>Write, run, test, and debug against the <strong>container</strong>, the Azure SQL Database engine running locally. Fast iteration, no Azure subscription.</p>
+        <p>Write, run, test, and debug against the Azure SQL Database engine running locally. Fast iteration, no Azure subscription, no credit card.</p>
       </div>
       <div class="loop-arrow" aria-hidden="true">
         <span class="loop-arrow-label">same code<br>connection string changes</span>
@@ -85,7 +85,7 @@ title: Azure SQL Database container
       <div class="loop-stage loop-stage-cloud">
         <span class="loop-tag loop-tag-cloud">Outer loop &middot; Azure</span>
         <h3>Deploy to Azure SQL Database</h3>
-        <p>Push to your repo, let CI/CD (GitHub Actions) deploy, and run the same app against <strong>Azure SQL Database</strong> in the Microsoft Azure cloud: the managed, production database.</p>
+        <p>Push to your repo, let CI/CD (GitHub Actions) deploy, and run the same app against Azure SQL Database in the Microsoft Azure cloud: the managed, production database.</p>
       </div>
     </div>
     <p class="loop-note"><strong>The container is for development.</strong> It is your local inner loop (development, testing, CI, and demos). Production is Azure SQL Database in the cloud: you deploy the same code there. You do not run this container in Azure as a production database.</p>
@@ -111,7 +111,7 @@ title: Azure SQL Database container
 </section>
 
 <!-- ============ SAME CODE (signature) ============ -->
-<section class="section section-rail">
+<section class="section section-rail" style="display: none;">
   <div class="container">
     <div class="section-head">
       <p class="eyebrow"><span class="eyebrow-dot"></span>Inner loop to the cloud</p>


### PR DESCRIPTION
Follow-up polish on the inner/outer-loop section from #41:
- Restyle the development-purpose note as a clean centered caption (was a boxy left-bar callout that read as ugly).
- Inner-loop stage copy tightened and de-bolded: "Write, run, test, and debug against the Azure SQL Database engine running locally. Fast iteration, no Azure subscription, no credit card."
- Removed the bold from "Azure SQL Database" in the outer-loop stage.
- Re-hid the "Same code. Only the connection string changes." section (the diagram now carries it).

Jekyll build clean; no em-dashes.