### PR TITLE
Correct the install guidance: drop --copy, verify instead

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-Guidance for AI coding agents working **in this repository** (the Azure SQL Developer Private Preview). If you instead want your own agent to run and build against the container in your project, install the skill: `npx skills add microsoft/azure-sql-database-container --copy`. This file is about contributing to the repo, not about using the container.
+Guidance for AI coding agents working **in this repository** (the Azure SQL Developer Private Preview). If you instead want your own agent to run and build against the container in your project, install the skill: `npx skills add microsoft/azure-sql-database-container`. This file is about contributing to the repo, not about using the container.
 
 ## What this project is
 
@@ -8,7 +8,7 @@ Azure SQL Developer is the Azure SQL Database engine, running locally in a conta
 
 ## Repository layout
 
-- `skills/`: the installable agent skill collection (`npx skills add microsoft/azure-sql-database-container --copy`). This is the single source of truth for how an agent runs and builds against the container. Do not duplicate that how-to elsewhere; link to it.
+- `skills/`: the installable agent skill collection (`npx skills add microsoft/azure-sql-database-container`). This is the single source of truth for how an agent runs and builds against the container. Do not duplicate that how-to elsewhere; link to it.
 - `docs/`: the GitHub Pages site (`what-is-the-container`, `prerequisites`, `getting-started`, `known-limitations`, `goals-of-the-private-preview`, `feedback-and-how-to-engage`), plus `docs/prompts/` (the build prompts) and `docs/llms.txt`.
 - `README.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, `LICENSE`, and `.github/` (issue and discussion templates).
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,23 +35,27 @@ From here you have two ways to reach your first query. Both end in the same plac
 
 ## Fastest: let your AI agent set it up
 
-Your agent does the whole setup for you: it pulls the image, starts the container, provisions the database, and runs your first query. You install the skill once, then ask in plain English.
+Your agent does the whole setup for you: it pulls the image, starts the container, provisions the database, and runs your first query. You install the skills once, then ask in plain English.
 
 ```bash
-npx skills add microsoft/azure-sql-database-container --copy
+npx skills add microsoft/azure-sql-database-container
 ```
 
-> **Why `--copy`?** Without it, the installer writes the skills to `.agents/skills/` and *symlinks* them into your agent's folder. Creating a symlink on Windows requires Developer Mode or an elevated shell, and when it fails the installer can still report success while your agent silently never loads the skills. `--copy` writes real directories instead. It is safe on every platform, so it is the recommended default.
-
-**Verify the skills loaded** before you rely on them. For Claude Code:
+That installs the whole collection, which is what we recommend: the skills route to each other, so the one that starts the container hands off to the one that runs your migrations. Only want a single skill? Name it:
 
 ```bash
-ls .claude/skills/
+npx skills add microsoft/azure-sql-database-container --skill azuresql-db-rag
 ```
 
-You should see the ten `azuresql-db-*` directories. If that folder is missing or empty while `.agents/skills/` is full, the symlink step failed: re-run with `--copy`, or copy them across with `mkdir -p .claude/skills && cp -R .agents/skills/azuresql-db-* .claude/skills/`. Other agents read from different folders; see the [install matrix](https://github.com/microsoft/azure-sql-database-container/tree/main/skills#install-matrix). You can also skip the installer entirely and [copy the skill directories in by hand](https://github.com/microsoft/azure-sql-database-container/tree/main/skills#manual-install), which works the same way.
+> **Check that the skills actually loaded.** Run `ls .claude/skills/` (Claude Code; other agents read from different folders, see the [install matrix](https://github.com/microsoft/azure-sql-database-container/tree/main/skills#install-matrix)). You should see the `azuresql-db-*` directories. If that folder is empty or missing while `.agents/skills/` is full, the installer did not target your agent, and it can report success when this happens. Re-run it naming your agent explicitly:
+>
+> ```bash
+> npx skills add microsoft/azure-sql-database-container -a claude-code
+> ```
+>
+> If it still does not appear, copy the directories across by hand with `mkdir -p .claude/skills && cp -R .agents/skills/azuresql-db-* .claude/skills/`, or skip the installer and [install manually](https://github.com/microsoft/azure-sql-database-container/tree/main/skills#manual-install). This is a known installer issue ([vercel-labs/skills#1355](https://github.com/vercel-labs/skills/issues/1355)), not a problem with the skills themselves.
 
-The skill works across Claude Code, GitHub Copilot (VS Code and CLI), Codex, and Cursor. Then ask your agent, for example:
+The skills work across Claude Code, GitHub Copilot (VS Code and CLI), Codex, and Cursor. Then ask your agent, for example:
 
 > Add a local Azure SQL Database to this project, then scaffold the schema, migrations, and data-access layer for my stack.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -237,8 +237,8 @@ title: Azure SQL Developer
     <div class="skill">
       <p class="skill-line">Install the agent skills once. They work across Claude Code, GitHub Copilot, Codex, and Cursor, then you just ask your agent in plain English.</p>
       <div class="skill-cmd">
-        <code><span class="cmd-p">$</span> npx skills add microsoft/azure-sql-database-container --copy</code>
-        <button class="copy-btn" type="button" data-copy-text="npx skills add microsoft/azure-sql-database-container --copy"><span class="copy-label">Copy</span></button>
+        <code><span class="cmd-p">$</span> npx skills add microsoft/azure-sql-database-container</code>
+        <button class="copy-btn" type="button" data-copy-text="npx skills add microsoft/azure-sql-database-container"><span class="copy-label">Copy</span></button>
       </div>
       <div class="skill-links">
         <a class="skill-link" href="{{ site.repo }}/tree/main/skills" rel="noopener">Browse on GitHub &rarr;</a>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -29,4 +29,4 @@ Copy-and-run prompts to hand your AI coding agent, each building a scenario agai
 
 ## Optional
 - [Repository](https://github.com/microsoft/azure-sql-database-container)
-- [Install the container agent skills](https://github.com/microsoft/azure-sql-database-container/tree/main/skills): npx skills add microsoft/azure-sql-database-container --copy
+- [Install the container agent skills](https://github.com/microsoft/azure-sql-database-container/tree/main/skills): npx skills add microsoft/azure-sql-database-container

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -63,12 +63,10 @@ If your container runtime's VM is set lower than this, the container may fail to
 If you are driving the container with an AI coding agent (Claude Code, Codex, GitHub Copilot, or Cursor) or from the CLI, install the container skill first. For that workflow it is a hard requirement, more important than any individual tool below: the skill teaches your agent the registry sign-in, image name, ports, connection string, and the local-to-cloud handoff, so a single plain-English prompt is enough.
 
 ```bash
-npx skills add microsoft/azure-sql-database-container --copy
+npx skills add microsoft/azure-sql-database-container
 ```
 
-> **Why `--copy`?** Without it, the installer writes the skills to `.agents/skills/` and symlinks them into your agent's folder. Creating a symlink on Windows requires Developer Mode or an elevated shell, and when it fails the installer can still report success while your agent never loads the skills. `--copy` writes real directories instead. It is safe on every platform, so it is the recommended default.
-
-Verify they loaded: `ls .claude/skills/` (Claude Code) should list the `azuresql-db-*` directories. If it is empty while `.agents/skills/` is populated, re-run with `--copy`. Other agents read from different folders; see the [install matrix](https://github.com/microsoft/azure-sql-database-container/tree/main/skills#install-matrix).
+> **Check that the skills loaded.** Run `ls .claude/skills/` (Claude Code) and confirm you see the `azuresql-db-*` directories. If that folder is empty while `.agents/skills/` is populated, the installer did not target your agent, and it can report success when this happens. Re-run it naming your agent explicitly, for example `npx skills add microsoft/azure-sql-database-container -a claude-code`. Other agents read from different folders; see the [install matrix](https://github.com/microsoft/azure-sql-database-container/tree/main/skills#install-matrix).
 
 It works across Claude Code, GitHub Copilot, Codex, and Cursor. Browse the skill and ready-made prompts in [agent skills](https://github.com/microsoft/azure-sql-database-container/tree/main/skills). Without it, the agent will not know how to sign in to the registry, which image to run, or how to connect.
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -40,28 +40,42 @@ EngineEdition `5` and Edition `'SQL Azure'` are the cloud engine's fingerprint. 
 The portable way. Works across agents that follow the skills.sh convention. The source is the **repository**, not a skill name:
 
 ```bash
-npx skills add microsoft/azure-sql-database-container --copy
+npx skills add microsoft/azure-sql-database-container
 ```
 
-Add `--all` to take every skill without prompting, or `-s` to pick a subset:
+Install the whole collection unless you have a reason not to: the hub skill routes to the others, so a partial install loses the handoffs. Add `--all` to take every skill without prompting.
+
+### Install just one
+
+Name the skill you want. This is the exception, not the default:
 
 ```bash
-npx skills add microsoft/azure-sql-database-container --copy -s azuresql-db-container,azuresql-db-rag
+npx skills add microsoft/azure-sql-database-container --skill azuresql-db-rag
 ```
 
-> **Why `--copy`?** Without it, the installer writes the skills to `.agents/skills/` and *symlinks* them into your agent's directory. Creating a symlink on Windows requires Developer Mode or an elevated shell, and when it fails the installer can still report success, leaving you with skills your agent never loads. `--copy` writes real directories instead and sidesteps the problem entirely. It is safe on every platform, so it is the recommended default. (Upstream issue: [vercel-labs/skills#1355](https://github.com/vercel-labs/skills/issues/1355).)
+Any skill name from the table above works. Each skill stands alone (the load-bearing facts are deliberately repeated in every one), so a single-skill install is functional; you just lose the routing between them.
 
-**Then verify the skills actually loaded.** This is the step worth not skipping:
+### Then verify the skills actually loaded
+
+This is the step worth not skipping:
 
 ```bash
 ls .claude/skills/          # Claude Code; see the matrix below for other agents
 ```
 
-You should see the ten `azuresql-db-*` directories. If the directory is missing or empty while `.agents/skills/` is populated, the symlink step failed: re-run with `--copy`, or copy them across by hand:
+You should see the `azuresql-db-*` directories. If the directory is missing or empty while `.agents/skills/` is populated, **the installer did not target your agent, and it can report success when this happens.** Re-run it naming your agent explicitly:
+
+```bash
+npx skills add microsoft/azure-sql-database-container -a claude-code
+```
+
+If they still do not appear, copy them across by hand:
 
 ```bash
 mkdir -p .claude/skills && cp -R .agents/skills/azuresql-db-* .claude/skills/
 ```
+
+This is a known installer issue ([vercel-labs/skills#1355](https://github.com/vercel-labs/skills/issues/1355), [#744](https://github.com/vercel-labs/skills/issues/744)), not a problem with the skills. It is not specific to Windows.
 
 ### Manual install
 


### PR DESCRIPTION
## This corrects a mistake I shipped in #83

#83 told users to run `npx skills add ... --copy`, and explained it as a Windows symlink-permission bug. **I read the shipped CLI source (`skills@1.5.17`) and that explanation is wrong on every point:**

| Claimed in #83 | What `dist/cli.mjs` actually does |
|---|---|
| Windows symlinks need Developer Mode | Uses **junctions** on win32 (`cli.mjs:1737`), which need **no privileges** |
| On failure it reports success and installs nothing | On symlink failure it **automatically copies the real files in** |
| It fails silently | Prints `Symlinks failed for: … Files were copied instead.` |

`--copy` also isn't sticky: `skills update` reverts copied skills to symlinks ([#1199](https://github.com/vercel-labs/skills/issues/1199)), and [#851](https://github.com/vercel-labs/skills/issues/851) has users reporting `--copy` failing as well. No other vendor ships the flag, which should have been the tell.

## The reported failure is real, but the cause is different

`installSkillForAgent` can return `{ success: true, skipped: true }` and write **nothing** into the agent's directory, leaving the skills only in `.agents/skills/` — which **Claude Code never reads** (verified: zero mentions of `.agents` in its changelog). That is a genuine false success, and it is **cross-platform**, not a Windows bug ([#744](https://github.com/vercel-labs/skills/issues/744), [#1355](https://github.com/vercel-labs/skills/issues/1355), [#1412](https://github.com/vercel-labs/skills/issues/1412)).

## What the docs say now

Guidance that holds regardless of root cause:

1. Run the **standard** command, same as every other vendor.
2. **Check it loaded**: `ls .claude/skills/`.
3. If it's empty while `.agents/skills/` is full, **name the agent explicitly**: `-a claude-code`.

Also adds the **single-skill install** (`--skill azuresql-db-rag`), documented as the exception rather than the default, since the hub routes to the other skills and a partial install loses the handoffs.

## Verification

`install-check.sh` was rewritten to test all three documented paths and assert `SKILL.md` is readable through `.claude/skills` in each. **5/5 pass.** `canon-check` 15/15.

Still unverified, and worth saying plainly: I have no Windows machine, so I could not reproduce the original failure or confirm the fix on Windows. The guidance above no longer *depends* on knowing the root cause, which is the point.