### PR TITLE
Feedback form: toast notifications instead of native validation bubbles

### DIFF
--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -586,6 +586,44 @@ section[id] { scroll-margin-top: 84px; }
 .fb-success { border: 1px solid var(--line); border-radius: var(--radius); padding: 28px; background: var(--tint); }
 .fb-success h2 { margin-top: 0; }
 
+/* toast notifications */
+.toast-wrap {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: min(360px, calc(100vw - 32px));
+}
+.toast {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  background: var(--white);
+  color: var(--ink);
+  border: 1px solid var(--line);
+  border-left: 4px solid var(--azure);
+  border-radius: 10px;
+  padding: 13px 15px;
+  font-size: .92rem;
+  line-height: 1.4;
+  box-shadow: var(--shadow-lg);
+  opacity: 0;
+  transform: translateY(10px);
+  transition: opacity .22s ease, transform .22s ease;
+}
+.toast.show { opacity: 1; transform: translateY(0); }
+.toast-error { border-left-color: #b3261e; }
+.toast-success { border-left-color: #0f7b3f; }
+.toast-icon { flex: 0 0 auto; font-weight: 700; }
+.toast-error .toast-icon { color: #b3261e; }
+.toast-success .toast-icon { color: #0f7b3f; }
+@media (max-width: 560px) {
+  .toast-wrap { left: 16px; right: 16px; bottom: 16px; width: auto; }
+}
+
 /* reduced motion */
 @media (prefers-reduced-motion: reduce) {
   html { scroll-behavior: auto; }

--- a/docs/assets/js/feedback.js
+++ b/docs/assets/js/feedback.js
@@ -1,20 +1,47 @@
-/* Feedback form: branch bug/feature, validate, POST to the Azure Function. */
+/* Feedback form: branch bug/feature, validate, POST to the Azure Function, toast feedback. */
 (function () {
   "use strict";
 
   var app = document.getElementById("feedback-app");
   if (!app) return;
   var fnUrl = (app.getAttribute("data-fn") || "").trim();
+  var SUPPORT = "azuresqldb-container@microsoft.com";
 
   var form = document.getElementById("fb-form");
   var submit = document.getElementById("fb-submit");
-  var status = document.getElementById("fb-status");
   var success = document.getElementById("fb-success");
   var successMsg = document.getElementById("fb-success-msg");
   var again = document.getElementById("fb-again");
   var groups = form.querySelectorAll(".fb-group");
-  // The type radios live in .fb-tabs, a sibling of the form — query from the app container, not the form.
+  // The type radios live in .fb-tabs, a sibling of the form — query from the app container.
   var typeRadios = app.querySelectorAll('input[name="type"]');
+
+  // --- toast ---
+  function toast(msg, type) {
+    var wrap = document.getElementById("fb-toast-wrap");
+    if (!wrap) {
+      wrap = document.createElement("div");
+      wrap.id = "fb-toast-wrap";
+      wrap.className = "toast-wrap";
+      document.body.appendChild(wrap);
+    }
+    var t = document.createElement("div");
+    t.className = "toast toast-" + (type || "info");
+    t.setAttribute("role", type === "error" ? "alert" : "status");
+    var icon = document.createElement("span");
+    icon.className = "toast-icon";
+    icon.textContent = type === "success" ? "✓" : (type === "error" ? "⚠" : "•");
+    var span = document.createElement("span");
+    span.textContent = msg;
+    t.appendChild(icon);
+    t.appendChild(span);
+    wrap.appendChild(t);
+    requestAnimationFrame(function () { t.classList.add("show"); });
+    setTimeout(function () {
+      t.classList.remove("show");
+      setTimeout(function () { if (t.parentNode) t.parentNode.removeChild(t); }, 260);
+    }, 4500);
+  }
 
   function setType(type) {
     groups.forEach(function (g) {
@@ -22,19 +49,12 @@
       g.classList.toggle("is-hidden", !match);
       g.disabled = !match; // disabled fieldset controls are excluded from submit + validation
     });
-    typeRadios.forEach(function (r) {
-      r.checked = r.value === type;
-    });
+    typeRadios.forEach(function (r) { r.checked = r.value === type; });
   }
 
   function currentType() {
     var checked = app.querySelector('input[name="type"]:checked');
     return checked ? checked.value : "bug";
-  }
-
-  function setStatus(msg, isError) {
-    status.textContent = msg || "";
-    status.classList.toggle("is-error", !!isError);
   }
 
   function resetTurnstile() {
@@ -43,38 +63,46 @@
     }
   }
 
+  // Friendly message for the first invalid control.
+  function invalidMessage(el) {
+    if (el.name === "confirm") return "Please confirm you checked the Known limitations page.";
+    var wrap = el.closest(".fb-field, .fb-checkset");
+    var lbl = wrap && wrap.querySelector(".fb-label");
+    var nm = lbl ? lbl.textContent.replace(/\*/g, "").trim() : "A required field";
+    return nm + " is required.";
+  }
+
   // Preselect from ?type=
   var params = new URLSearchParams(window.location.search);
   var initial = (params.get("type") || "").toLowerCase();
   setType(initial === "feature" ? "feature" : "bug");
 
   typeRadios.forEach(function (r) {
-    r.addEventListener("change", function () {
-      setType(r.value);
-      setStatus("");
-    });
+    r.addEventListener("change", function () { setType(r.value); });
   });
 
   form.addEventListener("submit", function (e) {
     e.preventDefault();
-    setStatus("");
 
     if (!fnUrl) {
-      setStatus("The feedback form is not fully configured yet. Please email azuresqldb-container@microsoft.com.", true);
+      toast("The feedback form isn’t configured yet. Please email " + SUPPORT + ".", "error");
       return;
     }
 
-    // Native validation on the visible (enabled) controls.
+    // Required fields (custom, so we can toast instead of the native bubble).
     if (!form.checkValidity()) {
-      form.reportValidity();
+      var firstInvalid = form.querySelector(":invalid");
+      if (firstInvalid) {
+        try { firstInvalid.focus(); } catch (e2) { /* ignore */ }
+        toast(invalidMessage(firstInvalid), "error");
+      }
       return;
     }
 
-    // Feature: require at least one "Who benefits".
+    // Feature: at least one "Who benefits".
     if (currentType() === "feature") {
-      var checked = form.querySelectorAll('input[name="who-benefits"]:checked');
-      if (checked.length === 0) {
-        setStatus("Please select at least one option for “Who benefits”.", true);
+      if (form.querySelectorAll('input[name="who-benefits"]:checked').length === 0) {
+        toast("Please select at least one option for “Who benefits”.", "error");
         return;
       }
     }
@@ -85,17 +113,17 @@
     var gh = ghField ? ghField.value.trim() : "";
     var em = emField ? emField.value.trim() : "";
     if (!gh && !em) {
-      setStatus("Please provide your GitHub username or an email so we can follow up.", true);
+      toast("Please provide your GitHub username or an email so we can follow up.", "error");
+      if (ghField) ghField.focus();
       return;
     }
 
-    var data = new FormData(form); // disabled fieldset => inactive branch excluded automatically
-    data.set("type", currentType()); // type radios live outside the form, so set it explicitly
+    var data = new FormData(form);
+    data.set("type", currentType()); // type radios live outside the form
 
     submit.disabled = true;
     var original = submit.textContent;
     submit.textContent = "Sending…";
-    setStatus("");
 
     fetch(fnUrl, { method: "POST", body: data })
       .then(function (res) {
@@ -103,20 +131,22 @@
       })
       .then(function (r) {
         if (r.status === 200 && r.body && r.body.ok) {
+          var tabs = document.querySelector(".fb-tabs");
+          if (tabs) tabs.hidden = true;
           form.hidden = true;
-          document.querySelector(".fb-tabs").hidden = true;
           if (r.body.ref) {
             successMsg.textContent = "Your feedback was sent to the team (reference #" + r.body.ref + ").";
           }
           success.hidden = false;
           success.scrollIntoView({ behavior: "smooth", block: "center" });
+          toast("Feedback sent — thank you!", "success");
         } else {
-          setStatus((r.body && r.body.error) || "Something went wrong. Please try again.", true);
+          toast((r.body && r.body.error) || "Something went wrong. Please try again.", "error");
           resetTurnstile();
         }
       })
       .catch(function () {
-        setStatus("Network error. Please retry, or email azuresqldb-container@microsoft.com.", true);
+        toast("Network error. Please retry, or email " + SUPPORT + ".", "error");
         resetTurnstile();
       })
       .then(function () {
@@ -126,8 +156,6 @@
   });
 
   if (again) {
-    again.addEventListener("click", function () {
-      window.location.reload();
-    });
+    again.addEventListener("click", function () { window.location.reload(); });
   }
 })();


### PR DESCRIPTION
Replaces the browser's native validation popups and inline status text with standard toast notifications (bottom-right, auto-dismiss, color-coded). Errors, network failures, and success all route through the toast; the first invalid field is focused.