### PR TITLE
Bug/feature links -> aka.ms/azuresql-developer-*

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ These drift easily; keep them aligned everywhere when you edit:
 - **The engine does not auto-create databases.** Provision `appdb` on a `master` connection before connecting to it. In a user-database (SDS) session USE returns Msg 40508 (Azure-faithful); a master connection is a non-SDS provisioning session where USE is not blocked. Select the database in the connection string and develop in the user database.
 - **Registry / image:** `sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest`. Registry, tag, and credentials are provisional during Private Preview.
 - **Do not advertise things that do not exist** (no empty sample folders, no unbuilt skill collections).
-- **Feedback links:** bug reports go to `https://aka.ms/azuresqldb-container-bug`, feature requests to `https://aka.ms/azuresqldb-container-feature-request`.
+- **Feedback links:** bug reports go to `https://aka.ms/azuresql-developer-bug`, feature requests to `https://aka.ms/azuresql-developer-feature-request`.
 
 ## Conventions for changes in this repository
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Run and build against Azure SQL Database, right on your local environment. Try i
 [![Sign Up](https://img.shields.io/badge/Sign%20Up-brightgreen?logo=github)](https://aka.ms/sqldbcontainerpreview-signup)
 [![Documentation](https://img.shields.io/badge/Documentation-blue?logo=github)](https://aka.ms/azuresql-developer)
 [![Agent skills](https://skills.sh/b/microsoft/azure-sql-database-container)](https://skills.sh/microsoft/azure-sql-database-container)
-[![Report Bug](https://img.shields.io/badge/Report%20Bug-red?logo=github)](https://aka.ms/azuresqldb-container-bug)
-[![Request Feature](https://img.shields.io/badge/Request%20Feature-blue?logo=github)](https://aka.ms/azuresqldb-container-feature-request)
+[![Report Bug](https://img.shields.io/badge/Report%20Bug-red?logo=github)](https://aka.ms/azuresql-developer-bug)
+[![Request Feature](https://img.shields.io/badge/Request%20Feature-blue?logo=github)](https://aka.ms/azuresql-developer-feature-request)
 [![Discussions](https://img.shields.io/badge/Discussions-blueviolet?logo=github)](../../discussions)
 
 <a href="https://youtu.be/S6PWxUAUspY">
@@ -33,8 +33,8 @@ For the first time, developers can build, test, and ship applications against th
 
 ## Feedback
 
-- File a bug: [GitHub Issues](https://aka.ms/azuresqldb-container-bug)
-- Request a feature: [GitHub Issues](https://aka.ms/azuresqldb-container-feature-request)
+- File a bug: [GitHub Issues](https://aka.ms/azuresql-developer-bug)
+- Request a feature: [GitHub Issues](https://aka.ms/azuresql-developer-feature-request)
 - Ask a question, share a build, suggest an idea: [GitHub Discussions](../../discussions)
 - Connect with the team: [book a session](https://aka.ms/azuresql-container-meet) or email [azuresqldb-container@microsoft.com](mailto:azuresqldb-container@microsoft.com)
 - Real-time conversation: the private Teams channel shared via the early-access feedback channel

--- a/docs/feedback-and-how-to-engage.md
+++ b/docs/feedback-and-how-to-engage.md
@@ -23,8 +23,8 @@ Filing a bug or requesting a feature? Go straight to the form:
 
 | You want to                                                | Use                                            |
 | ---------------------------------------------------------- | ---------------------------------------------- |
-| Report a bug, regression, or unexpected behavior           | [GitHub Issues: Bug report](https://aka.ms/azuresqldb-container-bug) |
-| Request a feature or capability                            | [GitHub Issues: Feature request](https://aka.ms/azuresqldb-container-feature-request) |
+| Report a bug, regression, or unexpected behavior           | [GitHub Issues: Bug report](https://aka.ms/azuresql-developer-bug) |
+| Request a feature or capability                            | [GitHub Issues: Feature request](https://aka.ms/azuresql-developer-feature-request) |
 | Ask a "how do I" question                                  | [GitHub Discussions: Q&A](https://github.com/microsoft/azure-sql-database-container/discussions/categories/q-a) |
 | Share what you built                                       | [GitHub Discussions: Show & Tell](https://github.com/microsoft/azure-sql-database-container/discussions/categories/show-and-tell) |
 | Suggest a direction or pitch an idea                       | [GitHub Discussions: Ideas](https://github.com/microsoft/azure-sql-database-container/discussions/categories/ideas) |

--- a/docs/index.html
+++ b/docs/index.html
@@ -422,7 +422,7 @@ title: Azure SQL Developer
         <h3>Discussions &rarr;</h3>
         <p>Ask a question, share what you built, or pitch an idea.</p>
       </a>
-      <a class="res" href="https://aka.ms/azuresqldb-container-bug" rel="noopener">
+      <a class="res" href="https://aka.ms/azuresql-developer-bug" rel="noopener">
         <h3>Report a bug &rarr;</h3>
         <p>A reproducible test case is the fastest path to a fix.</p>
       </a>

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -24,7 +24,7 @@ This page lists the limitations we know about as of the version date above. Two 
 - **Active issues we are fixing** are blockers we are working on now. If you hit one, the workaround is listed inline and the fix is tracked.
 - **Known behavior gaps** are functional differences from Azure SQL Database in the cloud. They may close, or they may not, depending on Private Preview feedback.
 
-If you hit a limitation that is not on this page, please file a [GitHub issue](https://aka.ms/azuresqldb-container-bug) so we can either add it here or fix it.
+If you hit a limitation that is not on this page, please file a [GitHub issue](https://aka.ms/azuresql-developer-bug) so we can either add it here or fix it.
 
 ## Active issues we are fixing
 

--- a/skills/azuresql-db-faq/references/limitations.md
+++ b/skills/azuresql-db-faq/references/limitations.md
@@ -4,7 +4,7 @@ This is a snapshot for offline use. The **live, always-current list is the sourc
 truth**: https://microsoft.github.io/azure-sql-database-container/known-limitations.html
 (repo: `docs/known-limitations.md`). If they disagree, trust the live page and report
 the drift. When a user hits something not listed, point them to
-https://aka.ms/azuresqldb-container-bug to file an issue.
+https://aka.ms/azuresql-developer-bug to file an issue.
 
 ## Active issues being fixed
 


### PR DESCRIPTION
Swaps the bug/feature aka.ms slugs to `azuresql-developer-bug` / `azuresql-developer-feature-request` across README, footer/nav (via index), feedback-and-how-to-engage, known-limitations, AGENTS, and the faq skill (11 spots). Both verified 301 -> the feedback form (`feedback.html#bug` / `#feature`). Signup/meet links unchanged.