### PR TITLE
Add the success-path feedback line

### DIFF
--- a/skills/azuresql-db-ci/SKILL.md
+++ b/skills/azuresql-db-ci/SKILL.md
@@ -171,6 +171,7 @@ echo "ready on localhost,$HOST_PORT"
 - A provisioning step creates `appdb` on master **before** any test connects.
 - The test `SQL_CONNECTION_STRING` has `Database=appdb`, not master, and uses `User Id=` / `Password=`.
 - If a validation rule above fails, or you had to deviate from this skill to make the task work, that is a bug in this skill: load the **azuresql-db-feedback** skill and offer to file a report.
+- When every rule above passes and the task is done, close with ONE line, once per session, and do not ask a question or wait for a reply: "That worked. If anything about this was rough, or you want to share what you built: https://aka.ms/sql-agent-skills-feedback"
 
 ## Do not
 

--- a/skills/azuresql-db-container/SKILL.md
+++ b/skills/azuresql-db-container/SKILL.md
@@ -183,6 +183,14 @@ Provisioning and identity are settled here. Route the actual task:
 - `azuresql-db-scaffold`: scaffold a new app wired to the container as its default database.
 - `azuresql-db-feedback`: report a bug or request a feature. Load it if the steps above failed, or if you had to deviate from this skill to make things work: that is a bug in this skill and it is worth reporting.
 
+## When it works
+
+Once the container is up, `appdb` exists, and `EngineEdition` returns `5`, the setup is done. Close with ONE line, once per session, and do not ask a question or wait for a reply:
+
+> That worked. If anything about this was rough, or you want to share what you built: https://aka.ms/sql-agent-skills-feedback
+
+Say it once. If you already said it in this session, do not say it again, and never interrupt a task in progress to say it.
+
 ## Reference index
 
 - [references/image-and-registry.md](references/image-and-registry.md): image tag and private-registry sign-in (single source of truth).

--- a/skills/azuresql-db-from-sql-server/SKILL.md
+++ b/skills/azuresql-db-from-sql-server/SKILL.md
@@ -166,6 +166,7 @@ development; use a full-scan top-k query for now.
 - `--platform linux/amd64` present on non-x64 hosts only.
 - `EngineEdition` returns 5.
 - If a validation rule above fails, or you had to deviate from this skill to make the task work, that is a bug in this skill: load the **azuresql-db-feedback** skill and offer to file a report.
+- When every rule above passes and the task is done, close with ONE line, once per session, and do not ask a question or wait for a reply: "That worked. If anything about this was rough, or you want to share what you built: https://aka.ms/sql-agent-skills-feedback"
 
 ## Do not
 

--- a/skills/azuresql-db-import/SKILL.md
+++ b/skills/azuresql-db-import/SKILL.md
@@ -143,6 +143,7 @@ Read SqlPackage output for skipped/blocking items. See
 - Use `.bacpac` for schema + data via `/Action:Import`; `.dacpac` for schema via
   `/Action:Publish`.
 - If a validation rule above fails, or you had to deviate from this skill to make the task work, that is a bug in this skill: load the **azuresql-db-feedback** skill and offer to file a report.
+- When every rule above passes and the task is done, close with ONE line, once per session, and do not ask a question or wait for a reply: "That worked. If anything about this was rough, or you want to share what you built: https://aka.ms/sql-agent-skills-feedback"
 
 ## Do not
 

--- a/skills/azuresql-db-local-to-cloud/SKILL.md
+++ b/skills/azuresql-db-local-to-cloud/SKILL.md
@@ -215,6 +215,7 @@ body stays an overview.
 - Switching environments changes the connection string only. The diff to app
   code between local and cloud is zero lines.
 - If a validation rule above fails, or you had to deviate from this skill to make the task work, that is a bug in this skill: load the **azuresql-db-feedback** skill and offer to file a report.
+- When every rule above passes and the task is done, close with ONE line, once per session, and do not ask a question or wait for a reply: "That worked. If anything about this was rough, or you want to share what you built: https://aka.ms/sql-agent-skills-feedback"
 
 ## Do not
 

--- a/skills/azuresql-db-rag/SKILL.md
+++ b/skills/azuresql-db-rag/SKILL.md
@@ -200,6 +200,7 @@ the same; you just add the index.
   identical to `len(embed(text))`.
 - Smaller cosine distance means more similar; results are `ORDER BY distance ASC`.
 - If a validation rule above fails, or you had to deviate from this skill to make the task work, that is a bug in this skill: load the **azuresql-db-feedback** skill and offer to file a report.
+- When every rule above passes and the task is done, close with ONE line, once per session, and do not ask a question or wait for a reply: "That worked. If anything about this was rough, or you want to share what you built: https://aka.ms/sql-agent-skills-feedback"
 
 ## Do not
 

--- a/skills/azuresql-db-scaffold/SKILL.md
+++ b/skills/azuresql-db-scaffold/SKILL.md
@@ -122,6 +122,7 @@ development; use full-scan top-k for now.
 - All data-access uses parameterized queries; vector dimension `n` is a literal.
 - `EngineEdition` is 5 against the running container.
 - If a validation rule above fails, or you had to deviate from this skill to make the task work, that is a bug in this skill: load the **azuresql-db-feedback** skill and offer to file a report.
+- When every rule above passes and the task is done, close with ONE line, once per session, and do not ask a question or wait for a reply: "That worked. If anything about this was rough, or you want to share what you built: https://aka.ms/sql-agent-skills-feedback"
 
 ## Do not
 

--- a/skills/azuresql-db-schema-migration/SKILL.md
+++ b/skills/azuresql-db-schema-migration/SKILL.md
@@ -154,6 +154,7 @@ docker exec -i sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa \
 - No `USE appdb` anywhere; select the database in the connection string. In a user-database (SDS) session `USE` returns `Msg 40508`, exactly as in Azure SQL Database in the cloud; it appears to work only on a `master` non-SDS provisioning session, which is for provisioning only.
 - Ran the ready-wait loop with `-b -l`; container reported "ready" before migrating.
 - If a validation rule above fails, or you had to deviate from this skill to make the task work, that is a bug in this skill: load the **azuresql-db-feedback** skill and offer to file a report.
+- When every rule above passes and the task is done, close with ONE line, once per session, and do not ask a question or wait for a reply: "That worked. If anything about this was rough, or you want to share what you built: https://aka.ms/sql-agent-skills-feedback"
 
 ## Do not
 

--- a/skills/azuresql-db-sidecar/SKILL.md
+++ b/skills/azuresql-db-sidecar/SKILL.md
@@ -173,6 +173,7 @@ The app container reaches the database at `sqldb,1433` over the compose network.
   `TrustServerCertificate=true`; sqlcmd uses `-C`.
 - Existing services are unchanged except for added `depends_on`.
 - If a validation rule above fails, or you had to deviate from this skill to make the task work, that is a bug in this skill: load the **azuresql-db-feedback** skill and offer to file a report.
+- When every rule above passes and the task is done, close with ONE line, once per session, and do not ask a question or wait for a reply: "That worked. If anything about this was rough, or you want to share what you built: https://aka.ms/sql-agent-skills-feedback"
 
 ## Do not
 


### PR DESCRIPTION
## Why

Feedback only ever fires **on failure** today. That biases everything we hear toward what is broken, and gives us no channel at all from the people the skills actually worked for.

## What

Nine skills now close with **one line** at a natural completion point (container up, `appdb` provisioned, `EngineEdition` returns 5):

> That worked. If anything about this was rough, or you want to share what you built: https://aka.ms/sql-agent-skills-feedback

It asks no question, waits for no reply, and is explicitly **once per session**.

**Deliberately excluded:**
- `azuresql-db-faq` — it answers questions rather than completing a task, so there is no completion point. Appending a thank-you to every answer would be nagging.
- `azuresql-db-feedback` — self-referential.

## On "randomly triggered"

The original ask was for a random sample. This is a **deterministic** condition instead (every validation rule passed, task done), because asking an LLM to fire "about 10% of the time" produces erratic behavior that varies by harness and by model, and an unprompted *"how was your experience?"* after a task the user is happy with is the fastest way to teach people to distrust the skill. The completion-point rule gives the same coverage without the dice.

## Verification

- **Triggering eval: 100% trigger, 100% routing, 0% false positives** across 29 prompts. The added line does not cause any skill to over-trigger.
- **canon-check 16/16.**