### PR TITLE
Add a skill feedback template, and per-skill install commands

### DIFF
--- a/.github/ISSUE_TEMPLATE/skill_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/skill_feedback.yml
@@ -1,0 +1,120 @@
+name: Agent skill feedback
+description: Report a problem with an azuresql-db-* agent skill, or suggest an improvement to one. For problems with the container itself, use the bug report instead.
+title: "[Skill]: "
+labels: ["skills", "needs-triage", "User-filled"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This is for feedback about the **agent skills**: the `azuresql-db-*` instructions your AI agent loads.
+
+        If the **container** is what misbehaved (it will not start, a query fails, the engine does something unexpected), that belongs in a [bug report](https://aka.ms/azuresql-developer-bug) instead. Rule of thumb: if the skill told your agent to do the right thing and the container still failed, it is a container bug. If the skill told your agent to do the *wrong* thing, or did not tell it enough, it is a skill bug and it belongs here.
+
+  - type: dropdown
+    id: skill
+    attributes:
+      label: Which skill
+      description: The skill that caused the problem. Pick "The collection as a whole" for install problems or for a skill that never loaded.
+      options:
+        - azuresql-db-container
+        - azuresql-db-from-sql-server
+        - azuresql-db-local-to-cloud
+        - azuresql-db-schema-migration
+        - azuresql-db-import
+        - azuresql-db-rag
+        - azuresql-db-ci
+        - azuresql-db-sidecar
+        - azuresql-db-scaffold
+        - azuresql-db-faq
+        - azuresql-db-feedback
+        - The collection as a whole (install, discovery, or the wrong skill loaded)
+        - Not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: problem-type
+    attributes:
+      label: What kind of problem
+      options:
+        - The skill told the agent to do something wrong
+        - The skill was missing something it needed to say
+        - The wrong skill was used, or no skill was used at all
+        - The skill would not install or would not load
+        - The skill worked, but I want to suggest an improvement
+        - Something else
+    validations:
+      required: true
+
+  - type: dropdown
+    id: agent
+    attributes:
+      label: Which agent
+      description: Skills behave differently across harnesses, and we cannot see which one you used.
+      options:
+        - Claude Code
+        - GitHub Copilot (VS Code)
+        - GitHub Copilot (CLI)
+        - Codex
+        - Cursor
+        - Other (describe below)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: How did you install the skills
+      options:
+        - npx skills add
+        - Copied the directories in by hand
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What you asked your agent to do, and what it did.
+      placeholder: |
+        I asked: "add a local Azure SQL database to this project"
+        The agent ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: skill-said
+    attributes:
+      label: What the skill said, and what you had to do instead
+      description: |
+        This is the most useful thing you can tell us, and the thing we are otherwise blind to. If the agent followed the skill and it did not work, quote the instruction that was wrong or missing, and say what actually worked. If the agent had to improvise or work around the skill, tell us what it worked around.
+      placeholder: |
+        The skill said to run:      docker run ... (without --platform)
+        What actually worked:       docker run --platform linux/amd64 ...
+    validations:
+      required: false
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: The prompt you gave the agent, and the commands it ran. Redact any password or credential before pasting.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Host OS, container runtime, or anything else that matters. Optional.
+
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: Confirmation
+      options:
+        - label: This is about an agent skill, not about the container itself.
+          required: true
+        - label: I removed any password, registry credential, or connection string from what I pasted above.
+          required: true

--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -463,6 +463,26 @@ section[id] { scroll-margin-top: 84px; }
 /* skill-name label on the agent-skill cards */
 .skill-tag { display: inline-block; font-family: var(--font-mono); font-size: .68rem; color: var(--azure); background: rgba(19,102,224,.07); border: 1px solid rgba(19,102,224,.18); border-radius: 5px; padding: 2px 7px; margin-bottom: 10px; }
 
+/* ---------- install a single skill (compact table, copy per skill) ---------- */
+.skill-install-title { font-size: 1.1rem; margin: 40px 0 6px; }
+.skill-install-lead { color: var(--muted); font-size: .95rem; max-width: 640px; margin: 0 0 16px; }
+.skill-install { background: var(--white); border: 1px solid var(--line); border-radius: var(--radius); box-shadow: var(--shadow); overflow: hidden; }
+.skill-install-table { width: 100%; border-collapse: collapse; }
+.skill-install-table td { padding: 10px 16px; border-bottom: 1px solid var(--line); vertical-align: middle; }
+.skill-install-table tr:last-child td { border-bottom: 0; }
+.skill-install-table tr:hover { background: rgba(19,102,224,.03); }
+.skill-install-table .si-name code { font-family: var(--font-mono); font-size: .8rem; color: var(--azure); white-space: nowrap; }
+.skill-install-table .si-what { color: var(--muted); font-size: .88rem; width: 100%; }
+.skill-install-table .si-act { text-align: right; white-space: nowrap; }
+/* the default copy-btn is styled for the dark command bar; this is its light-surface twin */
+.copy-btn.copy-light { color: var(--azure); background: rgba(19,102,224,.07); border-color: rgba(19,102,224,.18); }
+.copy-btn.copy-light:hover { background: rgba(19,102,224,.14); }
+.copy-btn.copy-light.is-copied { color: #0a7a3d; border-color: rgba(10,122,61,.45); background: rgba(10,122,61,.1); }
+
+@media (max-width: 640px) {
+  .skill-install-table .si-what { display: none; }
+}
+
 /* ---------- sample card footer (clone + GitHub) ---------- */
 .sample-foot { display: flex; align-items: center; justify-content: space-between; gap: 12px; align-self: stretch; padding-top: 18px; }
 .sample-foot .card-prompt { margin-top: 0; align-self: center; }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,9 +55,11 @@ npx skills add microsoft/azure-sql-database-container --skill azuresql-db-rag
 >
 > If it still does not appear, copy the directories across by hand with `mkdir -p .claude/skills && cp -R .agents/skills/azuresql-db-* .claude/skills/`, or skip the installer and [install manually](https://github.com/microsoft/azure-sql-database-container/tree/main/skills#manual-install). This is a known installer issue ([vercel-labs/skills#1355](https://github.com/vercel-labs/skills/issues/1355)), not a problem with the skills themselves.
 
-The skills work across Claude Code, GitHub Copilot (VS Code and CLI), Codex, and Cursor. Then ask your agent, for example:
+The skills work across Claude Code, GitHub Copilot (VS Code and CLI), Codex, and Cursor. Then ask your agent in plain English. Copy this and paste it into your agent:
 
-> Add a local Azure SQL Database to this project, then scaffold the schema, migrations, and data-access layer for my stack.
+```text
+Add a local Azure SQL Database to this project, then scaffold the schema, migrations, and data-access layer for my stack.
+```
 
 **Why use the skills?** They already know the private preview registry, the x64 image, the connection model (the engine does not auto-create databases, so they provision a database first, named `appdb` in these examples or whatever name you choose), the readiness wait, and the local-to-cloud story. So your agent stands up a real Azure SQL Database the right way the first time, instead of reaching for the SQL Server image (`mcr.microsoft.com/mssql/server`) or inventing behavior the engine does not have. Browse the [skills on GitHub](https://github.com/microsoft/azure-sql-database-container/tree/main/skills).
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -320,6 +320,32 @@ title: Azure SQL Developer
         <h4>Answer questions <span class="arrow">&rarr;</span></h4>
         <p>What Azure SQL Developer can and can't do, and why it differs from the cloud: backups, <code>USE</code>, vector index, x64-only, tooling.</p>
       </a>
+      <a class="skill-card" href="{{ site.repo }}/tree/main/skills/azuresql-db-feedback" rel="noopener">
+
+        <span class="skill-tag">azuresql-db-feedback</span>
+
+        <h4>Report a problem <span class="arrow">&rarr;</span></h4>
+        <p>Your agent writes the bug report for you, from what it already knows, and hands you a prefilled issue to review. It never files anything without your say-so.</p>
+      </a>
+    </div>
+
+    <h4 class="skill-install-title">Install a single skill</h4>
+    <p class="skill-install-lead">The command above installs the whole collection, which is what we recommend: the skills hand off to each other. To take just one, name it.</p>
+    <div class="skill-install">
+      <table class="skill-install-table">
+        {% assign one_skills = "azuresql-db-container|Start the engine,azuresql-db-from-sql-server|Convert from SQL Server,azuresql-db-local-to-cloud|Local to cloud,azuresql-db-schema-migration|Schema migrations,azuresql-db-import|Import a database,azuresql-db-rag|RAG and vector search,azuresql-db-ci|CI,azuresql-db-sidecar|Sidecar,azuresql-db-scaffold|Scaffold,azuresql-db-faq|Answer questions,azuresql-db-feedback|Report a problem" | split: "," %}
+        {% for row in one_skills %}
+          {% assign parts = row | split: "|" %}
+          {% assign sname = parts[0] %}
+          <tr>
+            <td class="si-name"><code>{{ sname }}</code></td>
+            <td class="si-what">{{ parts[1] }}</td>
+            <td class="si-act">
+              <button class="copy-btn copy-light" type="button" data-copy-text="npx skills add microsoft/azure-sql-database-container --skill {{ sname }}" aria-label="Copy the install command for {{ sname }}"><span class="copy-label">Copy</span></button>
+            </td>
+          </tr>
+        {% endfor %}
+      </table>
     </div>
   </div>
 </section>

--- a/skills/README.md
+++ b/skills/README.md
@@ -47,13 +47,27 @@ Install the whole collection unless you have a reason not to: the hub skill rout
 
 ### Install just one
 
-Name the skill you want. This is the exception, not the default:
+Name the skill you want:
 
 ```bash
-npx skills add microsoft/azure-sql-database-container --skill azuresql-db-rag
+npx skills add microsoft/azure-sql-database-container --skill <skill-name>
 ```
 
-Any skill name from the table above works. Each skill stands alone (the load-bearing facts are deliberately repeated in every one), so a single-skill install is functional; you just lose the routing between them.
+| Skill | Install |
+| --- | --- |
+| **azuresql-db-container** | `npx skills add microsoft/azure-sql-database-container --skill azuresql-db-container` |
+| **azuresql-db-from-sql-server** | `npx skills add microsoft/azure-sql-database-container --skill azuresql-db-from-sql-server` |
+| **azuresql-db-local-to-cloud** | `npx skills add microsoft/azure-sql-database-container --skill azuresql-db-local-to-cloud` |
+| **azuresql-db-schema-migration** | `npx skills add microsoft/azure-sql-database-container --skill azuresql-db-schema-migration` |
+| **azuresql-db-import** | `npx skills add microsoft/azure-sql-database-container --skill azuresql-db-import` |
+| **azuresql-db-rag** | `npx skills add microsoft/azure-sql-database-container --skill azuresql-db-rag` |
+| **azuresql-db-ci** | `npx skills add microsoft/azure-sql-database-container --skill azuresql-db-ci` |
+| **azuresql-db-sidecar** | `npx skills add microsoft/azure-sql-database-container --skill azuresql-db-sidecar` |
+| **azuresql-db-scaffold** | `npx skills add microsoft/azure-sql-database-container --skill azuresql-db-scaffold` |
+| **azuresql-db-faq** | `npx skills add microsoft/azure-sql-database-container --skill azuresql-db-faq` |
+| **azuresql-db-feedback** | `npx skills add microsoft/azure-sql-database-container --skill azuresql-db-feedback` |
+
+Each skill stands alone: the load-bearing facts are deliberately repeated in every one, so a single-skill install is fully functional. What you lose is the routing, since the hub hands off to the others. Install the whole collection unless you have a reason not to.
 
 ### Then verify the skills actually loaded
 

--- a/skills/azuresql-db-feedback/SKILL.md
+++ b/skills/azuresql-db-feedback/SKILL.md
@@ -1,119 +1,115 @@
 ---
 name: azuresql-db-feedback
 description: >-
-  Reports a bug, files a feature request, or shares feedback about Azure SQL Developer (the local Azure SQL Database engine in a container, Private Preview) and its azuresql-db-* agent skills. Use when the user says the container or a skill "did not work", hit an error, behaved unexpectedly, or is missing something; and when they say "report a bug", "file an issue", "open a GitHub issue", "request a feature", "give feedback", or "tell the team". Also use when you, the agent, had to deviate from an azuresql-db-* skill or work around a defect in it to finish a task: that is a bug in the skill and it is worth reporting. Builds a complete, prefilled GitHub issue from context you already have (image tag, host OS, runtime, the failing command, the error output) so the user does not have to assemble it by hand. Never submits anything without explicit confirmation from the user.
+  Reports a bug or files feedback about the azuresql-db-* agent skills themselves, or about Azure SQL Developer (the local Azure SQL Database engine in a container, Private Preview). Use when the user says a skill or the container "did not work", hit an error, behaved unexpectedly, or is missing something; and when they say "report a bug", "file an issue", "open a GitHub issue", "request a feature", "give feedback", or "tell the team". Also use when you, the agent, had to deviate from an azuresql-db-* skill or work around a defect in one to finish a task: that is a bug in the skill and it is worth reporting, even if the task ultimately succeeded. Decides whether the problem belongs to the SKILL or to the CONTAINER, since they use different issue templates, then builds a complete prefilled GitHub issue from context you already have. Never submits anything without explicit confirmation from the user.
 ---
 
-# Azure SQL Developer: report a bug or request a feature
+# Report a problem with the skills, or with the container
 
-The user should never have to assemble a bug report by hand. You are already holding everything a good one
-needs: the image tag, the host OS and architecture, the container runtime, the command that failed, the error
-text, and which skill you were following. Your job is to turn that into a complete report and hand it to the
-user to submit.
+The user should never have to assemble a bug report by hand. You are already holding what a good one needs:
+which skill you were following, what it told you to do, what you actually had to do, the image tag, the host,
+the runtime, the failing command, and the error. Your job is to turn that into a complete report and hand it
+to the user to submit.
 
-**Repository:** `microsoft/azure-sql-database-container`
+**Repository:** `microsoft/azure-sql-database-container` (both the container and the skills live here).
 
 ## The two rules that matter most
 
 1. **Never create an issue without explicit confirmation.** Show the user the full title and body first and
    wait for a clear yes. You may offer; you may never submit unasked. This applies to every path below,
    including the `gh` CLI.
-2. **Redact before you send.** Everything you submit is public. See [Redaction](#redaction-do-this-before-you-build-anything) below and treat it as a
-   hard requirement, not a nicety.
+2. **Redact before you send.** Everything submitted is public. See [Redaction](#step-3-redaction-do-this-before-you-build-anything).
 
-## Workflow
+## Step 1: skill problem, or container problem?
 
-Copy this checklist and work through it:
+**Get this right first: they use different issue templates.**
 
-```
-Feedback Progress:
-- [ ] Step 1: Decide bug or feature
-- [ ] Step 2: Gather the facts (bug only)
-- [ ] Step 3: Redact
-- [ ] Step 4: Draft the report and show it to the user
-- [ ] Step 5: Submit the way the user prefers
-```
+Ask yourself what actually failed.
 
-### Step 1: Decide bug or feature
+| The problem | It belongs to | Template |
+| --- | --- | --- |
+| A skill told the agent to do the **wrong** thing, or failed to say something it needed to say | the **skill** | `skill_feedback.yml` |
+| The **wrong skill** loaded, or no skill loaded when one should have | the **skill** | `skill_feedback.yml` |
+| A skill would not install, or the agent never picked it up | the **skill** | `skill_feedback.yml` |
+| You had to **deviate from the skill** or work around it to make the task succeed | the **skill** | `skill_feedback.yml` |
+| The skill said the right thing, the agent did the right thing, and **the container still failed** (will not start, query errors, engine behaves unexpectedly) | the **container** | `bug_report.yml` |
+| The **container** is missing a capability the user wants | the **container** | `feature_request.yml` |
 
-- Something is broken, wrong, or surprising, or you had to work around a skill to finish → **bug**.
-- Something is missing that the user wants → **feature request**.
+The test that settles it: **if the instructions were correct and the engine still broke, it is a container
+bug. If the instructions were wrong, incomplete, or ignored, it is a skill bug.** When genuinely torn, ask the
+user. Do not guess, and do not file both.
 
 If the user is only reporting that something worked well, do not open an issue. Point them at
-[Discussions](https://github.com/microsoft/azure-sql-database-container/discussions) instead and stop.
+[Discussions](https://github.com/microsoft/azure-sql-database-container/discussions) and stop.
 
-### Step 2: Gather the facts (bug only)
+## Step 2: gather the facts
 
-Collect these from the session, and only run a command if you do not already know the answer:
+Only run a command if you do not already know the answer.
 
-| Field | Where it comes from |
-| --- | --- |
-| Image tag | The `docker run` / compose file you used. Almost always `sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest`. |
-| Host OS | `uname -srm`. Map it to one of the four exact dropdown values in [references/issue-fields.md](references/issue-fields.md). |
-| Runtime and version | `docker --version` or `podman --version`. |
-| What happened | Expected versus actual, plus the error text. `docker logs sqldb` if the container is the problem. |
-| Steps to reproduce | The actual commands run in this session, in order. Not an idealized version. |
+**For a skill problem** (the important ones, and the ones we are otherwise blind to):
 
-If the bug is in a **skill** rather than the container, say so plainly in the description: name the skill, quote
-the instruction that was wrong or missing, and state what you had to do instead. That is the single most useful
-report we can receive, because it is invisible to us otherwise.
+- Which skill, by name (`azuresql-db-rag`, etc). If none loaded, say so: that is itself the bug.
+- Which agent you are (Claude Code, GitHub Copilot, Codex, Cursor). Skills behave differently across
+  harnesses and we cannot see which one the user ran.
+- **The instruction that was wrong or missing, quoted from the skill, and what actually worked instead.**
+  This is the single most valuable field in the whole report. Without it we cannot fix the skill.
+- The prompt the user gave you.
 
-### Step 3: Redaction (do this before you build anything)
+**For a container problem:** the image tag, the host OS (mapped to the exact dropdown value), the container
+runtime and version, what happened, and the commands that reproduce it. `docker logs sqldb` if the container
+is what broke.
 
-Strip all of the following from the description, the repro steps, and any logs:
+## Step 3: redaction (do this before you build anything)
+
+Strip all of the following from every field, including logs and repro steps:
 
 - The SA password (`MSSQL_SA_PASSWORD`, `-P <password>`, the `Password=` field of a connection string). Replace with `***`.
 - Registry credentials (the `docker login` username and password).
 - Full connection strings. Keep the shape, drop the secret: `Server=localhost,1433;Database=appdb;User Id=sa;Password=***;TrustServerCertificate=true`.
-- Any customer or application data, table contents, embeddings, or file paths that identify the user or their employer.
+- Any customer or application data, table contents, embeddings, or paths that identify the user or their employer.
 - Access tokens of any kind.
 
 The repository is public and issues are world readable. A report that leaks the user's password is worse than
 no report at all.
 
-### Step 4: Draft and show
+## Step 4: draft and show
 
-Write the report, then show it to the user in full and ask whether to file it. Say which fields you filled in
-and which you left blank. If you could not determine a value confidently, leave it blank rather than guess: a
-wrong image tag or host OS sends triage down the wrong path.
+Write the report, then show it to the user in full and ask whether to file it. Say which fields you filled and
+which you left blank. If you could not determine a value confidently, **leave it blank rather than guess**: a
+wrong skill name or host OS sends triage down the wrong path.
 
-### Step 5: Submit
+## Step 5: submit
 
-Try these in order and stop at the first one that works. Regardless of path, **confirm with the user first**.
+Try these in order, stop at the first that works, and **confirm with the user first** either way.
 
-**Tier 1: the `gh` CLI**, if `gh auth status` succeeds. The issue is authored by the user, which is what we
-want: they get notified of replies.
+**Tier 1: the `gh` CLI**, if `gh auth status` succeeds. The issue is authored by the user, so they get replies.
 
 ```bash
 gh issue create --repo microsoft/azure-sql-database-container \
-  --title "[Bug]: <one-line summary>" \
-  --label bug --label needs-triage --label User-filled --label via-skill \
+  --title "[Skill]: <one-line summary>" \
+  --label skills --label needs-triage --label User-filled --label via-skill \
   --body-file <path-to-body>
 ```
 
 Write the body to a file rather than passing it inline, so quoting and newlines survive.
 
-**Tier 2: a prefilled URL.** Works with no credentials and no setup, and the user sees exactly what will be
-submitted before anything happens. This is the fallback that always works, so use it whenever `gh` is not
-available.
+**Tier 2: a prefilled URL.** No credentials, no setup, and the user sees exactly what will be submitted before
+anything happens. Use this whenever `gh` is not available; it always works.
 
-Build the URL from the issue form's field ids and print it for the user to open. The exact field ids, the
-verbatim dropdown values, and a worked example are in
-[references/issue-fields.md](references/issue-fields.md). Read that file before constructing a URL.
-
-**Do not** invent a third path. Do not POST to the GitHub API with a token you found lying around in the
-environment, and never ask the user for a token.
+Build the URL from the issue form's field ids and print it for the user to open. The field ids, the **verbatim**
+dropdown values, and worked examples for all three templates are in
+[references/issue-fields.md](references/issue-fields.md). **Read that file before constructing a URL.**
 
 ## Do not
 
 - Do not create, comment on, or close an issue without explicit user confirmation.
 - Do not include the SA password, registry credentials, or access tokens in any field. Ever.
-- Do not guess at the image tag, host OS, or runtime. Leave the field blank if you are unsure.
-- Do not open an issue for something already listed on the [Known limitations](https://microsoft.github.io/azure-sql-database-container/known-limitations.html) page. Point the user there instead.
-- Do not use `aka.ms` short links to carry a prefilled report. They drop query strings, so every prefilled field is silently lost. Use the full `github.com` URL.
-- Do not file the same issue twice. Check [open issues](https://github.com/microsoft/azure-sql-database-container/issues) first.
+- Do not file a skill problem on the container template, or the reverse. They are triaged by different people.
+- Do not guess a dropdown value. Leave the field out if you are unsure; an omitted dropdown renders unselected, but a wrong one misroutes triage.
+- Do not use an `aka.ms` short link to carry a prefilled report. Those links drop query strings, so every field you filled in is silently lost. Use the full `github.com` URL. (The `aka.ms` links are for humans opening an empty form: [skills feedback](https://aka.ms/sql-agent-skills-feedback), [container bug](https://aka.ms/azuresql-developer-bug), [container feature](https://aka.ms/azuresql-developer-feature-request).)
+- Do not open an issue for something already on the [Known limitations](https://microsoft.github.io/azure-sql-database-container/known-limitations.html) page, or already in [open issues](https://github.com/microsoft/azure-sql-database-container/issues). Point the user there instead.
 - Do not nag. Offer once, take no for an answer, and move on.
 
 ## References
 
-- [references/issue-fields.md](references/issue-fields.md): the exact issue-form field ids, the verbatim dropdown values, URL construction and its length limit, and a worked example. Read this before building a prefilled URL.
+- [references/issue-fields.md](references/issue-fields.md): the exact field ids for all three templates, the verbatim dropdown values, URL construction and its length limit, and worked examples. Read this before building a prefilled URL.

--- a/skills/azuresql-db-feedback/references/issue-fields.md
+++ b/skills/azuresql-db-feedback/references/issue-fields.md
@@ -3,44 +3,107 @@
 ## Contents
 
 - [How prefilling works](#how-prefilling-works)
-- [Bug report fields](#bug-report-fields)
-- [Feature request fields](#feature-request-fields)
+- [Which template](#which-template)
+- [Skill feedback fields](#skill-feedback-fields-skill_feedbackyml)
+- [Container bug fields](#container-bug-fields-bug_reportyml)
+- [Container feature fields](#container-feature-fields-feature_requestyml)
 - [Labels: pass all of them](#labels-pass-all-of-them)
 - [URL length](#url-length)
-- [Worked example](#worked-example)
+- [Worked example: a skill bug](#worked-example-a-skill-bug)
 - [Checkboxes cannot be prefilled](#checkboxes-cannot-be-prefilled)
 
 ## How prefilling works
 
 GitHub issue forms prefill from URL query parameters. The parameter name is the field's `id` in the template
-YAML, and the value is URL-encoded. The base URL is:
+YAML; the value is URL-encoded. Base URL:
 
 ```
-https://github.com/microsoft/azure-sql-database-container/issues/new?template=bug_report.yml
+https://github.com/microsoft/azure-sql-database-container/issues/new?template=<template>.yml
 ```
 
 Append one `&<id>=<url-encoded value>` per field you can fill.
 
-Use the full `github.com` URL. **Do not route a prefilled report through an `aka.ms` short link:** those
-redirect to the bare form and drop the query string, so every field you filled in is silently lost.
+**Always use the full `github.com` URL.** Do not route a prefilled report through an `aka.ms` short link:
+those redirect to the bare form and **drop the query string**, so every field is silently lost. The `aka.ms`
+links exist for humans opening an empty form.
 
-## Bug report fields
+## Which template
 
-`?template=bug_report.yml`
+| Template | For | Human short link |
+| --- | --- | --- |
+| `skill_feedback.yml` | a problem with an `azuresql-db-*` **skill** | https://aka.ms/sql-agent-skills-feedback |
+| `bug_report.yml` | a problem with the **container** | https://aka.ms/azuresql-developer-bug |
+| `feature_request.yml` | a missing **container** capability | https://aka.ms/azuresql-developer-feature-request |
+
+## Skill feedback fields (`skill_feedback.yml`)
+
+Title prefix is `[Skill]: ` (preserve it).
 
 | Query param | Type | Notes |
 | --- | --- | --- |
-| `title` | string | The template prefix is `[Bug]: `. Preserve it: `title=[Bug]: container exits on start under emulation`. |
+| `skill` | dropdown | **Verbatim.** See below. |
+| `problem-type` | dropdown | **Verbatim.** See below. |
+| `agent` | dropdown | **Verbatim.** Which harness you are. |
+| `install-method` | dropdown | **Verbatim.** |
+| `what-happened` | textarea | What the user asked, and what the agent did. |
+| `skill-said` | textarea | **The most valuable field.** The instruction that was wrong or missing, quoted, and what actually worked instead. |
+| `repro` | textarea | The prompt and the commands. Redacted. |
+| `additional` | textarea | Host OS, runtime, anything else. Optional. |
+
+### `skill` values (verbatim, exactly one)
+
+- `azuresql-db-container`
+- `azuresql-db-from-sql-server`
+- `azuresql-db-local-to-cloud`
+- `azuresql-db-schema-migration`
+- `azuresql-db-import`
+- `azuresql-db-rag`
+- `azuresql-db-ci`
+- `azuresql-db-sidecar`
+- `azuresql-db-scaffold`
+- `azuresql-db-faq`
+- `azuresql-db-feedback`
+- `The collection as a whole (install, discovery, or the wrong skill loaded)`
+- `Not sure`
+
+### `problem-type` values (verbatim)
+
+- `The skill told the agent to do something wrong`
+- `The skill was missing something it needed to say`
+- `The wrong skill was used, or no skill was used at all`
+- `The skill would not install or would not load`
+- `The skill worked, but I want to suggest an improvement`
+- `Something else`
+
+### `agent` values (verbatim)
+
+- `Claude Code`
+- `GitHub Copilot (VS Code)`
+- `GitHub Copilot (CLI)`
+- `Codex`
+- `Cursor`
+- `Other (describe below)`
+
+### `install-method` values (verbatim)
+
+- `npx skills add`
+- `Copied the directories in by hand`
+- `Not sure`
+
+## Container bug fields (`bug_report.yml`)
+
+Title prefix is `[Bug]: `.
+
+| Query param | Type | Notes |
+| --- | --- | --- |
 | `image-tag` | input | Usually `sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest`. |
-| `host-os` | dropdown | **Must match one option verbatim.** See below. |
+| `host-os` | dropdown | **Verbatim.** See below. |
 | `runtime` | input | For example `Docker 27.0.3` or `Podman 5.0`. |
-| `description` | textarea | What you expected versus what happened, plus the error text. |
+| `description` | textarea | Expected versus actual, plus the error text. |
 | `repro` | textarea | The actual commands, in order. Newlines encode as `%0A`. |
-| `additional` | textarea | Driver/ORM and version, related issues. Optional. |
+| `additional` | textarea | Driver/ORM and version. Optional. |
 
-### `host-os` values (verbatim, exactly one)
-
-The dropdown only accepts a string that matches an option character for character:
+### `host-os` values (verbatim)
 
 - `macOS (x86_64 / Intel)`
 - `Linux (x86_64)`
@@ -48,24 +111,15 @@ The dropdown only accepts a string that matches an option character for characte
 - `Other (describe below)`
 
 Map from `uname -srm`. Apple Silicon runs the x64 image under emulation and still reports `arm64`; it is
-still macOS, so use `macOS (x86_64 / Intel)` and mention the emulation in the description. If none of the four
-fit, use `Other (describe below)` and explain. If you cannot tell, **omit the parameter entirely** rather than
-guessing: an omitted dropdown just renders unselected, but a wrong one misroutes triage.
+still macOS, so use `macOS (x86_64 / Intel)` and mention the emulation in the description. If you cannot tell,
+**omit the parameter** rather than guessing.
 
-## Feature request fields
+## Container feature fields (`feature_request.yml`)
 
-`?template=feature_request.yml`. Title prefix is `[Feature]: `.
+Title prefix is `[Feature]: `. Fields: `use-case`, `current-workaround`, `proposed`, `who-benefits`
+(multi-select dropdown), `urgency` (dropdown), `additional`.
 
-| Query param | Type | Notes |
-| --- | --- | --- |
-| `use-case` | textarea | What the user is trying to do. |
-| `current-workaround` | textarea | Optional. "No workaround" is a valid answer. |
-| `proposed` | textarea | What the ideal solution looks like. |
-| `who-benefits` | dropdown (multi) | Verbatim values below. Comma-separate for multiple. |
-| `urgency` | dropdown | Verbatim values below. |
-| `additional` | textarea | Optional. |
-
-### `who-benefits` values (verbatim)
+`who-benefits` values (verbatim, comma-separate for several):
 
 - `Modern Application Developers (Next.js, NestJS, FastAPI, Hono, etc.)`
 - `AI / Cloud-Native Developers (RAG, agents, AI features)`
@@ -73,62 +127,65 @@ guessing: an omitted dropdown just renders unselected, but a wrong one misroutes
 - `Database Developers (T-SQL, schema, migrations)`
 - `All developers`
 
-### `urgency` values (verbatim)
+`urgency` values (verbatim):
 
 - `Blocks my evaluation of the Private Preview`
 - `Important for my Public Preview adoption`
 - `Nice to have`
 
-Do not guess urgency on the user's behalf. Ask them, or omit it.
+Do not guess urgency on the user's behalf. Ask, or omit it.
 
 ## Labels: pass all of them
 
-A `labels=` query parameter **replaces** the template's own labels rather than adding to them. The bug template
-carries `bug`, `needs-triage`, and `User-filled`; the feature template carries `enhancement`, `needs-triage`,
-and `User-filled`. So if you pass only `via-skill`, you strip the rest and the issue lands untriaged.
+A `labels=` query parameter **replaces** the template's own labels rather than adding to them. So passing only
+`via-skill` strips the rest and the issue lands untriaged. Always pass the full set:
 
-Always pass the full set:
-
-- Bug: `&labels=bug,needs-triage,User-filled,via-skill`
-- Feature: `&labels=enhancement,needs-triage,User-filled,via-skill`
+| Template | Labels to pass |
+| --- | --- |
+| `skill_feedback.yml` | `&labels=skills,needs-triage,User-filled,via-skill` |
+| `bug_report.yml` | `&labels=bug,needs-triage,User-filled,via-skill` |
+| `feature_request.yml` | `&labels=enhancement,needs-triage,User-filled,via-skill` |
 
 `via-skill` is what lets the team see which reports came through an agent skill. Include it every time.
 
 ## URL length
 
-GitHub returns `414 URI Too Long` on an over-long URL, and truncates very long field values. Keep the whole
-URL comfortably under about 8,000 characters:
+GitHub returns `414 URI Too Long` on an over-long URL and truncates very long values. Keep the whole URL under
+about 8,000 characters:
 
-- Cap `repro` at roughly 1,500 characters.
-- Cap `description` at roughly 2,000 characters.
-- Truncate logs to the ~30 lines that actually matter, and tell the user in your message that you trimmed them
-  and they should paste the rest into the form before submitting.
+- Cap `repro` at roughly 1,500 characters and `what-happened` / `description` at roughly 2,000.
+- Truncate logs to the ~30 lines that matter, and tell the user you trimmed them so they can paste the rest
+  into the form before submitting.
 
-If the content genuinely will not fit, prefill the short fields, leave `description` for the user, and give
-them the trimmed text in the chat to paste in.
+If it genuinely will not fit, prefill the short fields, leave the long one for the user, and give them the
+trimmed text in the chat to paste in.
 
-## Worked example
+## Worked example: a skill bug
 
-Bug: the container exits at startup because `--platform` was omitted on an Apple Silicon host.
+The `azuresql-db-container` skill omitted `--platform` on an Apple Silicon host, so the container died and the
+agent had to add the flag itself.
 
 ```
 https://github.com/microsoft/azure-sql-database-container/issues/new
-?template=bug_report.yml
-&labels=bug,needs-triage,User-filled,via-skill
-&title=%5BBug%5D%3A%20container%20exits%20immediately%20on%20Apple%20Silicon%20without%20--platform
-&image-tag=sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io%2Fazure-sql%2Fdb-dev%3Alatest
-&host-os=macOS%20(x86_64%20%2F%20Intel)
-&runtime=Docker%2027.0.3
-&description=Expected%20the%20container%20to%20start.%20It%20exited%20with%20code%20139.%0A%0Adocker%20logs%20sqldb%3A%0A%60%60%60%0Aexec%20format%20error%0A%60%60%60
-&repro=1.%20docker%20run%20-d%20--name%20sqldb%20-e%20%22ACCEPT_EULA%3DY%22%20-e%20%22MSSQL_SA_PASSWORD%3D***%22%20-p%201433%3A1433%20sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io%2Fazure-sql%2Fdb-dev%3Alatest%0A2.%20docker%20ps%20-a%20shows%20Exited%20(139)
+?template=skill_feedback.yml
+&labels=skills,needs-triage,User-filled,via-skill
+&title=%5BSkill%5D%3A%20azuresql-db-container%20omits%20--platform%20on%20Apple%20Silicon
+&skill=azuresql-db-container
+&problem-type=The%20skill%20was%20missing%20something%20it%20needed%20to%20say
+&agent=Claude%20Code
+&install-method=npx%20skills%20add
+&what-happened=I%20asked%20the%20agent%20to%20add%20a%20local%20Azure%20SQL%20database.%20It%20followed%20the%20skill%2C%20the%20container%20exited%20with%20code%20139.
+&skill-said=The%20skill%20said%3A%20docker%20run%20-d%20--name%20sqldb%20...%0AWhat%20actually%20worked%3A%20docker%20run%20--platform%20linux%2Famd64%20-d%20--name%20sqldb%20...%0AThe%20skill%20never%20mentioned%20--platform%20for%20a%20non-x64%20host.
+&repro=1.%20Ask%3A%20%22add%20a%20local%20Azure%20SQL%20database%22%0A2.%20Agent%20runs%20docker%20run%20-e%20%22MSSQL_SA_PASSWORD%3D***%22%20...%0A3.%20docker%20ps%20-a%20shows%20Exited%20(139)
 ```
 
-(Written across lines for readability. Emit it as a single line with no whitespace.)
+(Wrapped for readability. Emit it as a single line with no whitespace.)
 
 Note the password is `***`, not the real value. That is not optional.
 
 ## Checkboxes cannot be prefilled
 
-`bug_report.yml` ends with a required `confirm` checkbox ("I scanned open issues and Known limitations for a
-duplicate"). Checkbox fields do not prefill from the URL, and that is fine: the user ticking it is the moment
-they take ownership of the report. Tell them they need to tick it before GitHub will let them submit.
+Both templates end with required checkboxes (`confirm`). Checkbox fields do **not** prefill from the URL, and
+that is fine: the user ticking them is the moment they take ownership of the report. Tell them they need to
+tick the boxes before GitHub will let them submit. On `skill_feedback.yml` there are two, and one of them is
+the confirmation that they redacted their credentials, so do not paper over it.


### PR DESCRIPTION
## Skill feedback template

Feedback about a **skill** and feedback about the **container** are different things, triaged by different people. Until now they shared one bug template built around the container (`image-tag`, `runtime`, `docker logs`), so a user reporting *"the skill told my agent the wrong thing"* had nowhere to put it.

`skill_feedback.yml` captures what we're actually blind to:

- **Which skill** (dropdown of all 11, plus "the collection as a whole" for install/discovery failures)
- **Which agent** (Claude Code / Copilot / Codex / Cursor) — skills behave differently across harnesses and we cannot see which one the user ran
- **How they installed it** — this alone would have surfaced the install bug from #83
- **What the skill *said*, versus what they had to do instead** ← the money field. It is the one thing we cannot get any other way, and it is the entire reason the feedback flow exists.

Issues land under a new **`skills`** label, so skill reports are separable from container reports in the same repo. Routes from `aka.ms/sql-agent-skills-feedback`.

### The skill now routes before it files

`azuresql-db-feedback` decides skill-vs-container first, with a rule that settles it:

> **If the instructions were correct and the engine still broke, it is a container bug. If the instructions were wrong, incomplete, or ignored, it is a skill bug.**

It never files both, and asks the user when genuinely torn.

### The dropdown is a prefill contract

The skill fills the `skill` field with a value that must match a dropdown option **verbatim**. If someone adds a 12th skill and forgets the dropdown, the prefill silently breaks. **`canon-check` now asserts the dropdown lists exactly the skills on disk** (16/16 passing; verified it fails when they drift).

## Per-skill install commands

Following the pattern Supabase uses: one command for the whole collection, plus a table with a **copy button per skill**. Added to both `skills/README.md` and the landing page.

Also adds the **`azuresql-db-feedback` card**, which was missing from the grid, so the landing page now shows all 11 skills.

## The example prompt

It was a blockquote, which did not read as something you paste. It is a code block now, so it looks like a prompt and picks up a copy button from the existing docs JS automatically.

## Verification

- **Triggering eval: 100% trigger, 100% routing, 0% false positives** across 29 prompts, including two new rows that specifically test skill-feedback routing (`f1`: *"the azuresql-db-rag skill told me to do something that does not work"*, `f2`: *"where do I file feedback on these skills"*).
- **canon-check 16/16**, including the new dropdown contract.
- `skill_feedback.yml` parses; the dropdown matches the 11 skills on disk exactly.
- Install table rendered and inspected: 11 rows, correct per-skill command bound to every copy button.