### PR TITLE
Add public feedback form (bug/feature) for the Private Preview

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -13,6 +13,12 @@ repo: "https://github.com/microsoft/azure-sql-database-container"
 public_repo: "https://github.com/microsoft/azure-sql-database-container"
 youtube_id: "S6PWxUAUspY"
 
+# Feedback intake (feedback.html). Set these after deploying the Azure Function
+# (see the azuresqldb-feedback-intake folder). Leave blank until then — the form
+# shows a "not configured" message rather than failing silently.
+feedback_function_url: ""   # e.g. https://sqldbfback-func-xxxx.azurewebsites.net/api/feedback
+turnstile_sitekey: ""       # Cloudflare Turnstile site key (public)
+
 markdown: kramdown
 kramdown:
   input: GFM

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -16,7 +16,7 @@ youtube_id: "S6PWxUAUspY"
 # Feedback intake (feedback.html). Set these after deploying the Azure Function
 # (see the azuresqldb-feedback-intake folder). Leave blank until then — the form
 # shows a "not configured" message rather than failing silently.
-feedback_function_url: ""   # e.g. https://sqldbfback-func-xxxx.azurewebsites.net/api/feedback
+feedback_function_url: "https://sqldbfback-func-7qsfrn6fzaz5y.azurewebsites.net/api/feedback"
 turnstile_sitekey: ""       # Cloudflare Turnstile site key (public)
 
 markdown: kramdown

--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -510,6 +510,82 @@ section[id] { scroll-margin-top: 84px; }
   .hero-cta .btn { flex: 1; justify-content: center; }
 }
 
+/* feedback form (feedback.html) */
+#feedback-app { margin-top: 24px; }
+
+.btn-ghost {
+  background: var(--white);
+  color: var(--ink);
+  border: 1px solid var(--line);
+}
+.btn-ghost:hover { background: var(--mist); }
+
+.fb-tabs {
+  display: inline-flex;
+  gap: 4px;
+  padding: 4px;
+  background: var(--mist);
+  border-radius: 12px;
+  margin-bottom: 24px;
+}
+.fb-tab { position: relative; cursor: pointer; }
+.fb-tab input { position: absolute; opacity: 0; inset: 0; cursor: pointer; }
+.fb-tab span {
+  display: block;
+  padding: 8px 18px;
+  border-radius: 9px;
+  font-weight: 600;
+  font-size: .95rem;
+  color: var(--muted);
+}
+.fb-tab input:checked + span { background: var(--white); color: var(--ink); box-shadow: var(--shadow); }
+.fb-tab input:focus-visible + span { outline: 2px solid var(--azure); outline-offset: 2px; }
+
+.fb-group { border: 0; padding: 0; margin: 0; min-width: 0; }
+.fb-group.is-hidden { display: none; }
+
+.fb-field { display: block; margin-bottom: 18px; }
+.fb-label { display: block; font-weight: 600; color: var(--ink); margin-bottom: 6px; }
+.fb-label em { color: var(--azure); font-style: normal; }
+.fb-help { display: block; font-size: .85rem; color: var(--muted); margin-bottom: 8px; }
+
+.fb-field input[type="text"],
+.fb-field input[type="email"],
+.fb-field select,
+.fb-field textarea {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  font: inherit;
+  color: var(--text);
+  background: var(--white);
+}
+.fb-field textarea { resize: vertical; }
+.fb-field input:focus,
+.fb-field select:focus,
+.fb-field textarea:focus {
+  outline: none;
+  border-color: var(--azure);
+  box-shadow: 0 0 0 3px rgba(19,102,224,.15);
+}
+
+.fb-checkset { border: 1px solid var(--line); border-radius: 12px; padding: 14px 16px; margin: 0 0 18px; }
+.fb-checkset legend { padding: 0 6px; }
+
+.fb-check { display: flex; gap: 10px; align-items: flex-start; margin: 8px 0; font-size: .95rem; color: var(--text); }
+.fb-check input { margin-top: 3px; flex: 0 0 auto; }
+
+.fb-actions { display: flex; align-items: center; gap: 16px; flex-wrap: wrap; margin-top: 8px; }
+.fb-status { margin: 0; font-size: .9rem; color: var(--muted); }
+.fb-status.is-error { color: #b3261e; }
+
+.cf-turnstile { margin: 8px 0 18px; }
+
+.fb-success { border: 1px solid var(--line); border-radius: var(--radius); padding: 28px; background: var(--tint); }
+.fb-success h2 { margin-top: 0; }
+
 /* reduced motion */
 @media (prefers-reduced-motion: reduce) {
   html { scroll-behavior: auto; }

--- a/docs/assets/js/feedback.js
+++ b/docs/assets/js/feedback.js
@@ -1,0 +1,121 @@
+/* Feedback form: branch bug/feature, validate, POST to the Azure Function. */
+(function () {
+  "use strict";
+
+  var app = document.getElementById("feedback-app");
+  if (!app) return;
+  var fnUrl = (app.getAttribute("data-fn") || "").trim();
+
+  var form = document.getElementById("fb-form");
+  var submit = document.getElementById("fb-submit");
+  var status = document.getElementById("fb-status");
+  var success = document.getElementById("fb-success");
+  var successMsg = document.getElementById("fb-success-msg");
+  var again = document.getElementById("fb-again");
+  var groups = form.querySelectorAll(".fb-group");
+  var typeRadios = form.querySelectorAll('input[name="type"]');
+
+  function setType(type) {
+    groups.forEach(function (g) {
+      var match = g.getAttribute("data-group") === type;
+      g.classList.toggle("is-hidden", !match);
+      g.disabled = !match; // disabled fieldset controls are excluded from submit + validation
+    });
+    typeRadios.forEach(function (r) {
+      r.checked = r.value === type;
+    });
+  }
+
+  function currentType() {
+    var checked = form.querySelector('input[name="type"]:checked');
+    return checked ? checked.value : "bug";
+  }
+
+  function setStatus(msg, isError) {
+    status.textContent = msg || "";
+    status.classList.toggle("is-error", !!isError);
+  }
+
+  function resetTurnstile() {
+    if (window.turnstile && typeof window.turnstile.reset === "function") {
+      try { window.turnstile.reset(); } catch (e) { /* ignore */ }
+    }
+  }
+
+  // Preselect from ?type=
+  var params = new URLSearchParams(window.location.search);
+  var initial = (params.get("type") || "").toLowerCase();
+  setType(initial === "feature" ? "feature" : "bug");
+
+  typeRadios.forEach(function (r) {
+    r.addEventListener("change", function () {
+      setType(r.value);
+      setStatus("");
+    });
+  });
+
+  form.addEventListener("submit", function (e) {
+    e.preventDefault();
+    setStatus("");
+
+    if (!fnUrl) {
+      setStatus("The feedback form is not fully configured yet. Please email azuresqldb-container@microsoft.com.", true);
+      return;
+    }
+
+    // Native validation on the visible (enabled) controls.
+    if (!form.checkValidity()) {
+      form.reportValidity();
+      return;
+    }
+
+    // Feature: require at least one "Who benefits".
+    if (currentType() === "feature") {
+      var checked = form.querySelectorAll('input[name="who-benefits"]:checked');
+      if (checked.length === 0) {
+        setStatus("Please select at least one option for “Who benefits”.", true);
+        return;
+      }
+    }
+
+    var data = new FormData(form); // disabled fieldset => inactive branch excluded automatically
+
+    submit.disabled = true;
+    var original = submit.textContent;
+    submit.textContent = "Sending…";
+    setStatus("");
+
+    fetch(fnUrl, { method: "POST", body: data })
+      .then(function (res) {
+        return res.json().then(function (body) { return { status: res.status, body: body }; });
+      })
+      .then(function (r) {
+        if (r.status === 200 && r.body && r.body.ok) {
+          form.hidden = true;
+          document.querySelector(".fb-tabs").hidden = true;
+          if (r.body.ref) {
+            successMsg.textContent = "Your feedback was sent to the team (reference #" + r.body.ref + ").";
+          }
+          success.hidden = false;
+          success.scrollIntoView({ behavior: "smooth", block: "center" });
+        } else {
+          setStatus((r.body && r.body.error) || "Something went wrong. Please try again.", true);
+          resetTurnstile();
+        }
+      })
+      .catch(function () {
+        setStatus("Network error. Please retry, or email azuresqldb-container@microsoft.com.", true);
+        resetTurnstile();
+      })
+      .then(function () {
+        submit.disabled = false;
+        submit.textContent = original;
+      });
+  });
+
+  if (again) {
+    again.addEventListener("click", function () {
+      window.location.reload();
+    });
+  }
+})();

--- a/docs/feedback.html
+++ b/docs/feedback.html
@@ -1,0 +1,155 @@
+---
+layout: page
+title: Send feedback
+description: File a bug or request a feature for the Azure SQL Database container Private Preview.
+---
+
+<p>
+  Use this form to report a bug or request a feature during the Private Preview. It goes straight to the
+  team. For questions, sharing what you built, or ideas, see
+  <a href="{{ '/feedback-and-how-to-engage.html' | relative_url }}">Feedback and how to engage</a>.
+</p>
+
+<div id="feedback-app"
+     data-fn="{{ site.feedback_function_url }}"
+     data-sitekey="{{ site.turnstile_sitekey }}">
+
+  <div class="fb-tabs" role="tablist" aria-label="Feedback type">
+    <label class="fb-tab">
+      <input type="radio" name="type" value="bug" checked>
+      <span>Bug report</span>
+    </label>
+    <label class="fb-tab">
+      <input type="radio" name="type" value="feature">
+      <span>Feature request</span>
+    </label>
+  </div>
+
+  <form id="fb-form" novalidate>
+
+    <!-- BUG -->
+    <fieldset class="fb-group" data-group="bug">
+      <label class="fb-field">
+        <span class="fb-label">Container image tag <em>*</em></span>
+        <input type="text" name="image-tag" required
+               value="sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest">
+      </label>
+
+      <label class="fb-field">
+        <span class="fb-label">Host OS <em>*</em></span>
+        <select name="host-os" required>
+          <option value="" disabled selected>Select…</option>
+          <option>macOS (x86_64 / Intel)</option>
+          <option>Linux (x86_64)</option>
+          <option>Windows 11 (x86_64)</option>
+          <option>Other (describe below)</option>
+        </select>
+      </label>
+
+      <label class="fb-field">
+        <span class="fb-label">Container runtime and version <em>*</em></span>
+        <input type="text" name="runtime" required
+               placeholder="Docker 27.0.3 / Podman 5.0 / Rancher Desktop 1.13">
+      </label>
+
+      <label class="fb-field">
+        <span class="fb-label">What happened <em>*</em></span>
+        <span class="fb-help">What you expected versus what actually happened. Include error messages and <code>docker logs sqldb</code>.</span>
+        <textarea name="description" rows="4" required></textarea>
+      </label>
+
+      <label class="fb-field">
+        <span class="fb-label">Steps to reproduce <em>*</em></span>
+        <span class="fb-help">Include the <code>docker run</code> command or <code>docker-compose.yml</code> if relevant.</span>
+        <textarea name="repro" rows="4" required
+                  placeholder="1. Start the container with ...&#10;2. Connect with sqlcmd ...&#10;3. Run query / observe ..."></textarea>
+      </label>
+
+      <label class="fb-field">
+        <span class="fb-label">Additional context</span>
+        <span class="fb-help">Driver/ORM and version, related issues. Optional.</span>
+        <textarea name="additional" rows="3"></textarea>
+      </label>
+
+      <label class="fb-check">
+        <input type="checkbox" name="confirm" required>
+        <span>I checked the <a href="{{ '/known-limitations.html' | relative_url }}" target="_blank" rel="noopener">Known limitations</a> page for a duplicate. <em>*</em></span>
+      </label>
+    </fieldset>
+
+    <!-- FEATURE -->
+    <fieldset class="fb-group" data-group="feature" disabled>
+      <label class="fb-field">
+        <span class="fb-label">Use case <em>*</em></span>
+        <span class="fb-help">What are you trying to do? Describe the developer workflow or scenario.</span>
+        <textarea name="use-case" rows="4" placeholder="I am building ... and I need ..."></textarea>
+      </label>
+
+      <label class="fb-field">
+        <span class="fb-label">Current workaround</span>
+        <span class="fb-help">How are you handling this today? "No workaround" is a valid answer. Optional.</span>
+        <textarea name="current-workaround" rows="3"></textarea>
+      </label>
+
+      <label class="fb-field">
+        <span class="fb-label">Proposed behavior <em>*</em></span>
+        <span class="fb-help">What would the ideal solution look like?</span>
+        <textarea name="proposed" rows="4"></textarea>
+      </label>
+
+      <fieldset class="fb-checkset" data-name="who-benefits">
+        <legend class="fb-label">Who benefits <em>*</em></legend>
+        <label class="fb-check"><input type="checkbox" name="who-benefits" value="Modern Application Developers (Next.js, NestJS, FastAPI, Hono, etc.)"><span>Modern Application Developers (Next.js, NestJS, FastAPI, Hono, etc.)</span></label>
+        <label class="fb-check"><input type="checkbox" name="who-benefits" value="AI / Cloud-Native Developers (RAG, agents, AI features)"><span>AI / Cloud-Native Developers (RAG, agents, AI features)</span></label>
+        <label class="fb-check"><input type="checkbox" name="who-benefits" value="Platform Engineers (Dev Containers, docker compose, CI / CD)"><span>Platform Engineers (Dev Containers, docker compose, CI / CD)</span></label>
+        <label class="fb-check"><input type="checkbox" name="who-benefits" value="Database Developers (T-SQL, schema, migrations)"><span>Database Developers (T-SQL, schema, migrations)</span></label>
+        <label class="fb-check"><input type="checkbox" name="who-benefits" value="All developers"><span>All developers</span></label>
+      </fieldset>
+
+      <label class="fb-field">
+        <span class="fb-label">Urgency <em>*</em></span>
+        <select name="urgency">
+          <option value="" disabled selected>Select…</option>
+          <option>Blocks my evaluation of the Private Preview</option>
+          <option>Important for my Public Preview adoption</option>
+          <option>Nice to have</option>
+        </select>
+      </label>
+
+      <label class="fb-field">
+        <span class="fb-label">Additional context</span>
+        <span class="fb-help">Links to related issues, prior art in other databases, spec references. Optional.</span>
+        <textarea name="additional" rows="3"></textarea>
+      </label>
+    </fieldset>
+
+    <!-- SHARED -->
+    <label class="fb-field">
+      <span class="fb-label">Your email</span>
+      <span class="fb-help">So the team can follow up. Optional but recommended (issues are private, so we can't @-mention you).</span>
+      <input type="email" name="email" placeholder="you@example.com">
+    </label>
+
+    <label class="fb-field">
+      <span class="fb-label">Attachments</span>
+      <span class="fb-help">Optional. Screenshots or logs (PNG/JPG/GIF/WEBP/TXT, up to 3 files, 5 MB each).</span>
+      <input type="file" name="attachment" multiple accept=".png,.jpg,.jpeg,.gif,.webp,.txt,.log,image/*,text/plain">
+    </label>
+
+    <div class="cf-turnstile" data-sitekey="{{ site.turnstile_sitekey }}"></div>
+
+    <div class="fb-actions">
+      <button type="submit" class="btn btn-primary" id="fb-submit">Send feedback</button>
+      <p class="fb-status" id="fb-status" role="status" aria-live="polite"></p>
+    </div>
+  </form>
+
+  <div class="fb-success" id="fb-success" hidden>
+    <h2>Thanks — we got it.</h2>
+    <p id="fb-success-msg">Your feedback was sent to the team.</p>
+    <p><button type="button" class="btn btn-ghost" id="fb-again">Send more feedback</button></p>
+  </div>
+</div>
+
+<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+<script src="{{ '/assets/js/feedback.js' | relative_url }}" defer></script>


### PR DESCRIPTION
Adds a public feedback form to the Pages site so external Private Preview participants can file bugs/features without access to the private repo. The form POSTs to an Azure Function (hosted in a separate local folder, **not** in this repo) that creates the issue in the private repo.

**In this PR (repo/site only):**
- `docs/feedback.html` — one form, Bug/Feature toggle (preselected via `?type=`), fields mirror `bug_report.yml` / `feature_request.yml`.
- `docs/assets/js/feedback.js` — branch logic, validation, POST, success/error UX.
- `docs/assets/css/main.scss` — form styles.
- `docs/_config.yml` — `feedback_function_url` + `turnstile_sitekey` (blank until deploy).

**Draft until backend is live:** deploy the Azure Function, then set the two `_config.yml` values and retarget the aka.ms links. Backend code + Bicep live outside this repo.

Confirmation checkbox points at the public **Known limitations** page (external users can't see the private issue list).