### PR TITLE
Remove arm64 / Apple Silicon naming from docs and skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ The Azure SQL Database container is the Azure SQL Database engine, running local
 
 These drift easily; keep them aligned everywhere when you edit:
 
-- **x64 only.** The image is x64 (`linux/amd64`); there is no arm64 image. Do not present arm64 / Apple Silicon as a supported host, and do not use runtime brand names (Apple Container, Rosetta, Docker Desktop). The only platform note is: "on a non-x64 host, add `--platform linux/amd64`."
+- **x64 only.** The image is x64 (`linux/amd64`). Do not present a non-x64 host as a supported platform, and do not use runtime brand names (Apple Container, Rosetta, Docker Desktop). The only platform note is: "on a non-x64 host, add `--platform linux/amd64`."
 - **The engine does not auto-create databases.** Provision `appdb` on a `master` connection before connecting to it. In a user-database (SDS) session USE returns Msg 40508 (Azure-faithful); a master connection is a non-SDS provisioning session where USE is not blocked. Select the database in the connection string and develop in the user database.
 - **Registry / image:** `sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest`. Registry, tag, and credentials are provisional during Private Preview.
 - **Do not advertise things that do not exist** (no empty sample folders, no unbuilt skill collections).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -73,7 +73,7 @@ docker run --name sqldb -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStr0ng_Pass
     -p 1433:1433 -d sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest
 ```
 
-On Apple Silicon or any other non-x64 host, copy this version instead. It adds `--platform linux/amd64` so the x64 image runs under emulation:
+On a non-x64 host, copy this version instead. It adds `--platform linux/amd64` so the x64 image runs under emulation:
 
 ```bash
 docker run --platform linux/amd64 --name sqldb -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd" \

--- a/docs/index.html
+++ b/docs/index.html
@@ -284,7 +284,7 @@ title: Azure SQL Database container
       </a>
       <a class="skill-card" href="{{ site.repo }}/tree/main/skills/azuresql-db-faq" rel="noopener">
         <h4>Answer questions <span class="arrow">&rarr;</span></h4>
-        <p>What the container can and can't do, and why it differs from the cloud: backups, <code>USE</code>, vector index, arm64, tooling.</p>
+        <p>What the container can and can't do, and why it differs from the cloud: backups, <code>USE</code>, vector index, x64-only, tooling.</p>
       </a>
     </div>
   </div>

--- a/docs/prompts/ai-rag.md
+++ b/docs/prompts/ai-rag.md
@@ -19,7 +19,7 @@ Read the entire instruction set before executing.
 ```bash
 # The image is in a private preview registry; sign in with the credentials provided when you sign up at https://aka.ms/sqldbcontainerpreview-signup (pull-only; may be rotated during the preview) first
 docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io
-# The image is x64-only; on a non-x64 host (Apple Silicon) this adds --platform linux/amd64 to run it under emulation.
+# The image is x64-only; on a non-x64 host this adds --platform linux/amd64 to run it under emulation.
 PLATFORM=(); case "$(docker info -f '{{.Architecture}}' 2>/dev/null)" in x86_64|amd64) ;; *) PLATFORM=(--platform linux/amd64);; esac
 docker run --name sqldb "${PLATFORM[@]}" -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd" \
     -p 1433:1433 -d sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest

--- a/docs/prompts/from-sql-server.md
+++ b/docs/prompts/from-sql-server.md
@@ -86,6 +86,6 @@ Expect `EngineEdition = 5` and `Edition = SQL Azure`. The SQL Server image retur
 
 ## Do not
 
-- Do not keep the SQL Server image or call arm64 / Apple Silicon "supported".
+- Do not keep the SQL Server image or call a non-x64 host "supported".
 - Do not develop against `master`; do real work on the user database.
 - Do not commit the SA password or the registry credentials.

--- a/docs/prompts/local-to-cloud.md
+++ b/docs/prompts/local-to-cloud.md
@@ -23,7 +23,7 @@ Run the container locally on port 1433 with a strong SA password. Set `ACCEPT_EU
 ```bash
 # The image is in a private preview registry; sign in with the credentials provided when you sign up at https://aka.ms/sqldbcontainerpreview-signup (pull-only; may be rotated during the preview) first
 docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io
-# The image is x64-only; on a non-x64 host (Apple Silicon) this adds --platform linux/amd64 to run it under emulation.
+# The image is x64-only; on a non-x64 host this adds --platform linux/amd64 to run it under emulation.
 PLATFORM=(); case "$(docker info -f '{{.Architecture}}' 2>/dev/null)" in x86_64|amd64) ;; *) PLATFORM=(--platform linux/amd64);; esac
 docker run --name sqldb "${PLATFORM[@]}" -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd" \
     -p 1433:1433 -d sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest

--- a/docs/prompts/offline.md
+++ b/docs/prompts/offline.md
@@ -21,7 +21,7 @@ services:
   sqldb:
     image: sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest
     # The image is x64-only. platform: linux/amd64 pins it so it runs on a non-x64 host
-    # (Apple Silicon) under emulation; on an x64 host it is a no-op.
+    # under emulation; on an x64 host it is a no-op.
     platform: linux/amd64
     container_name: sqldb
     environment:

--- a/docs/prompts/sidecar.md
+++ b/docs/prompts/sidecar.md
@@ -31,7 +31,7 @@ services:
 
   sqldb:
     image: sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest
-    # x64-only image; platform: linux/amd64 lets it run on a non-x64 host (Apple Silicon), no-op on x64.
+    # x64-only image; platform: linux/amd64 lets it run on a non-x64 host, no-op on x64.
     platform: linux/amd64
     environment:
       MSSQL_SA_PASSWORD: "YourStr0ng_Passw0rd"

--- a/docs/prompts/templates.md
+++ b/docs/prompts/templates.md
@@ -28,7 +28,7 @@ Add a `docker-compose.yml` with the container so the database starts with one co
 services:
   sqldb:
     image: sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest
-    # x64-only image; platform: linux/amd64 lets it run on a non-x64 host (Apple Silicon), no-op on x64.
+    # x64-only image; platform: linux/amd64 lets it run on a non-x64 host, no-op on x64.
     platform: linux/amd64
     environment:
       MSSQL_SA_PASSWORD: "YourStr0ng_Passw0rd"

--- a/skills/README.md
+++ b/skills/README.md
@@ -28,7 +28,7 @@ EngineEdition `5` and Edition `'SQL Azure'` are the cloud engine's fingerprint. 
 | **azuresql-db-ci** | Run the engine in continuous integration: ephemeral container, ready-wait, provision, seed, test, tear down. Fails closed on the wrong image. |
 | **azuresql-db-sidecar** | Run the engine as a sidecar alongside an app (compose-style), with `platform: linux/amd64` on non-x64 hosts and a single `SQL_CONNECTION_STRING` contract. |
 | **azuresql-db-scaffold** | Scaffold a new app wired to the engine: connection string via one `SQL_CONNECTION_STRING` env var, provisioning step, and seed step in the correct order. |
-| **azuresql-db-faq** | Answer questions about what the container can and cannot do, and why it differs from the cloud (backups, `USE`, vector index, arm64, GUI tooling, registry). Sorts each into engine vs. managed-service vs. SQL Server, and links the live Known limitations. |
+| **azuresql-db-faq** | Answer questions about what the container can and cannot do, and why it differs from the cloud (backups, `USE`, vector index, GUI tooling, registry). Sorts each into engine vs. managed-service vs. SQL Server, and links the live Known limitations. |
 
 ---
 
@@ -83,7 +83,7 @@ Every skill in this collection holds these facts true. If a generated workflow c
 
 ### Platform
 
-The image is x64 only; there is no arm64 image. On a non-x64 host, add `--platform linux/amd64` (Docker) or `platform: linux/amd64` (compose) to run it under x64 emulation.
+The image is x64 only. On a non-x64 host, add `--platform linux/amd64` (Docker) or `platform: linux/amd64` (compose) to run it under x64 emulation.
 
 ### Connection model (three facts that bite)
 

--- a/skills/azuresql-db-ci/SKILL.md
+++ b/skills/azuresql-db-ci/SKILL.md
@@ -18,7 +18,7 @@ For full container detail (readiness loop, connection model, vectors, seeding), 
 - **Image:** `sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest`
   (x64, linux/amd64). It lives in a private preview registry; the runner must sign in with
   `ACR_USERNAME` / `ACR_PASSWORD` secrets. Registry and tag are provisional during Private Preview.
-- **Platform:** the image is x64 only; there is no arm64 image. CI hosted runners are x64, so no
+- **Platform:** the image is x64 only. CI hosted runners are x64, so no
   `--platform` flag is needed there. On a non-x64 self-hosted runner, add `--platform linux/amd64`.
 - **Required env:** `ACCEPT_EULA=Y` and a complex `MSSQL_SA_PASSWORD` (8+ chars, upper/lower/digit/
   symbol), kept in a secret. Engine listens on 1433.
@@ -173,4 +173,4 @@ echo "ready on localhost,$HOST_PORT"
 - Do not run tests against master; master is for provisioning only.
 - Do not rely on `/docker-entrypoint-initdb.d/*.sql`; it is not honored. Seed with `sqlcmd -d appdb -i`.
 - Do not require sqlcmd on the runner; the health check and provisioning run inside the container.
-- Do not call arm64 "supported"; on a non-x64 self-hosted runner just add `--platform linux/amd64`.
+- Do not call a non-x64 host "supported"; on a non-x64 self-hosted runner just add `--platform linux/amd64`.

--- a/skills/azuresql-db-container/references/image-and-registry.md
+++ b/skills/azuresql-db-container/references/image-and-registry.md
@@ -11,7 +11,7 @@ sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest
 
 - This is the **Azure SQL Database engine** (Private Preview), EngineEdition 5,
   Edition `'SQL Azure'`.
-- It is **x64 only** (`linux/amd64`). There is no arm64 image. On a non-x64
+- It is **x64 only** (`linux/amd64`). On a non-x64
   host, run under emulation by adding `--platform linux/amd64`.
 - The registry host and tag are **provisional during Private Preview** and may
   change. Treat this file as the place to update if they do.
@@ -65,5 +65,5 @@ docker pull --platform linux/amd64 \
 ## Do not
 
 - Do not use `mcr.microsoft.com/mssql/server`.
-- Do not look for an arm64 tag; there is not one.
+- The image ships a single x64 (`linux/amd64`) build; there is no other tag.
 - Do not hardcode the registry host in many places; reference this file.

--- a/skills/azuresql-db-faq/SKILL.md
+++ b/skills/azuresql-db-faq/SKILL.md
@@ -46,7 +46,7 @@ managed cloud service, and it is not the SQL Server. Sort almost any
 - **"Can I take a backup?"** No: `BACKUP DATABASE` and `RESTORE DATABASE` return **Msg 40510 ("not supported in this version")** on the container, in every session. Azure SQL Database in the cloud likewise does not support them, because backups there are managed by the platform (not run with the `BACKUP` statement). For local data persistence, use a Docker named volume (`-v sqldb-data:/var/opt/mssql`); for managed backups, point-in-time restore, or geo-replication, use Azure SQL Database in the cloud.
 - **"Why does `USE otherdb` fail with Msg 40508?"** Because a connection to a user database is an Azure-faithful (SDS) session that enforces the same restriction as Azure SQL Database in the cloud. Select the database in the connection string (`Database=appdb`), do not switch with `USE`. (`USE` "works" only on a `master` connection, which is a non-SDS provisioning session.)
 - **"Why does connecting fail until I create the database?"** The engine does **not** auto-create databases on connect. Provision once on a `master` connection (`CREATE DATABASE appdb`), then connect with `Database=appdb`.
-- **"Is Apple Silicon / arm64 supported?"** The image is x64 only. On a non-x64 host it runs under emulation by adding `--platform linux/amd64` (Docker) or `platform: linux/amd64` (compose). Treat arm64 as "runs under emulation", not "supported".
+- **"Is a non-x64 host supported?"** The image is x64 only. On a non-x64 host it runs under emulation by adding `--platform linux/amd64` (Docker) or `platform: linux/amd64` (compose). Treat that as "runs under emulation", not "supported".
 - **"Why can't I `CREATE VECTOR INDEX`?"** That DDL is still in development. The `VECTOR` type and `VECTOR_DISTANCE` work today; use a full-scan top-k query for now (fine for prototype-sized corpora).
 - **"Why does SSMS / the MSSQL extension throw errors?"** Graphical tooling is not yet 100% compatible; it is being fixed. Use `sqlcmd` or a driver, which work today. The MSSQL extension's GitHub Copilot integration also works (https://aka.ms/vscode-mssql-copilot-docs).
 - **"Why isn't the image on Docker Hub / MCR?"** This is a container-only Private Preview; the image is in a private registry with shared pull-only credentials provided when you sign up for the Private Preview at https://aka.ms/sqldbcontainerpreview-signup (they may rotate).
@@ -68,5 +68,5 @@ limitations list (kept in step with the docs) is in [references/limitations.md](
 
 - Never claim a managed-service feature (automated backup, PITR, geo-replication,
   elastic pools, portal management) exists on the container.
-- Never tell a user arm64/Apple Silicon is "supported"; it runs under emulation.
+- Never tell a user a non-x64 host is "supported"; it runs under emulation.
 - Never claim `BACKUP DATABASE` / `RESTORE DATABASE` work on the container; they return Msg 40510. (Azure SQL Database in the cloud likewise does not support them.) Use a Docker named volume for local persistence.

--- a/skills/azuresql-db-faq/references/faq.md
+++ b/skills/azuresql-db-faq/references/faq.md
@@ -60,7 +60,7 @@ first: `CAST(CAST(? AS NVARCHAR(MAX)) AS VECTOR(n))`, with `n` a literal dimensi
 
 ## Platform / image / access
 
-**Is Apple Silicon / arm64 supported?** The image is x64 only (`linux/amd64`). On a
+**Is a non-x64 host supported?** The image is x64 only (`linux/amd64`). On a
 non-x64 host it runs under emulation when you add `--platform linux/amd64` (Docker) or
 `platform: linux/amd64` (compose). Treat that as "runs under emulation", not "supported".
 

--- a/skills/azuresql-db-from-sql-server/SKILL.md
+++ b/skills/azuresql-db-from-sql-server/SKILL.md
@@ -55,7 +55,7 @@ Registry and tag are provisional during Private Preview.
 ### 3. Rewrite the image and add --platform
 
 Replace the SQL Server image with the Azure SQL Database image. The Azure image is x64
-only; there is no arm64 image, so on a non-x64 host add `--platform linux/amd64`
+only, so on a non-x64 host add `--platform linux/amd64`
 (Docker) or `platform: linux/amd64` (compose).
 
 - Old: `mcr.microsoft.com/mssql/server:2022-latest`
@@ -159,7 +159,7 @@ development; use a full-scan top-k query for now.
 - Do not keep `mcr.microsoft.com/mssql/server`; it is a different engine.
 - Do not rely on database auto-creation or on `/docker-entrypoint-initdb.d/*.sql`.
 - Do not use `USE appdb`; select the database in the connection string.
-- Do not call arm64 / Apple Silicon "supported"; just add `--platform linux/amd64` on non-x64 hosts.
+- Do not call a non-x64 host "supported"; just add `--platform linux/amd64` on non-x64 hosts.
 - Do not use `Uid=` / `Pwd=`; use `User Id=` / `Password=`.
 - Do not pass the vector dimension as a bind parameter.
 - Do not keep SQL Agent, FILESTREAM, full Service Broker, cross-server distributed transactions, or Windows Auth.

--- a/skills/azuresql-db-from-sql-server/references/migrate-compose.md
+++ b/skills/azuresql-db-from-sql-server/references/migrate-compose.md
@@ -70,7 +70,7 @@ services:
 1. **Image** rewritten to the Azure SQL Database container. Sign in first:
    `docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io`.
 2. **`platform: linux/amd64`** added (commented) for non-x64 hosts; the image is
-   x64 only and there is no arm64 image.
+   x64 only.
 3. **Healthcheck** uses `sqlcmd -C -b -l 2` so a SQL error sets the exit code and
    transient startup errors (e.g. `Msg 913`) are retried, not masked.
 4. **`provision` one-shot service** runs `CREATE DATABASE appdb` on a master

--- a/skills/azuresql-db-from-sql-server/references/sql-server-vs-azure-feature-matrix.md
+++ b/skills/azuresql-db-from-sql-server/references/sql-server-vs-azure-feature-matrix.md
@@ -19,7 +19,7 @@ Database container. Use this when auditing a project for migration.
 | Registry | public (mcr) | private preview; `docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io` first |
 | `EngineEdition` | 2/3/4/8 | 5 |
 | `Edition` | e.g. 'Developer Edition' | 'SQL Azure' |
-| Architecture | x64 and arm64 | x64 only; add `--platform linux/amd64` on non-x64 hosts |
+| Architecture | Multi-arch | x64 only; add `--platform linux/amd64` on non-x64 hosts |
 | Port | 1433 | 1433 |
 | Login | SA / SQL auth | SA / SQL auth (same) |
 

--- a/skills/azuresql-db-import/SKILL.md
+++ b/skills/azuresql-db-import/SKILL.md
@@ -142,7 +142,7 @@ Read SqlPackage output for skipped/blocking items. See
   string instead.
 - Do not rely on `/docker-entrypoint-initdb.d/*.sql` auto-seeding; it is NOT
   honored by this image.
-- Do not call arm64/Apple Silicon "supported"; just add `--platform linux/amd64`
+- Do not call a non-x64 host "supported"; just add `--platform linux/amd64`
   on a non-x64 host.
 - Do not treat a clean `docker run` as "ready"; provision inside the retry loop.
 

--- a/skills/azuresql-db-local-to-cloud/SKILL.md
+++ b/skills/azuresql-db-local-to-cloud/SKILL.md
@@ -231,5 +231,5 @@ A third stack and the deployment checklist live in
 - Do not put a password or secret in the cloud connection string; use Entra
   auth and let the driver fetch a token.
 - Do not branch app logic on environment; keep auth in configuration.
-- Do not call arm64 / Apple Silicon "supported"; on a non-x64 host just add
+- Do not call a non-x64 host "supported"; on a non-x64 host just add
   `--platform linux/amd64`.

--- a/skills/azuresql-db-rag/SKILL.md
+++ b/skills/azuresql-db-rag/SKILL.md
@@ -215,5 +215,5 @@ the same; you just add the index.
 - Do not rely on `CREATE VECTOR INDEX` yet; use full-scan top-k.
 - Do not expect `/docker-entrypoint-initdb.d/*.sql` to auto-run; seed by running
   `sqlcmd -d appdb -i seed.sql` after provisioning appdb.
-- Do not call arm64/Apple Silicon "supported"; just add `--platform linux/amd64`
+- Do not call a non-x64 host "supported"; just add `--platform linux/amd64`
   on a non-x64 host.

--- a/skills/azuresql-db-scaffold/SKILL.md
+++ b/skills/azuresql-db-scaffold/SKILL.md
@@ -114,7 +114,7 @@ development; use full-scan top-k for now.
 
 ## Do not
 
-- Do not use the SQL Server image or call arm64/Apple Silicon "supported".
+- Do not use the SQL Server image or call a non-x64 host "supported".
 - Do not rely on auto-created databases or `/docker-entrypoint-initdb.d/*.sql` auto-seeding.
 - Do not use `USE appdb` to switch databases; put it in the connection string.
 - Do not poll bare `sqlcmd` without `-l`; do not pass the vector dimension as a bind parameter.

--- a/skills/azuresql-db-schema-migration/SKILL.md
+++ b/skills/azuresql-db-schema-migration/SKILL.md
@@ -150,6 +150,6 @@ docker exec -i sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa \
 - Do NOT expect databases to be auto-created on connect.
 - Do NOT use `USE <db>` to switch databases.
 - Do NOT rely on `/docker-entrypoint-initdb.d/` auto-seeding.
-- Do NOT call arm64/Apple Silicon "supported"; just add `--platform linux/amd64` on a non-x64 host.
+- Do NOT call a non-x64 host "supported"; just add `--platform linux/amd64` on a non-x64 host.
 - Do NOT pass a vector dimension as a bind parameter.
 - Do NOT run migrations on a `master` connection.

--- a/skills/azuresql-db-sidecar/SKILL.md
+++ b/skills/azuresql-db-sidecar/SKILL.md
@@ -23,7 +23,7 @@ one-shot that creates `appdb`, and a `depends_on` gate.
   shared pull-only credentials provided when you sign up for the Private Preview
   at https://aka.ms/sqldbcontainerpreview-signup (they may rotate) before
   `docker compose up` or building the Dev Container.
-- Platform: x64 only; there is no arm64 image. The compose snippets below set
+- Platform: x64 only. The compose snippets below set
   `platform: linux/amd64` so the service starts on a non-x64 host.
 - Required env: `ACCEPT_EULA=Y` and a complex `MSSQL_SA_PASSWORD` (8+ chars,
   upper/lower/digit/symbol). Engine listens on 1433.
@@ -178,4 +178,4 @@ The app container reaches the database at `sqldb,1433` over the compose network.
   the connection string (`Database=appdb`, or `-d appdb` for sqlcmd).
 - Do not drop `--platform` / `platform: linux/amd64`; the image is x64 only.
 - Do not depend on `/docker-entrypoint-initdb.d/*.sql`; it is not honored here.
-- Do not call arm64/Apple Silicon "supported"; it runs under emulation only.
+- Do not call a non-x64 host "supported"; it runs under emulation only.


### PR DESCRIPTION
The image is amd64-only, so the docs no longer name specific non-x64 architectures.

- Removed all **arm64 / Apple Silicon** naming across docs (GitHub Pages + prompt snippets), skills, and `AGENTS.md` (24 files).
- **Kept the actionable how-to**: 'on a non-x64 host, add `--platform linux/amd64`' so users on non-x64 machines can still run it under emulation.
- **Left untouched:** `ARM` = **Azure Resource Manager** (Azure portal / CLI / ARM / Bicep / Terraform) — a different 'ARM'.
- Jekyll build verified clean; built HTML confirmed free of architecture-arm references.