### PR TITLE
Drop 'box' jargon, add consistent Related content, rework nav buttons

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -8,6 +8,9 @@ description: >-
 baseurl: "/azure-sql-database-container"
 url: "https://microsoft.github.io"
 repo: "https://github.com/microsoft/azure-sql-database-container"
+# Public repo the nav "GitHub repo" button opens. Update this to the public repo URL
+# once it exists (the current repo is private and 404s for external users).
+public_repo: "https://github.com/microsoft/azure-sql-database-container"
 youtube_id: "S6PWxUAUspY"
 
 markdown: kramdown

--- a/docs/_includes/nav.html
+++ b/docs/_includes/nav.html
@@ -15,8 +15,11 @@
       <a href="{{ '/getting-started.html' | relative_url }}">Get started</a>
       <a href="{{ '/#build' | relative_url }}">Build</a>
       <a href="{{ '/known-limitations.html' | relative_url }}">Limitations</a>
-      <a href="{{ '/feedback-and-how-to-engage.html' | relative_url }}">Feedback</a>
-      <a class="btn btn-primary btn-sm nav-gh-btn" href="{{ site.repo }}" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a class="btn btn-primary btn-sm nav-feedback-btn" href="{{ '/feedback-and-how-to-engage.html' | relative_url }}">Feedback</a>
+      <a class="btn btn-sm nav-gh-btn" href="{{ site.public_repo }}" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository">
+        <svg viewBox="0 0 16 16" width="15" height="15" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.03 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+        GitHub repo
+      </a>
     </nav>
   </div>
 </header>

--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -96,6 +96,9 @@ code, pre { font-family: var(--font-mono); }
 .btn-primary:hover { background: var(--azure-700); color: #fff; }
 .btn-ghost-light { background: transparent; color: var(--on-dark); border-color: var(--line-dark); }
 .btn-ghost-light:hover { background: rgba(255,255,255,.07); color: #fff; }
+.nav-gh-btn { background: var(--white); color: var(--ink); border-color: var(--line); gap: 7px; }
+.nav-gh-btn:hover { background: var(--mist); color: var(--ink); border-color: #c6d6ee; }
+.nav-gh-btn svg { flex-shrink: 0; }
 .play-glyph { width: 0; height: 0; border-style: solid; border-width: 6px 0 6px 10px; border-color: transparent transparent transparent currentColor; margin-right: 1px; }
 
 /* ---------- nav ---------- */
@@ -114,6 +117,7 @@ code, pre { font-family: var(--font-mono); }
 .nav-links a { color: var(--muted); font-weight: 500; font-size: .95rem; }
 .nav-links a:hover { color: var(--ink); text-decoration: none; }
 .nav-links a.btn-primary { color: #fff; }
+.nav-links a.nav-gh-btn { color: var(--ink); }
 .nav-gh { font-weight: 600 !important; color: var(--ink) !important; }
 .nav-toggle, .nav-burger { display: none; }
 
@@ -479,6 +483,7 @@ section[id] { scroll-margin-top: 84px; }
   }
   .nav-links a { padding: 13px 0; border-bottom: 1px solid var(--line); }
   .nav-links a.btn-primary { margin-top: 12px; justify-content: center; border-bottom: 0; }
+  .nav-links a.nav-gh-btn { margin-top: 8px; justify-content: center; border-bottom: 0; }
   .nav-toggle:checked ~ .nav-links { max-height: 460px; visibility: visible; padding-top: 8px; }
   .nav-toggle:checked ~ .nav-burger span:nth-child(1) { transform: translateY(7px) rotate(45deg); }
   .nav-toggle:checked ~ .nav-burger span:nth-child(2) { opacity: 0; }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,6 +13,7 @@ description: "Go from pulling the Azure SQL Database container to your first que
   - [Step 2: start the container](#step-2-start-the-container)
   - [Step 3: connect and run your first query](#step-3-connect-and-run-your-first-query)
 - [Next: build something](#next-build-something)
+- [Related content](#related-content)
 
 ## Before you start
 
@@ -44,7 +45,7 @@ The skill works across Claude Code, GitHub Copilot (VS Code and CLI), Codex, and
 
 > Add a local Azure SQL Database to this project, then scaffold the schema, migrations, and data-access layer for my stack.
 
-**Why use the skills?** They already know the private preview registry, the x64 image, the connection model (the engine does not auto-create databases, so they provision a database first, named `appdb` in these examples or whatever name you choose), the readiness wait, and the local-to-cloud story. So your agent stands up a real Azure SQL Database the right way the first time, instead of reaching for the SQL Server box image (`mcr.microsoft.com/mssql/server`) or inventing behavior the engine does not have. Browse the [skills on GitHub](https://github.com/microsoft/azure-sql-database-container/tree/main/skills).
+**Why use the skills?** They already know the private preview registry, the x64 image, the connection model (the engine does not auto-create databases, so they provision a database first, named `appdb` in these examples or whatever name you choose), the readiness wait, and the local-to-cloud story. So your agent stands up a real Azure SQL Database the right way the first time, instead of reaching for the SQL Server image (`mcr.microsoft.com/mssql/server`) or inventing behavior the engine does not have. Browse the [skills on GitHub](https://github.com/microsoft/azure-sql-database-container/tree/main/skills).
 
 ## Manual: run it yourself
 
@@ -139,3 +140,10 @@ Pick a job and let your AI coding agent build it against the container. Each lin
 - [Scaffold new projects]({{ '/prompts/templates.md' | relative_url }}): start a new .NET Aspire, FastAPI, Next.js, or NestJS project.
 
 Haven't installed the skill yet? See [Agent skill](prerequisites.md#agent-skill).
+
+## Related content
+
+- [What is the Azure SQL Database container](what-is-the-container.md)
+- [Prerequisites](prerequisites.md)
+- [Known limitations](known-limitations.md)
+- [Feedback and how to engage](feedback-and-how-to-engage.md)

--- a/docs/index.html
+++ b/docs/index.html
@@ -199,7 +199,7 @@ title: Azure SQL Database container
         </div>
       </div>
     </div>
-    <p class="steps-foot">Prefer docker compose, VS Code, or step-by-step detail? Read the <a href="{{ '/getting-started.html' | relative_url }}">full Get started guide &rarr;</a></p>
+    <p class="steps-foot">Want your AI agent to set it up, or prefer the full step-by-step? Read the <a href="{{ '/getting-started.html' | relative_url }}">full Get started guide &rarr;</a></p>
   </div>
 </section>
 
@@ -244,7 +244,7 @@ title: Azure SQL Database container
     </div>
 
     <h3 class="skill-cards-title">Agent skills</h3>
-    <p class="skill-lead">A collection of skills your agent loads on demand. Each one teaches it to use the engine the right way, so it does not reach for the SQL Server box image or invent behavior the engine does not have.</p>
+    <p class="skill-lead">A collection of skills your agent loads on demand. Each one teaches it to use the engine the right way, so it does not reach for the SQL Server image or invent behavior the engine does not have.</p>
     <div class="skill-cards">
       <a class="skill-card" href="{{ site.repo }}/tree/main/skills/azuresql-db-container" rel="noopener">
         <h4>Start the engine <span class="arrow">&rarr;</span></h4>
@@ -252,7 +252,7 @@ title: Azure SQL Database container
       </a>
       <a class="skill-card" href="{{ site.repo }}/tree/main/skills/azuresql-db-from-sql-server" rel="noopener">
         <h4>Convert from SQL Server <span class="arrow">&rarr;</span></h4>
-        <p>Move a project off the <code>mcr.microsoft.com/mssql/server</code> box image to the real Azure SQL Database engine.</p>
+        <p>Move a project off the <code>mcr.microsoft.com/mssql/server</code> SQL Server image to the real Azure SQL Database engine.</p>
       </a>
       <a class="skill-card" href="{{ site.repo }}/tree/main/skills/azuresql-db-local-to-cloud" rel="noopener">
         <h4>Local to cloud <span class="arrow">&rarr;</span></h4>
@@ -302,7 +302,7 @@ title: Azure SQL Database container
       <article class="card">
         <span class="tag">from sql server</span>
         <h3>Already using the SQL Server image?</h3>
-        <p>Convert a project on the <code>mcr.microsoft.com/mssql/server</code> box image to the Azure SQL Database engine: swap the image, fix the connection model, and flag box-only features. Azure-faithful local dev.</p>
+        <p>Convert a project on the <code>mcr.microsoft.com/mssql/server</code> SQL Server image to the Azure SQL Database engine: swap the image, fix the connection model, and flag SQL Server-only features. Azure-faithful local dev.</p>
         <div class="card-actions">
           <button class="card-prompt" type="button" data-prompt="{{ '/prompts/from-sql-server.md' | relative_url }}"><span class="card-prompt-ico" aria-hidden="true"></span><span class="copy-label">Copy prompt</span></button>
           <a class="card-view" href="{{ '/prompts/from-sql-server.md' | relative_url }}">View</a>

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -11,6 +11,7 @@ description: "Current gaps and rough edges in the Private Preview, with workarou
 - [Known behavior gaps](#known-behavior-gaps)
 - [Out of scope by design](#out-of-scope-by-design)
 - [Where to find live status](#where-to-find-live-status)
+- [Related content](#related-content)
 
 ## Development use only
 
@@ -78,9 +79,16 @@ These are intentional non-goals for the container:
 
 - **Cloud-only management surfaces.** Azure portal, Azure CLI, ARM, Bicep, and Terraform target the cloud service. They are not applicable to the container.
 - **PaaS multi-tenancy controls.** Elastic pools, hyperscale tier, serverless auto-pause, and similar PaaS service-tier features are properties of the cloud service, not the engine.
-- **SQL Server box-product behavior.** Features that exist in SQL Server but not in Azure SQL Database (e.g., SQL Agent, FILESTREAM, full Service Broker, Windows Authentication / NTLM, distributed transactions across multiple databases on different servers) are intentionally not present.
+- **SQL Server behavior.** Features that exist in SQL Server but not in Azure SQL Database (e.g., SQL Agent, FILESTREAM, full Service Broker, Windows Authentication / NTLM, distributed transactions across multiple databases on different servers) are intentionally not present.
 
 ## Where to find live status
 
 - **Open issues:** [GitHub Issues](https://github.com/microsoft/azure-sql-database-container/issues)
 - **Roadmap discussion:** [GitHub Discussions](https://github.com/microsoft/azure-sql-database-container/discussions)
+
+## Related content
+
+- [What is the Azure SQL Database container](what-is-the-container.md)
+- [Get started](getting-started.md)
+- [Prerequisites](prerequisites.md)
+- [Feedback and how to engage](feedback-and-how-to-engage.md)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -15,14 +15,14 @@ Copy-and-run prompts to hand your AI coding agent, each building a scenario agai
 - [Build locally, ship to Azure (Node.js)](https://github.com/microsoft/azure-sql-database-container/blob/main/docs/prompts/local-to-cloud.md)
 - [Prototype AI / RAG with vector search (Python + Ollama)](https://github.com/microsoft/azure-sql-database-container/blob/main/docs/prompts/ai-rag.md)
 - [Run integration tests in CI](https://github.com/microsoft/azure-sql-database-container/blob/main/docs/prompts/ci.md)
-- [Convert from the SQL Server box image](https://github.com/microsoft/azure-sql-database-container/blob/main/docs/prompts/from-sql-server.md)
+- [Convert from the SQL Server image](https://github.com/microsoft/azure-sql-database-container/blob/main/docs/prompts/from-sql-server.md)
 - [Develop offline](https://github.com/microsoft/azure-sql-database-container/blob/main/docs/prompts/offline.md)
 - [Drop in as a sidecar](https://github.com/microsoft/azure-sql-database-container/blob/main/docs/prompts/sidecar.md)
 - [Scaffold a new project](https://github.com/microsoft/azure-sql-database-container/blob/main/docs/prompts/templates.md)
 - [Agent skills for Claude Code, GitHub Copilot, Codex, and Cursor](https://github.com/microsoft/azure-sql-database-container/tree/main/skills)
 
 ## Key facts
-- Image: sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition, x64 (linux/amd64); on a non-x64 host, add --platform linux/amd64. It is the Azure SQL Database engine (SERVERPROPERTY('EngineEdition')=5, Edition='SQL Azure'), not the SQL Server box image. The shared pull-only registry credentials are provided when you sign up for the Private Preview at https://aka.ms/sqldbcontainerpreview-signup and may rotate.
+- Image: sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition, x64 (linux/amd64); on a non-x64 host, add --platform linux/amd64. It is the Azure SQL Database engine (SERVERPROPERTY('EngineEdition')=5, Edition='SQL Azure'), not the SQL Server image. The shared pull-only registry credentials are provided when you sign up for the Private Preview at https://aka.ms/sqldbcontainerpreview-signup and may rotate.
 - Connection: TCP port 1433; SQL login (sa) locally, Microsoft Entra in the cloud. Apps read the connection string from the SQL_CONNECTION_STRING environment variable.
 - AI-native: native vector data type, DiskANN vector indexes, VECTOR_DISTANCE similarity search, AI_GENERATE_EMBEDDINGS, CREATE EXTERNAL MODEL, native JSON, and RegEx.
 - Parity: same engine, defaults, T-SQL, and error messages as Azure SQL Database in the cloud.

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -13,6 +13,7 @@ description: "Supported host platforms, container runtimes, system resources, an
 - [Agent skill](#agent-skill)
 - [Tooling](#tooling)
 - [Azure account (optional, for local-to-cloud)](#azure-account-optional-for-local-to-cloud)
+- [Related content](#related-content)
 
 ## Private Preview access
 
@@ -82,3 +83,10 @@ The container itself does not require an Azure subscription. The local-to-cloud 
 - A target compute resource for the application: Azure App Service, Azure Container Apps, or Azure Functions, depending on the stack
 
 See the [local-to-cloud skill](https://github.com/microsoft/azure-sql-database-container/tree/main/skills/azuresql-db-local-to-cloud) for the deploy flow. If you do not have an Azure subscription, you can still do all local development and exercise the full inner loop.
+
+## Related content
+
+- [What is the Azure SQL Database container](what-is-the-container.md)
+- [Get started](getting-started.md)
+- [Known limitations](known-limitations.md)
+- [Feedback and how to engage](feedback-and-how-to-engage.md)

--- a/docs/prompts/from-sql-server.md
+++ b/docs/prompts/from-sql-server.md
@@ -1,8 +1,8 @@
-# AI Prompt: Convert a SQL Server box-image setup to the Azure SQL Database container
+# AI Prompt: Convert a SQL Server setup to the Azure SQL Database container
 
-**Role:** You are an expert agent converting the current project from the SQL Server box image (`mcr.microsoft.com/mssql/server`) to the Azure SQL Database container, so local development is Azure-faithful (the same engine you run in Azure SQL Database in the cloud).
+**Role:** You are an expert agent converting the current project from the SQL Server image (`mcr.microsoft.com/mssql/server`) to the Azure SQL Database container, so local development is Azure-faithful (the same engine you run in Azure SQL Database in the cloud).
 
-**Purpose:** Detect the box image, swap it for the Azure SQL Database engine image, fix the connection model, flag features that exist only in the box product, and verify you are on the real engine.
+**Purpose:** Detect the SQL Server image, swap it for the Azure SQL Database engine image, fix the connection model, flag features that exist only in the SQL Server, and verify you are on the real engine.
 
 **Scope:** A project that already runs `mcr.microsoft.com/mssql/server` (a `docker run`, a `docker-compose.yml`, a Dockerfile, or a Dev Container) with an `sa` login.
 
@@ -12,7 +12,7 @@ Read the entire instruction set before executing.
 
 ## Instructions
 
-### 1. Detect the box image
+### 1. Detect the SQL Server image
 
 Search the repo for `mcr.microsoft.com/mssql/server` (and `mssql/server`) in `docker-compose*.yml`, Dockerfiles, run scripts, CI, and `.devcontainer/`. Note where the image, the `ACCEPT_EULA`/`MSSQL_SA_PASSWORD` env, and the connection string live.
 
@@ -42,7 +42,7 @@ docker run -d --name sqldb "${PLATFORM[@]}" -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASS
 
 ### 4. Fix the connection model
 
-The Azure SQL Database engine does **not** auto-create databases, and the connection model differs from the box product. Provision the application database on a `master` connection, then point the app at that database:
+The Azure SQL Database engine does **not** auto-create databases, and the connection model differs from the SQL Server. Provision the application database on a `master` connection, then point the app at that database:
 
 ```bash
 # The engine is not ready the instant docker run returns; retry until it accepts connections.
@@ -55,9 +55,9 @@ done
 
 Re-point connection strings from `Database=master` to `Database=appdb`. Do not switch databases with `USE`: in a user-database (SDS) session `USE` returns `Msg 40508`, exactly as in Azure SQL Database in the cloud (a `master` connection is a non-SDS provisioning session where it appears to work, but `master` is for provisioning only). Select the database in the connection string.
 
-### 5. Flag box-only features to remove
+### 5. Flag SQL Server-only features to remove
 
-These exist in the SQL Server box product but **not** in Azure SQL Database; remove or replace any usage so the app works against the engine and the cloud:
+These exist in the SQL Server but **not** in Azure SQL Database; remove or replace any usage so the app works against the engine and the cloud:
 
 - SQL Server Agent jobs (`msdb.dbo.sp_add_job`, etc.)
 - FILESTREAM / FileTable
@@ -72,7 +72,7 @@ docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0n
     -d appdb -Q "SELECT SERVERPROPERTY('EngineEdition') AS EngineEdition, SERVERPROPERTY('Edition') AS Edition;"
 ```
 
-Expect `EngineEdition = 5` and `Edition = SQL Azure`. The box image returns different values; if you see those, the image was not swapped.
+Expect `EngineEdition = 5` and `Edition = SQL Azure`. The SQL Server image returns different values; if you see those, the image was not swapped.
 
 ---
 
@@ -81,11 +81,11 @@ Expect `EngineEdition = 5` and `Edition = SQL Azure`. The box image returns diff
 - No `mcr.microsoft.com/mssql/server` remains in compose, Dockerfiles, run scripts, CI, or Dev Container.
 - `--platform linux/amd64` is added on non-x64 hosts (compose `platform:` or the array-form shell snippet).
 - `appdb` is created on a `master` connection before the app connects with `Database=appdb`; no `USE` to switch databases.
-- At least one box-only feature is flagged (or the app confirmed not to use any).
+- At least one SQL Server-only feature is flagged (or the app confirmed not to use any).
 - `EngineEdition = 5` against the running container.
 
 ## Do not
 
-- Do not keep the box image or call arm64 / Apple Silicon "supported".
+- Do not keep the SQL Server image or call arm64 / Apple Silicon "supported".
 - Do not develop against `master`; do real work on the user database.
 - Do not commit the SA password or the registry credentials.

--- a/docs/what-is-the-container.md
+++ b/docs/what-is-the-container.md
@@ -12,6 +12,7 @@ description: "The Azure SQL Database engine, running locally for development and
 - [How it fits a developer workflow](#how-it-fits-a-developer-workflow)
 - [Container runtimes and platforms](#container-runtimes-and-platforms)
 - [About this Private Preview](#about-this-private-preview)
+- [Related content](#related-content)
 
 ## Overview
 
@@ -23,7 +24,7 @@ The container runs the same engine that powers Azure SQL Database in the cloud. 
 
 The container is the **Azure SQL Database engine** itself, running locally. Three things follow from that:
 
-1. **The same engine as the cloud.** The container runs the same engine, the same defaults, and the same T-SQL as Azure SQL Database. Features that are cloud-only in the box SQL Server product (Always Encrypted with secure enclaves, ledger, some DMVs) work locally the same way they work in the cloud.
+1. **The same engine as the cloud.** The container runs the same engine, the same defaults, and the same T-SQL as Azure SQL Database. Features that are cloud-only in SQL Server (Always Encrypted with secure enclaves, ledger, some DMVs) work locally the same way they work in the cloud.
 2. **No Azure subscription, no credit card required.** The container runs entirely on the developer machine or in CI. No service principal, no credit card, no shared instance. Free for local development and CI.
 3. **Works with the drivers, ORMs, and editors you already use.** Everything that talks to Azure SQL Database talks to the container without changes: node-mssql, mssql-python, pyodbc, and mssql-jdbc; Prisma, SQLAlchemy, EF Core, Django, and TypeORM; sqlcmd, and VS Code with the MSSQL extension's GitHub Copilot integration. (Graphical tooling like the full MSSQL extension UI and SSMS is not yet 100% compatible; see [known limitations](known-limitations.md).)
 
@@ -31,7 +32,7 @@ The container is the **Azure SQL Database engine** itself, running locally. Thre
 
 The container exposes the same engine surface as Azure SQL Database:
 
-- T-SQL dialect aligned to the cloud engine, not to SQL Server box product behavior.
+- T-SQL dialect aligned to the cloud engine, not to SQL Server behavior.
 - `EngineEdition = 5` so application code that checks the edition behaves the same locally and in the cloud.
 - System views and DMVs that are available in Azure SQL Database PaaS, including the ones that are not present in SQL Server.
 - Wire protocol (TDS) compatible with every driver and ORM that connects to Azure SQL Database in the cloud.
@@ -114,3 +115,10 @@ This is the first time the container is in the hands of developers building real
 - **It is not a SQL Server replacement.** This is the Azure SQL Database engine. PaaS-only behavior applies. If your workload depends on SQL Server features not present in Azure SQL Database, the container will not help you.
 - **It is not a production database.** The container is for your local inner loop; for production, deploy the same code to Azure SQL Database in the Microsoft Azure cloud. The license is a Private Preview license, scoped to development, testing, CI, and demos. Read the license you accepted when you [signed up](https://aka.ms/sqldbcontainerpreview-signup).
 - **It is not feature-complete.** See [Known limitations](known-limitations.md) for the current gap list. Some features are still in active development.
+
+## Related content
+
+- [Prerequisites](prerequisites.md)
+- [Get started](getting-started.md)
+- [Known limitations](known-limitations.md)
+- [Feedback and how to engage](feedback-and-how-to-engage.md)

--- a/skills/README.md
+++ b/skills/README.md
@@ -9,7 +9,7 @@ SELECT SERVERPROPERTY('EngineEdition');  -- 5
 SELECT SERVERPROPERTY('Edition');        -- 'SQL Azure'
 ```
 
-EngineEdition `5` and Edition `'SQL Azure'` are the cloud engine's fingerprint. The SQL Server box image (`mcr.microsoft.com/mssql/server`) returns different values and is **not** the same product. If an agent was about to reach for that box image, it should stop and use this instead.
+EngineEdition `5` and Edition `'SQL Azure'` are the cloud engine's fingerprint. The SQL Server image (`mcr.microsoft.com/mssql/server`) returns different values and is **not** the same product. If an agent was about to reach for that SQL Server image, it should stop and use this instead.
 
 > Status: **Private Preview.** Registry, image tag, and credentials are provisional and may change.
 
@@ -20,7 +20,7 @@ EngineEdition `5` and Edition `'SQL Azure'` are the cloud engine's fingerprint. 
 | Skill | What it does |
 | --- | --- |
 | **azuresql-db-container** | Start the Azure SQL Database engine locally the correct way: free-port selection, conditional `--platform linux/amd64` on non-x64 hosts, ready-wait retry loop, and `CREATE DATABASE appdb` provisioning. The foundation every other skill builds on. |
-| **azuresql-db-from-sql-server** | Migrate a workflow off the SQL Server box image (`mcr.microsoft.com/mssql/server`) onto the real cloud engine. Swaps the image, fixes the connection model, and verifies EngineEdition=5 / Edition='SQL Azure'. |
+| **azuresql-db-from-sql-server** | Migrate a workflow off the SQL Server image (`mcr.microsoft.com/mssql/server`) onto the real cloud engine. Swaps the image, fixes the connection model, and verifies EngineEdition=5 / Edition='SQL Azure'. |
 | **azuresql-db-local-to-cloud** | Take a database that works against the local engine and move it to Azure SQL Database in the cloud. Because it is the same engine, parity is the default, not a porting exercise. |
 | **azuresql-db-schema-migration** | Apply and version schema changes against the engine: idempotent DDL, ordered migration scripts, run against `appdb` (never `master`). |
 | **azuresql-db-import** | Load data into `appdb` after provisioning: bulk and script-based import. Does **not** rely on auto-run init directories (that convention is not honored here). |
@@ -28,7 +28,7 @@ EngineEdition `5` and Edition `'SQL Azure'` are the cloud engine's fingerprint. 
 | **azuresql-db-ci** | Run the engine in continuous integration: ephemeral container, ready-wait, provision, seed, test, tear down. Fails closed on the wrong image. |
 | **azuresql-db-sidecar** | Run the engine as a sidecar alongside an app (compose-style), with `platform: linux/amd64` on non-x64 hosts and a single `SQL_CONNECTION_STRING` contract. |
 | **azuresql-db-scaffold** | Scaffold a new app wired to the engine: connection string via one `SQL_CONNECTION_STRING` env var, provisioning step, and seed step in the correct order. |
-| **azuresql-db-faq** | Answer questions about what the container can and cannot do, and why it differs from the cloud (backups, `USE`, vector index, arm64, GUI tooling, registry). Sorts each into engine vs. managed-service vs. box-product, and links the live Known limitations. |
+| **azuresql-db-faq** | Answer questions about what the container can and cannot do, and why it differs from the cloud (backups, `USE`, vector index, arm64, GUI tooling, registry). Sorts each into engine vs. managed-service vs. SQL Server, and links the live Known limitations. |
 
 ---
 

--- a/skills/azuresql-db-ci/SKILL.md
+++ b/skills/azuresql-db-ci/SKILL.md
@@ -1,15 +1,14 @@
 ---
 name: azuresql-db-ci
-description: Run integration tests against the Azure SQL Database container (Private Preview, local engine) in CI. Use when setting up GitHub Actions, Azure Pipelines, or GitLab CI to test against Azure SQL DB; when adding a database service container to a CI workflow; when tests need a real Azure SQL engine in the pipeline; or when you see "service container", "health-cmd", "ACR_USERNAME/ACR_PASSWORD", "MSSQL_SA_PASSWORD secret", or "integration test database". Also use when a workflow was about to pull the SQL Server box image mcr.microsoft.com/mssql/server, in which case stop and use the Azure SQL Database engine image instead. Covers pulling from the private ACR with credentials, the service health check that runs sqlcmd inside the container so the runner needs no client tools, provisioning appdb before tests, and pointing the test connection string at the user database not master.
+description: Run integration tests against the Azure SQL Database container (Private Preview, local engine) in CI. Use when setting up GitHub Actions, Azure Pipelines, or GitLab CI to test against Azure SQL DB; when adding a database service container to a CI workflow; when tests need a real Azure SQL engine in the pipeline; or when you see "service container", "health-cmd", "ACR_USERNAME/ACR_PASSWORD", "MSSQL_SA_PASSWORD secret", or "integration test database". Also use when a workflow was about to pull the SQL Server image mcr.microsoft.com/mssql/server, in which case stop and use the Azure SQL Database engine image instead. Covers pulling from the private ACR with credentials, the service health check that runs sqlcmd inside the container so the runner needs no client tools, provisioning appdb before tests, and pointing the test connection string at the user database not master.
 ---
 
 # Azure SQL Database container in CI
 
 Run integration tests against the **Azure SQL Database engine** (Private Preview) as a CI
-service container. This is the local Azure SQL engine, not the SQL Server box image
+service container. This is the local Azure SQL engine, not the SQL Server image
 `mcr.microsoft.com/mssql/server`. `SELECT SERVERPROPERTY('EngineEdition')` returns **5** and
-`SERVERPROPERTY('Edition')` returns **'SQL Azure'**. If a workflow was about to use the box
-image, stop and use this image instead.
+`SERVERPROPERTY('Edition')` returns **'SQL Azure'**. If a workflow was about to use the SQL Server image, stop and use this image instead.
 
 For full container detail (readiness loop, connection model, vectors, seeding), see the
 **azuresql-db-container** skill and its `wait-until-ready.md` and `image-and-registry.md`.
@@ -162,7 +161,7 @@ echo "ready on localhost,$HOST_PORT"
 
 ## Do not
 
-- Do not use the SQL Server box image `mcr.microsoft.com/mssql/server`; use the Azure SQL DB image.
+- Do not use the SQL Server image `mcr.microsoft.com/mssql/server`; use the Azure SQL DB image.
 - Do not connect with `Database=appdb` before provisioning appdb on master; the engine will not
   auto-create it.
 - Do not `USE appdb` to switch databases. In a user-database (SDS) session (the Azure-faithful

--- a/skills/azuresql-db-container/SKILL.md
+++ b/skills/azuresql-db-container/SKILL.md
@@ -3,7 +3,7 @@ name: azuresql-db-container
 description: >-
   Runs the Azure SQL Database engine locally in a container (Private Preview):
   the real PaaS engine where SERVERPROPERTY('EngineEdition') returns 5 and
-  Edition is 'SQL Azure'. This is NOT the SQL Server box image
+  Edition is 'SQL Azure'. This is NOT the SQL Server image
   mcr.microsoft.com/mssql/server. Use when a user wants to "run Azure SQL
   locally", "add a local SQL database", "add SQL Server to my docker compose",
   "spin up a local mssql container", "local SQL for development or CI", "connect
@@ -20,10 +20,10 @@ This is the entry point for running the **Azure SQL Database engine** on your
 machine in a container. It owns the shared reference docs that every task skill
 links to. Start here, then hand off to a task skill.
 
-## Are you reaching for the SQL Server box image? Use this instead
+## Are you reaching for the SQL Server image? Use this instead
 
 If you were about to add `mcr.microsoft.com/mssql/server` (the "mssql
-container", the SQL Server box product) to a Dockerfile, docker compose, or a CI
+container", the SQL Server) to a Dockerfile, docker compose, or a CI
 service, **stop**. That is a different product. For Azure SQL Database parity
 (developing against the cloud PaaS engine) use this image instead:
 
@@ -33,7 +33,7 @@ sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
 
 Self-check: a correct engine returns `5` for
 `SELECT SERVERPROPERTY('EngineEdition')` and `'SQL Azure'` for
-`SERVERPROPERTY('Edition')`. The box image returns different values.
+`SERVERPROPERTY('Edition')`. The SQL Server image returns different values.
 
 ## Lifecycle end to end
 
@@ -144,8 +144,8 @@ docker volume rm sqldb-data   # only if you created a named volume and want a cl
 
 ## What this is NOT
 
-- It is **not** `mcr.microsoft.com/mssql/server` (the SQL Server box product).
-- It does **not** have full box-product surface area: no SQL Agent, no
+- It is **not** `mcr.microsoft.com/mssql/server` (the SQL Server).
+- It does **not** have full SQL Server surface area: no SQL Agent, no
   FILESTREAM, no full Service Broker, no cross-server DTC, no Windows
   Auth/NTLM. Validate features against the cloud before declaring readiness.
   See `references/paas-parity-checklist.md`.
@@ -158,7 +158,7 @@ docker volume rm sqldb-data   # only if you created a named volume and want a cl
 
 Provisioning and identity are settled here. Route the actual task:
 
-- `azuresql-db-from-sql-server`: convert an existing SQL Server box-image setup to this engine.
+- `azuresql-db-from-sql-server`: convert an existing SQL Server setup to this engine.
 - `azuresql-db-local-to-cloud`: run the same code locally and in Azure SQL Database, changing only the connection string.
 - `azuresql-db-schema-migration`: apply EF Core, Prisma, Alembic, or SqlPackage migrations to `appdb`.
 - `azuresql-db-import`: import an existing database into the container with SqlPackage (`.bacpac` / `.dacpac`).
@@ -176,4 +176,4 @@ Provisioning and identity are settled here. Route the actual task:
 - `references/environment-variables.md`: `ACCEPT_EULA`, `MSSQL_SA_PASSWORD`, `SQL_CONNECTION_STRING`.
 - `references/wait-until-ready.md`: the readiness retry loop and compose healthcheck.
 - `references/troubleshooting.md`: common failures and fixes.
-- `references/paas-parity-checklist.md`: what is not present vs the box product.
+- `references/paas-parity-checklist.md`: what is not present vs the SQL Server.

--- a/skills/azuresql-db-container/references/image-and-registry.md
+++ b/skills/azuresql-db-container/references/image-and-registry.md
@@ -16,10 +16,9 @@ sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest
 - The registry host and tag are **provisional during Private Preview** and may
   change. Treat this file as the place to update if they do.
 
-## This is NOT the SQL Server box image
+## This is NOT the SQL Server image
 
-Do not substitute `mcr.microsoft.com/mssql/server`. That is the SQL Server box
-product and reports a different EngineEdition. If a task pulled the box image,
+Do not substitute `mcr.microsoft.com/mssql/server`. That is SQL Server and reports a different EngineEdition. If a task pulled the SQL Server image,
 stop and switch to the image above.
 
 ## Sign in to the private registry (Path B: external access)

--- a/skills/azuresql-db-container/references/paas-parity-checklist.md
+++ b/skills/azuresql-db-container/references/paas-parity-checklist.md
@@ -1,15 +1,15 @@
 # PaaS parity checklist
 
 This container is the Azure SQL Database engine (EngineEdition 5), not the SQL
-Server box product. Some box-product features are intentionally absent because
+Server SQL Server. Some SQL Server features are intentionally absent because
 they are not part of the PaaS surface. Validate features against the cloud
 before declaring readiness.
 
-## Not present (vs the SQL Server box product)
+## Not present (vs the SQL Server)
 
 - **SQL Server Agent**: no Agent jobs/schedules. Use an external scheduler.
 - **FILESTREAM / FileTable**: not available.
-- **Full Service Broker**: not the full box-product Service Broker surface; do
+- **Full Service Broker**: not the full SQL Server Service Broker surface; do
   not assume cross-instance broker messaging.
 - **Cross-server DTC / distributed transactions**: no cross-server MSDTC.
 - **Windows Authentication / NTLM**: not available; use SQL authentication
@@ -69,7 +69,7 @@ source of truth:
 
 ## Do not
 
-- Do not assume box-product features (Agent, FILESTREAM, full Service Broker,
+- Do not assume SQL Server features (Agent, FILESTREAM, full Service Broker,
   cross-server DTC, Windows Auth) are available.
 - Do not declare readiness without validating the feature against Azure SQL
   Database in the cloud.

--- a/skills/azuresql-db-container/references/troubleshooting.md
+++ b/skills/azuresql-db-container/references/troubleshooting.md
@@ -90,8 +90,7 @@ rather than masked. See `wait-until-ready.md`.
 ## Wrong image (EngineEdition is not 5)
 
 If `SELECT SERVERPROPERTY('EngineEdition')` does not return `5`, or
-`SERVERPROPERTY('Edition')` is not `'SQL Azure'`, you started the SQL Server box
-image. Stop it and start the Azure SQL Database image from
+`SERVERPROPERTY('Edition')` is not `'SQL Azure'`, you started the SQL Server image. Stop it and start the Azure SQL Database image from
 `image-and-registry.md`:
 
 ```bash

--- a/skills/azuresql-db-container/scripts/verify.sh
+++ b/skills/azuresql-db-container/scripts/verify.sh
@@ -6,7 +6,7 @@
 # Steps:
 #   1. Pick a free host port starting at 1433.
 #   2. Add --platform linux/amd64 only on a non-x64 host.
-#   3. docker run the engine image (FAIL CLOSED on the SQL Server box image).
+#   3. docker run the engine image (FAIL CLOSED on the SQL Server image).
 #   4. Wait-until-ready with the sqlcmd -C -b -l 2 retry loop.
 #   5. Assert EngineEdition=5 AND Edition='SQL Azure' (non-zero exit otherwise).
 #   6. CREATE DATABASE appdb.
@@ -32,11 +32,11 @@ for arg in "$@"; do
 done
 
 # ----------------------------------------------------------------------------
-# FAIL CLOSED: the SQL Server box image is NOT the Azure SQL Database engine.
+# FAIL CLOSED: the SQL Server image is NOT the Azure SQL Database engine.
 # ----------------------------------------------------------------------------
 case "$IMAGE" in
   *mcr.microsoft.com/mssql/server*)
-    echo "ERROR: '$IMAGE' is the SQL Server box image, NOT the Azure SQL Database engine." >&2
+    echo "ERROR: '$IMAGE' is the SQL Server image, NOT the Azure SQL Database engine." >&2
     echo "       Use sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest" >&2
     echo "       (returns EngineEdition=5 / Edition='SQL Azure'). Aborting." >&2
     exit 1

--- a/skills/azuresql-db-faq/SKILL.md
+++ b/skills/azuresql-db-faq/SKILL.md
@@ -19,10 +19,10 @@ from the cloud" questions accurately, instead of guessing from general SQL Serve
 or Azure SQL Database knowledge. A base model does not know this preview product's
 specifics, and the honest answers are often nuanced.
 
-## The mental model: engine vs. managed service vs. box product
+## The mental model: engine vs. managed service vs. SQL Server
 
 The container is the **Azure SQL Database engine, running locally**. It is not the
-managed cloud service, and it is not the SQL Server box product. Sort almost any
+managed cloud service, and it is not the SQL Server. Sort almost any
 "is X supported" question into one of four buckets and the answer follows:
 
 1. **Engine features -> present.** T-SQL dialect, system views, `VECTOR` type and
@@ -32,7 +32,7 @@ managed cloud service, and it is not the SQL Server box product. Sort almost any
    restore, geo-replication, elastic pools, hyperscale, serverless auto-pause,
    per-database DTU/vCore caps, audit-to-cloud, and Azure portal / CLI / ARM
    management. These wrap the engine in the cloud; the container is only the engine.
-3. **SQL Server box-only features -> intentionally absent** (they are not in Azure
+3. **SQL Server-only features -> intentionally absent** (they are not in Azure
    SQL Database either): SQL Agent jobs, FILESTREAM / FileTable, full cross-instance
    Service Broker, linked servers, cross-server distributed transactions, Windows
    Authentication / NTLM.
@@ -61,7 +61,7 @@ limitations list (kept in step with the docs) is in [references/limitations.md](
 - When the question is about a current gap, give the workaround and point to the
   live, always-current list: https://microsoft.github.io/azure-sql-database-container/known-limitations.html
 - Distinguish "the engine does not do this" (a real gap) from "the managed cloud
-  service does this, the engine does not" (by design) from "the box product does
+  service does this, the engine does not" (by design) from "the SQL Server does
   this, Azure SQL Database does not" (intentionally absent).
 
 ## Never do

--- a/skills/azuresql-db-faq/references/faq.md
+++ b/skills/azuresql-db-faq/references/faq.md
@@ -92,8 +92,7 @@ can cause subtle edge-case differences. Set the ones you depend on explicitly.
 ## Box-product features (intentionally absent, like the cloud)
 
 **Why are SQL Agent jobs / FILESTREAM / linked servers / Windows Authentication /
-cross-server distributed transactions missing?** These exist in the SQL Server box
-product but not in Azure SQL Database, so they are intentionally absent here too.
+cross-server distributed transactions missing?** These exist in SQL Server but not in Azure SQL Database, so they are intentionally absent here too.
 Removing a dependency on them is part of being cloud-ready. Use the `sa` login locally
 and Microsoft Entra in the cloud instead of Windows Authentication.
 

--- a/skills/azuresql-db-faq/references/limitations.md
+++ b/skills/azuresql-db-faq/references/limitations.md
@@ -28,4 +28,4 @@ https://aka.ms/azuresqldb-container-bug to file an issue.
 
 - **Cloud-only management surfaces** (Azure portal, CLI, ARM, Bicep, Terraform) target the cloud service, not the container.
 - **PaaS multi-tenancy controls** (elastic pools, hyperscale, serverless auto-pause) are cloud service-tier features, not engine features.
-- **SQL Server box-product behavior** not in Azure SQL Database (SQL Agent, FILESTREAM, full Service Broker, Windows Authentication / NTLM, cross-server distributed transactions) is intentionally absent.
+- **SQL Server behavior** not in Azure SQL Database (SQL Agent, FILESTREAM, full Service Broker, Windows Authentication / NTLM, cross-server distributed transactions) is intentionally absent.

--- a/skills/azuresql-db-from-sql-server/SKILL.md
+++ b/skills/azuresql-db-from-sql-server/SKILL.md
@@ -1,22 +1,22 @@
 ---
 name: azuresql-db-from-sql-server
-description: Migrates a local SQL Server box-image setup to the Azure SQL Database container for Azure-faithful local development. Use when a project already uses mcr.microsoft.com/mssql/server, mssql/server, an sqlcmd plus SA password docker setup, a "SQL Server in docker" or "local mssql container", or a docker-compose with the mssql/server image; and use when the user asks for "SQL Server locally", "run mssql in Docker", "spin up a local SQL database", or "test against SQL Server" but actually wants the Azure SQL Database engine (EngineEdition 5). Detects the box image, rewrites it to the Azure SQL Database container, adds --platform on non-x64 hosts, keeps the SA login, flags box-only features (SQL Agent, FILESTREAM, full Service Broker, cross-server distributed transactions, Windows Auth), and re-points connection strings from master to a provisioned user database.
+description: Migrates a local SQL Server setup to the Azure SQL Database container for Azure-faithful local development. Use when a project already uses mcr.microsoft.com/mssql/server, mssql/server, an sqlcmd plus SA password docker setup, a "SQL Server in docker" or "local mssql container", or a docker-compose with the mssql/server image; and use when the user asks for "SQL Server locally", "run mssql in Docker", "spin up a local SQL database", or "test against SQL Server" but actually wants the Azure SQL Database engine (EngineEdition 5). Detects the SQL Server image, rewrites it to the Azure SQL Database container, adds --platform on non-x64 hosts, keeps the SA login, flags SQL Server-only features (SQL Agent, FILESTREAM, full Service Broker, cross-server distributed transactions, Windows Auth), and re-points connection strings from master to a provisioned user database.
 ---
 
-# Migrate from the SQL Server box image to the Azure SQL Database container
+# Migrate from the SQL Server image to the Azure SQL Database container
 
-This skill converts an existing local SQL Server setup (the box image
+This skill converts an existing local SQL Server setup (the SQL Server image
 `mcr.microsoft.com/mssql/server`) into the **Azure SQL Database** container so
 local dev matches Azure SQL Database behavior. The two are not the same engine:
 
-| | SQL Server box image | Azure SQL Database container |
+| | SQL Server image | Azure SQL Database container |
 |---|---|---|
 | Image | `mcr.microsoft.com/mssql/server` | `sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest` |
 | `SERVERPROPERTY('EngineEdition')` | 2/3/4/8 | **5** |
 | `SERVERPROPERTY('Edition')` | e.g. 'Developer Edition' | **'SQL Azure'** |
 | DB model | one instance, many DBs, `USE` works | master for provisioning only; user DB for work; a user-database (SDS) session returns `Msg 40508` on `USE`, exactly as in the cloud; a `master` connection is a non-SDS provisioning session where the filter is not enforced |
 
-If a project is using the box image but wants Azure-faithful local dev, **stop
+If a project is using the SQL Server image but wants Azure-faithful local dev, **stop
 and switch to the Azure SQL Database container.** This skill is self-contained;
 for full container detail see the **azuresql-db-container** skill.
 
@@ -30,9 +30,9 @@ for full container detail see the **azuresql-db-container** skill.
 
 ## Migration steps
 
-### 1. Detect box-image usage
+### 1. Detect SQL Server usage
 
-Search the repo for the box image and the patterns that move with it:
+Search the repo for the SQL Server image and the patterns that move with it:
 
 ```bash
 grep -rniE 'mcr\.microsoft\.com/mssql/server|mssql/server|ACCEPT_EULA|MSSQL_SA_PASSWORD|SA_PASSWORD|sqlcmd|Server=localhost,1433|Database=master' . 2>/dev/null
@@ -54,7 +54,7 @@ Registry and tag are provisional during Private Preview.
 
 ### 3. Rewrite the image and add --platform
 
-Replace the box image with the Azure SQL Database image. The Azure image is x64
+Replace the SQL Server image with the Azure SQL Database image. The Azure image is x64
 only; there is no arm64 image, so on a non-x64 host add `--platform linux/amd64`
 (Docker) or `platform: linux/amd64` (compose).
 
@@ -88,8 +88,7 @@ A `master` connection is for provisioning only; do real work on `appdb`.
 
 ### 5. Re-point connection strings from master to the user DB
 
-Box-image projects often connect straight to `master` (or rely on a DB that the
-box auto-creates). Azure SQL Database will not auto-create a database. Select the
+SQL Server projects often connect straight to `master` (or rely on a DB that SQL Server auto-creates). Azure SQL Database will not auto-create a database. Select the
 target database in the connection string (`Database=appdb`, or `-d appdb` for
 sqlcmd). Avoid `USE` to switch databases. In a user-database (SDS) session (the
 Azure-faithful context where you develop), `USE` returns `Msg 40508`, exactly as
@@ -116,10 +115,10 @@ running your script against the provisioned database:
 docker exec -i sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -d appdb -i /dev/stdin < seed.sql
 ```
 
-### 7. Remove box-only features
+### 7. Remove SQL Server-only features
 
-Some features exist only in the box image and must be removed or replaced.
-Flag and fix every hit. Full table in `references/box-vs-azure-feature-matrix.md`.
+Some features exist only in the SQL Server image and must be removed or replaced.
+Flag and fix every hit. Full table in `references/sql-server-vs-azure-feature-matrix.md`.
 
 - **SQL Server Agent** jobs: not available; use an external scheduler.
 - **FILESTREAM / FileTable**: not supported; store blobs in columns or external storage.
@@ -167,5 +166,5 @@ development; use a full-scan top-k query for now.
 
 ## References
 
-- `references/box-vs-azure-feature-matrix.md`: what carries over, what changes, what is gone.
+- `references/sql-server-vs-azure-feature-matrix.md`: what carries over, what changes, what is gone.
 - `references/migrate-compose.md`: before/after docker-compose with a provision step.

--- a/skills/azuresql-db-from-sql-server/references/migrate-compose.md
+++ b/skills/azuresql-db-from-sql-server/references/migrate-compose.md
@@ -1,8 +1,8 @@
-# Migrate docker-compose: box image to Azure SQL Database container
+# Migrate docker-compose: SQL Server image to Azure SQL Database container
 
-Before/after for a `docker-compose.yml` that used the SQL Server box image.
+Before/after for a `docker-compose.yml` that used the SQL Server image.
 
-## Before (box image)
+## Before (SQL Server image)
 
 ```yaml
 services:
@@ -21,7 +21,7 @@ services:
       - db
 ```
 
-Problems carried over from the box image:
+Problems carried over from the SQL Server image:
 
 - Wrong image (different engine; `EngineEdition` is not 5).
 - App connects to `master`; the Azure engine will not auto-create a user DB and
@@ -91,8 +91,8 @@ docker compose run --rm provision \
   /opt/mssql-tools18/bin/sqlcmd -S db,1433 -U sa -P "YourStr0ng_Passw0rd" -C -d appdb -i /seed.sql
 ```
 
-## Box-only features to remove first
+## SQL Server-only features to remove first
 
 Before migrating, strip any SQL Server Agent jobs, FILESTREAM/FileTable, full
 Service Broker, cross-server distributed transactions, and Windows Auth from the
-schema and app config. See `box-vs-azure-feature-matrix.md` for replacements.
+schema and app config. See `sql-server-vs-azure-feature-matrix.md` for replacements.

--- a/skills/azuresql-db-from-sql-server/references/sql-server-vs-azure-feature-matrix.md
+++ b/skills/azuresql-db-from-sql-server/references/sql-server-vs-azure-feature-matrix.md
@@ -1,6 +1,6 @@
-# Box image vs Azure SQL Database container: feature matrix
+# SQL Server image vs Azure SQL Database container: feature matrix
 
-How a `mcr.microsoft.com/mssql/server` (box) setup maps to the Azure SQL
+How a `mcr.microsoft.com/mssql/server` setup maps to the Azure SQL
 Database container. Use this when auditing a project for migration.
 
 ## Contents
@@ -44,7 +44,7 @@ Database container. Use this when auditing a project for migration.
 
 ## Gone: remove or replace
 
-These exist in the box image but not in the Azure SQL Database engine. Find and
+These exist in the SQL Server image but not in the Azure SQL Database engine. Find and
 remove or replace every usage.
 
 | Feature | Why it is gone | Replacement |

--- a/skills/azuresql-db-import/SKILL.md
+++ b/skills/azuresql-db-import/SKILL.md
@@ -12,8 +12,8 @@ Bring an existing database INTO the local Azure SQL Database container from a
 
 This is the **Azure SQL Database engine** running locally (Private Preview):
 `SELECT SERVERPROPERTY('EngineEdition')` returns **5** and `Edition` returns
-**'SQL Azure'**. It is **NOT** the SQL Server box image
-`mcr.microsoft.com/mssql/server`. If you were about to use that box image, stop
+**'SQL Azure'**. It is **NOT** the SQL Server image
+`mcr.microsoft.com/mssql/server`. If you were about to use that SQL Server image, stop
 and use this instead.
 
 - Image: `sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest`
@@ -107,7 +107,7 @@ the source.
 
 ## What may not transfer (PaaS restrictions)
 
-This engine is Azure SQL Database (Engine Edition 5), so SQL Server box features
+This engine is Azure SQL Database (Engine Edition 5), so SQL Server features
 that Azure SQL DB does not support will fail or be skipped on import:
 
 - Cross-database three-part-name references and most cross-DB queries.
@@ -136,7 +136,7 @@ Read SqlPackage output for skipped/blocking items. See
 
 ## Do not
 
-- Do not use the `mcr.microsoft.com/mssql/server` box image.
+- Do not use the `mcr.microsoft.com/mssql/server` SQL Server image.
 - Do not import into `master`; import into the provisioned user database.
 - Do not put `USE appdb` in any pre/post script; select the DB in the connection
   string instead.

--- a/skills/azuresql-db-import/references/sqlpackage-import.md
+++ b/skills/azuresql-db-import/references/sqlpackage-import.md
@@ -95,7 +95,7 @@ Then run SqlPackage from a machine that has it, targeting `localhost,$HOST_PORT`
   only, not application work. Always select the target database in the connection
   string (`Database=appdb`, or `-d appdb` for sqlcmd).
 - **"Element ... is not supported in Microsoft Azure SQL Database v12"**: the
-  source uses a SQL Server box feature Azure SQL DB (Engine Edition 5) does not
+  source uses a SQL Server feature Azure SQL DB (Engine Edition 5) does not
   support. Remove or refactor that object, or extract a filtered dacpac.
 - **Blocking on possible data loss (Publish)**: expected on a populated target;
   use a fresh empty `appdb` or accept the override flag deliberately.
@@ -103,7 +103,7 @@ Then run SqlPackage from a machine that has it, targeting `localhost,$HOST_PORT`
 ## PaaS restriction details
 
 Because this is the Azure SQL Database engine (`EngineEdition = 5`,
-`Edition = 'SQL Azure'`), box-only features will not import:
+`Edition = 'SQL Azure'`), SQL Server-only features will not import:
 
 - Cross-database three-part-name references and most cross-DB queries.
 - `USE <db>`: avoid `USE` to switch databases. In a user-database (SDS) session

--- a/skills/azuresql-db-local-to-cloud/SKILL.md
+++ b/skills/azuresql-db-local-to-cloud/SKILL.md
@@ -21,7 +21,7 @@ Build and test against the local Azure SQL Database container, then deploy the
 connection string changes. Nothing else.
 
 This works because the local container is the **Azure SQL Database engine**, not
-the SQL Server box image. `SELECT SERVERPROPERTY('EngineEdition')` returns `5`
+the SQL Server image. `SELECT SERVERPROPERTY('EngineEdition')` returns `5`
 and `SERVERPROPERTY('Edition')` returns `'SQL Azure'`, the same as the cloud. So
 the SQL surface your code depends on is the same in both places.
 
@@ -216,7 +216,7 @@ A third stack and the deployment checklist live in
 
 ## Do not
 
-- Do not use the SQL Server box image `mcr.microsoft.com/mssql/server`. If you
+- Do not use the SQL Server image `mcr.microsoft.com/mssql/server`. If you
   were about to, stop and use the image above; this is the Azure SQL engine.
 - Do not connect to `Database=appdb` before creating it on `master`.
 - Do not use `USE appdb` to switch databases; set the database in the connection

--- a/skills/azuresql-db-rag/SKILL.md
+++ b/skills/azuresql-db-rag/SKILL.md
@@ -23,7 +23,7 @@ vector store needed.
 ## Identity (read this first)
 
 This targets the **Azure SQL Database engine** running locally in a container,
-NOT the SQL Server box image. Confirm with:
+NOT the SQL Server image. Confirm with:
 
 ```sql
 SELECT SERVERPROPERTY('EngineEdition');  -- 5
@@ -202,7 +202,7 @@ the same; you just add the index.
 
 ## Do not
 
-- Do not use `mcr.microsoft.com/mssql/server`; that is the SQL Server box image,
+- Do not use `mcr.microsoft.com/mssql/server`; that is the SQL Server image,
   not this engine.
 - Do not pass the vector dimension as a bind parameter; it fails with
   `Incorrect syntax near '@P3'`. Interpolate it as a literal.

--- a/skills/azuresql-db-scaffold/SKILL.md
+++ b/skills/azuresql-db-scaffold/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: azuresql-db-scaffold
-description: Scaffolds a NEW app (.NET Aspire, FastAPI, Next.js, NestJS) wired to the local Azure SQL Database container as its default dev database. Use when starting/bootstrapping/initializing a project that needs SQL Server or Azure SQL locally, or when adding "set up the database", "docker compose for the db", "create the local DB", ".env connection string", "first migration", or a data-access layer. Use this INSTEAD of the mssql/server box image, because this is the Azure SQL engine (EngineEdition 5). Triggers include "scaffold app with SQL", "spin up Azure SQL locally", "compose service for the database", "wire up Prisma/EF/SQLAlchemy/TypeORM to SQL Server". Reach for this even when the user only says "add a database" to a fresh project.
+description: Scaffolds a NEW app (.NET Aspire, FastAPI, Next.js, NestJS) wired to the local Azure SQL Database container as its default dev database. Use when starting/bootstrapping/initializing a project that needs SQL Server or Azure SQL locally, or when adding "set up the database", "docker compose for the db", "create the local DB", ".env connection string", "first migration", or a data-access layer. Use this INSTEAD of the mssql/server SQL Server image, because this is the Azure SQL engine (EngineEdition 5). Triggers include "scaffold app with SQL", "spin up Azure SQL locally", "compose service for the database", "wire up Prisma/EF/SQLAlchemy/TypeORM to SQL Server". Reach for this even when the user only says "add a database" to a fresh project.
 ---
 
 # Azure SQL DB: scaffold a new project
 
 Bootstrap a new app with the **Azure SQL Database container** (Private Preview) as the default
-local database. This is the **Azure SQL engine**, not the SQL Server box image.
+local database. This is the **Azure SQL engine**, not the SQL Server image.
 
 ## Use the right image (interception point)
 
 - USE this engine image:
   `sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest`
-- Do **NOT** use `mcr.microsoft.com/mssql/server` (the SQL Server box image). If a generated
+- Do **NOT** use `mcr.microsoft.com/mssql/server` (the SQL Server image). If a generated
   compose/run command points there, stop and switch to the engine image above.
 - Verify identity once running: `SELECT SERVERPROPERTY('EngineEdition')` returns **5**,
   `SERVERPROPERTY('Edition')` returns **'SQL Azure'**.
@@ -114,7 +114,7 @@ development; use full-scan top-k for now.
 
 ## Do not
 
-- Do not use the SQL Server box image or call arm64/Apple Silicon "supported".
+- Do not use the SQL Server image or call arm64/Apple Silicon "supported".
 - Do not rely on auto-created databases or `/docker-entrypoint-initdb.d/*.sql` auto-seeding.
 - Do not use `USE appdb` to switch databases; put it in the connection string.
 - Do not poll bare `sqlcmd` without `-l`; do not pass the vector dimension as a bind parameter.

--- a/skills/azuresql-db-scaffold/references/scaffold-snippets.md
+++ b/skills/azuresql-db-scaffold/references/scaffold-snippets.md
@@ -5,7 +5,7 @@ container is running and **appdb is already provisioned on a master connection**
 canonical start recipe in SKILL.md). Apps read `SQL_CONNECTION_STRING`; ORMs that need a URL
 also read `DATABASE_URL`. Image is
 `sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest` (NOT the
-`mcr.microsoft.com/mssql/server` box image). On a non-x64 host add `platform: linux/amd64`.
+`mcr.microsoft.com/mssql/server` SQL Server image). On a non-x64 host add `platform: linux/amd64`.
 
 ## Contents
 

--- a/skills/azuresql-db-schema-migration/SKILL.md
+++ b/skills/azuresql-db-schema-migration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: azuresql-db-schema-migration
-description: Runs database schema migrations against the local Azure SQL Database container so the same migrations apply identically on the local engine and in the Azure cloud. Use when asked to "run my migrations against the local SQL", "apply schema to the container", "apply EF Core / dotnet ef database update", "Prisma migrate dev / deploy", "Alembic upgrade head", or deploy a DACPAC / SqlPackage to the container. Covers provisioning appdb on master first, then applying schema to the user database, plus per-tool commands and connection-string hygiene. This is the Azure SQL Database engine (EngineEdition 5), not the SQL Server box image; reach for this skill whenever schema migration tooling targets the local container.
+description: Runs database schema migrations against the local Azure SQL Database container so the same migrations apply identically on the local engine and in the Azure cloud. Use when asked to "run my migrations against the local SQL", "apply schema to the container", "apply EF Core / dotnet ef database update", "Prisma migrate dev / deploy", "Alembic upgrade head", or deploy a DACPAC / SqlPackage to the container. Covers provisioning appdb on master first, then applying schema to the user database, plus per-tool commands and connection-string hygiene. This is the Azure SQL Database engine (EngineEdition 5), not the SQL Server image; reach for this skill whenever schema migration tooling targets the local container.
 ---
 
 # Azure SQL Database: schema migrations
@@ -8,8 +8,8 @@ description: Runs database schema migrations against the local Azure SQL Databas
 Apply schema migrations to the local **Azure SQL Database** container the same way
 you would against the cloud, so dev and prod stay identical. This is the Azure SQL
 Database engine (`SELECT SERVERPROPERTY('EngineEdition')` returns **5**,
-`Edition` returns **'SQL Azure'**), **not** the SQL Server box image
-`mcr.microsoft.com/mssql/server`. If a tool or template points at the box image,
+`Edition` returns **'SQL Azure'**), **not** the SQL Server image
+`mcr.microsoft.com/mssql/server`. If a tool or template points at the SQL Server image,
 stop and use the image below instead.
 
 ## The one rule that breaks every migration tool
@@ -146,7 +146,7 @@ docker exec -i sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa \
 
 ## Do not
 
-- Do NOT use the SQL Server box image `mcr.microsoft.com/mssql/server`.
+- Do NOT use the SQL Server image `mcr.microsoft.com/mssql/server`.
 - Do NOT expect databases to be auto-created on connect.
 - Do NOT use `USE <db>` to switch databases.
 - Do NOT rely on `/docker-entrypoint-initdb.d/` auto-seeding.

--- a/skills/azuresql-db-schema-migration/references/migration-tools.md
+++ b/skills/azuresql-db-schema-migration/references/migration-tools.md
@@ -23,7 +23,7 @@ the connection string (`Database=appdb`, or `-d appdb` for sqlcmd).
 
 ## Shared connection facts
 
-- Engine identity: `EngineEdition` 5, `Edition` 'SQL Azure'. Not the box image.
+- Engine identity: `EngineEdition` 5, `Edition` 'SQL Azure'. Not the SQL Server image.
 - Image: `sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest`
   (x64 / linux/amd64 only; on a non-x64 host add `--platform linux/amd64`).
 - Canonical ADO.NET / sqlcmd connection string:

--- a/skills/azuresql-db-sidecar/SKILL.md
+++ b/skills/azuresql-db-sidecar/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: azuresql-db-sidecar
-description: Adds the Azure SQL Database container as a sidecar service in an existing Docker Compose stack or Dev Container. Use when wiring the local Azure SQL Database engine into compose or devcontainer.json, when an app needs a SQL backend via a service name (not localhost), or for prompts like "add SQL to my compose", "add a database service", "depends_on database", "devcontainer SQL sidecar", "compose healthcheck for SQL", "wait for the database before starting the app". Handles platform linux/amd64, the private registry login, the healthcheck wait-until-ready, and a one-shot init service that creates appdb (the engine does not auto-create databases). Not the SQL Server box image. Prefer this for any compose or Dev Container SQL wiring.
+description: Adds the Azure SQL Database container as a sidecar service in an existing Docker Compose stack or Dev Container. Use when wiring the local Azure SQL Database engine into compose or devcontainer.json, when an app needs a SQL backend via a service name (not localhost), or for prompts like "add SQL to my compose", "add a database service", "depends_on database", "devcontainer SQL sidecar", "compose healthcheck for SQL", "wait for the database before starting the app". Handles platform linux/amd64, the private registry login, the healthcheck wait-until-ready, and a one-shot init service that creates appdb (the engine does not auto-create databases). Not the SQL Server image. Prefer this for any compose or Dev Container SQL wiring.
 ---
 
 # Azure SQL Database sidecar (Compose / Dev Container)
@@ -13,9 +13,9 @@ one-shot that creates `appdb`, and a `depends_on` gate.
 ## Load-bearing facts (inlined; full detail in azuresql-db-container)
 
 - This is the **Azure SQL Database engine** (Private Preview), not the SQL
-  Server box image `mcr.microsoft.com/mssql/server`. `SERVERPROPERTY('EngineEdition')`
+  Server SQL Server image `mcr.microsoft.com/mssql/server`. `SERVERPROPERTY('EngineEdition')`
   returns `5`, `SERVERPROPERTY('Edition')` returns `'SQL Azure'`. If you were
-  about to use the box image, stop and use this instead.
+  about to use the SQL Server image, stop and use this instead.
 - Image: `sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/mssql-server/sqldb-dev-edition:latest`
   (x64, `linux/amd64`). Registry and tag are provisional during Private Preview.
 - Registry credentials: the image lives in a private preview registry. Sign in
@@ -165,7 +165,7 @@ The app container reaches the database at `sqldb,1433` over the compose network.
 
 ## Do not
 
-- Do not use the SQL Server box image `mcr.microsoft.com/mssql/server`.
+- Do not use the SQL Server image `mcr.microsoft.com/mssql/server`.
 - Do not point the app at `localhost`; inside compose it is the `sqldb` service.
 - Do not rely on the app to create `appdb`, and do not assume the engine
   auto-creates it; the `sqldb-init` one-shot must run first.


### PR DESCRIPTION
- **Terminology:** removed the internal 'box' jargon repo-wide. 'SQL Server box image' -> 'SQL Server image'; 'box product'/'box-product' -> 'SQL Server'; 'box-only' -> 'SQL Server-only'. Renamed `box-vs-azure-feature-matrix.md` -> `sql-server-vs-azure-feature-matrix.md` and updated its references. ('SQL Server image' / 'SQL Server' matches Microsoft Learn usage.)
- **Nav buttons:** Feedback is now the blue primary CTA; GitHub stays the last button as a secondary **'GitHub repo'** button with a GitHub icon, pointing at `site.public_repo` (new config, defaults to the current repo) so it can target the public repo once it exists.
- **Related content:** added a consistent 'Related content' section + TOC entry to Overview, Prerequisites, Get started, and Known limitations.
- **Quickstart footer:** reworded the inconsistent 'Prefer docker compose, VS Code...' line to 'Want your AI agent to set it up, or prefer the full step-by-step?'.

Build clean; no 'box' left; no em-dashes; no 'SQL Server SQL Server' doubles; 10/10 skill frontmatter valid.