### PR TITLE
Fix feedback form type toggle + add GitHub username capture

### DIFF
--- a/docs/assets/js/feedback.js
+++ b/docs/assets/js/feedback.js
@@ -13,7 +13,8 @@
   var successMsg = document.getElementById("fb-success-msg");
   var again = document.getElementById("fb-again");
   var groups = form.querySelectorAll(".fb-group");
-  var typeRadios = form.querySelectorAll('input[name="type"]');
+  // The type radios live in .fb-tabs, a sibling of the form — query from the app container, not the form.
+  var typeRadios = app.querySelectorAll('input[name="type"]');
 
   function setType(type) {
     groups.forEach(function (g) {
@@ -27,7 +28,7 @@
   }
 
   function currentType() {
-    var checked = form.querySelector('input[name="type"]:checked');
+    var checked = app.querySelector('input[name="type"]:checked');
     return checked ? checked.value : "bug";
   }
 
@@ -78,7 +79,18 @@
       }
     }
 
+    // Require a way to follow up: GitHub username or email.
+    var ghField = form.querySelector('input[name="github-username"]');
+    var emField = form.querySelector('input[name="email"]');
+    var gh = ghField ? ghField.value.trim() : "";
+    var em = emField ? emField.value.trim() : "";
+    if (!gh && !em) {
+      setStatus("Please provide your GitHub username or an email so we can follow up.", true);
+      return;
+    }
+
     var data = new FormData(form); // disabled fieldset => inactive branch excluded automatically
+    data.set("type", currentType()); // type radios live outside the form, so set it explicitly
 
     submit.disabled = true;
     var original = submit.textContent;

--- a/docs/feedback.html
+++ b/docs/feedback.html
@@ -125,8 +125,14 @@ description: File a bug or request a feature for the Azure SQL Database containe
 
     <!-- SHARED -->
     <label class="fb-field">
-      <span class="fb-label">Your email</span>
-      <span class="fb-help">So the team can follow up. Optional but recommended (issues are private, so we can't @-mention you).</span>
+      <span class="fb-label">GitHub username <em>*</em></span>
+      <span class="fb-help">Your GitHub handle so the team can follow up (e.g. octocat). If you don't have one, use email below.</span>
+      <input type="text" name="github-username" placeholder="octocat" autocapitalize="off" autocorrect="off" spellcheck="false">
+    </label>
+
+    <label class="fb-field">
+      <span class="fb-label">Email</span>
+      <span class="fb-help">Required only if you don't have a GitHub account.</span>
       <input type="email" name="email" placeholder="you@example.com">
     </label>
 


### PR DESCRIPTION
Fixes the live form: the Bug/Feature radios were outside the `<form>`, so the toggle never worked (both groups showed) and `type` wasn't submitted ("Unknown feedback type" error). Also adds a **GitHub username** field (preferred contact, email fallback, at least one required); issues show the reporter as a linked `@handle`.