### PR TITLE
Split the interactive login from the pull, and link the bare URLs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,7 +23,7 @@ Confirm you have:
 
 - A supported container engine installed and running (Docker, Podman, containerd, or Rancher Desktop). See [Prerequisites](prerequisites.md).
 - Port `1433` available on the host.
-- The registry username and password, provided when you sign up at https://aka.ms/sqldbcontainerpreview-signup (pull-only; may be rotated during the preview).
+- The registry username and password, provided when you sign up at [aka.ms/sqldbcontainerpreview-signup](https://aka.ms/sqldbcontainerpreview-signup) (pull-only; may be rotated during the preview).
 
 You do **not** need sqlcmd or any database tool installed: the container brings its own. Everything below works the same on macOS, Linux, and Windows.
 
@@ -61,12 +61,17 @@ Prefer to run it yourself? Three commands take you from pull to query, with Dock
 
 ### Step 1: sign in and pull the image
 
-The preview image is served from a private registry. Sign in, then pull the image.
-
-> **Note:** the registry username and password are **provided when you sign up for the Private Preview** at https://aka.ms/sqldbcontainerpreview-signup. They are shared and pull-only, must be treated as secrets, and may be rotated during the preview.
+The preview image is served from a private registry. Sign in first. This prompts for your password, so run it on its own:
 
 ```bash
 docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io -u <username>
+```
+
+> **Note:** the registry username and password are **provided when you sign up for the Private Preview** at [aka.ms/sqldbcontainerpreview-signup](https://aka.ms/sqldbcontainerpreview-signup). They are shared and pull-only, must be treated as secrets, and may be rotated during the preview.
+
+Once you are signed in, pull the image:
+
+```bash
 docker pull sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest
 ```
 


### PR DESCRIPTION
## The login/pull block was a copy-paste trap

`docker login` **prompts for a password**. When it shares a code block with `docker pull`, copying the whole block sends the `docker pull` line as the password. The login fails, and the pull never runs.

Split into two blocks: sign in (with the credentials note attached), then pull.

**Left alone deliberately:** the multi-command blocks in the skills and in `docs/prompts/*`. Those are handed to an *agent*, which runs commands one at a time, so the trap does not apply. Only `getting-started.md` is copied into a terminal by a human.

## Bare URLs

The two bare `https://aka.ms/...` URLs in getting started are now proper links, displayed as `aka.ms/xxx`.

Left the **descriptive labels** elsewhere as they are ("Report a bug", "sign up for the Private Preview", "GitHub Copilot integration"). Those read better in prose than a raw slug would; the rule applied is: show the slug when the URL is the thing being handed to the reader, keep the label when it is a phrase in a sentence.