### PR TITLE
Drop the landing-page dev note box; use a blockquote callout in getting-started

### DIFF
--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -271,8 +271,7 @@ section[id] { scroll-margin-top: 84px; }
 .loop-arrow::before { content: ""; flex: 1; width: 2px; background: linear-gradient(var(--vector), var(--azure)); border-radius: 2px; }
 .loop-arrow::after { content: ""; flex: 1; width: 2px; background: linear-gradient(var(--vector), var(--azure)); border-radius: 2px; }
 .loop-arrow-label { font-family: var(--font-mono); font-size: .72rem; color: var(--muted); text-align: center; line-height: 1.5; }
-.loop-note { max-width: 720px; margin: 10px auto 0; text-align: center; font-size: .95rem; line-height: 1.6; color: var(--muted); }
-.loop-note strong { display: block; margin-bottom: 3px; color: var(--ink); font-family: var(--font-display); font-weight: 600; font-size: 1.06rem; }
+.loop { margin-bottom: 8px; }
 
 /* personas */
 .persona { background: var(--white); border: 1px solid var(--line); border-radius: var(--radius); padding: 26px; border-top: 3px solid var(--azure); }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,7 +28,7 @@ You do **not** need sqlcmd or any database tool installed: the container brings 
 
 The image is in a private registry, so **[sign up for the Private Preview](https://aka.ms/sqldbcontainerpreview-signup)** first. Signing up is the only way to get the registry username and password (pull-only; may rotate) that you need to pull the image.
 
-The container is for **local development**, your inner loop. When you are ready for production, deploy the same code to Azure SQL Database in the Microsoft Azure cloud (the outer loop); you do not run this container in Azure. See the [local-to-cloud skill](https://github.com/microsoft/azure-sql-database-container/tree/main/skills/azuresql-db-local-to-cloud).
+> **The container is for development.** It is your local inner loop (development, testing, CI, and demos). For production, deploy the same code to Azure SQL Database in the Microsoft Azure cloud (the outer loop); you do not run this container in Azure. See the [local-to-cloud skill](https://github.com/microsoft/azure-sql-database-container/tree/main/skills/azuresql-db-local-to-cloud).
 
 From here you have two ways to reach your first query. Both end in the same place, a running container you can connect to, so pick one.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -88,8 +88,6 @@ title: Azure SQL Database container
         <p>Push to your repo, let CI/CD (GitHub Actions) deploy, and run the same app against Azure SQL Database in the Microsoft Azure cloud: the managed, production database.</p>
       </div>
     </div>
-    <p class="loop-note"><strong>The container is for development.</strong> It is your local inner loop (development, testing, CI, and demos). Production is Azure SQL Database in the cloud: you deploy the same code there. You do not run this container in Azure as a production database.</p>
-
     <div class="grid-3">
       <article class="card">
         <span class="tag">Same engine</span>


### PR DESCRIPTION
The boxed 'The container is for development' note on the landing page looked bad. Removed it from the `#why` section (the inner/outer-loop diagram and the section lead still carry the message). Moved the development warning into a **blockquote callout** in getting-started Step 0, matching the existing callout style (example prompt, credentials note). Build clean, no em-dashes.