### PR TITLE
Point the footer GitHub Discussions link at the public repo

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -23,7 +23,7 @@
       <a href="{{ '/feedback-and-how-to-engage.html' | relative_url }}">Feedback and how to engage</a>
       <a href="https://aka.ms/azuresql-container-meet" rel="noopener">Connect with the team</a>
       <a href="mailto:azuresqldb-container@microsoft.com">Email the team</a>
-      <a href="{{ site.repo }}/discussions" rel="noopener">GitHub Discussions</a>
+      <a href="{{ site.public_repo }}/discussions" rel="noopener">GitHub Discussions</a>
       <a href="https://aka.ms/azuresqldb-container-bug" rel="noopener">Report a bug</a>
     </div>
   </div>


### PR DESCRIPTION
The footer is a single shared include (`footer.html`) used by both layouts, so it already renders byte-identically on every page (verified by hashing the rendered `<footer>` across all 7 pages). The only inconsistency was the GitHub Discussions link still using the private `site.repo` while the nav now uses `site.public_repo`; aligned it.