### PR TITLE
Move the single-skill install into a modal, behind a 12th card

### DIFF
--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -463,10 +463,26 @@ section[id] { scroll-margin-top: 84px; }
 /* skill-name label on the agent-skill cards */
 .skill-tag { display: inline-block; font-family: var(--font-mono); font-size: .68rem; color: var(--azure); background: rgba(19,102,224,.07); border: 1px solid rgba(19,102,224,.18); border-radius: 5px; padding: 2px 7px; margin-bottom: 10px; }
 
+/* ---------- "install a single skill" card: a button that reads as a card ----------
+   .skill-card is styled for <a>. A <button> brings its own font, alignment and
+   intrinsic width, so reset those or it spans the grid instead of sitting in a cell. */
+.skill-card-action { font: inherit; text-align: left; cursor: pointer; width: 100%; min-width: 0; margin: 0; appearance: none; }
+.skill-card-action:hover h4 { color: var(--azure); }
+.skill-card-action:hover h4 .arrow { color: var(--azure); transform: translateX(3px); }
+.skill-tag-alt { color: var(--muted); background: var(--mist); border-color: var(--line); }
+
+/* ---------- modal (native <dialog>) ---------- */
+.modal { width: min(620px, calc(100vw - 32px)); padding: 0; border: 1px solid var(--line); border-radius: var(--radius); box-shadow: var(--shadow-lg); color: inherit; background: var(--white); }
+.modal::backdrop { background: rgba(11,18,32,.55); backdrop-filter: blur(2px); }
+.modal-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; padding: 20px 22px 14px; border-bottom: 1px solid var(--line); }
+.modal-head h3 { font-size: 1.1rem; margin: 0 0 4px; }
+.modal-head p { color: var(--muted); font-size: .9rem; margin: 0; max-width: 46ch; }
+.modal-close { flex-shrink: 0; font-size: 1.4rem; line-height: 1; color: var(--muted); background: none; border: 0; cursor: pointer; padding: 2px 8px; border-radius: 6px; }
+.modal-close:hover { color: var(--ink); background: var(--mist); }
+.modal-close:focus-visible { outline: 2px solid var(--azure); outline-offset: 2px; }
+.modal-body { max-height: min(64vh, 560px); overflow-y: auto; }
+
 /* ---------- install a single skill (compact table, copy per skill) ---------- */
-.skill-install-title { font-size: 1.1rem; margin: 40px 0 6px; }
-.skill-install-lead { color: var(--muted); font-size: .95rem; max-width: 640px; margin: 0 0 16px; }
-.skill-install { background: var(--white); border: 1px solid var(--line); border-radius: var(--radius); box-shadow: var(--shadow); overflow: hidden; }
 .skill-install-table { width: 100%; border-collapse: collapse; }
 .skill-install-table td { padding: 10px 16px; border-bottom: 1px solid var(--line); vertical-align: middle; }
 .skill-install-table tr:last-child td { border-bottom: 0; }

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -44,6 +44,23 @@
     }
   }
 
+  // modals (native <dialog>: Escape and focus handling come for free)
+  document.querySelectorAll("[data-open-modal]").forEach(function (btn) {
+    btn.addEventListener("click", function () {
+      var dlg = document.getElementById(btn.getAttribute("data-open-modal"));
+      if (dlg && typeof dlg.showModal === "function") dlg.showModal();
+    });
+  });
+  document.querySelectorAll("dialog.modal").forEach(function (dlg) {
+    dlg.querySelectorAll("[data-close-modal]").forEach(function (btn) {
+      btn.addEventListener("click", function () { dlg.close(); });
+    });
+    // click the backdrop (i.e. the dialog element itself, outside its content) to close
+    dlg.addEventListener("click", function (e) {
+      if (e.target === dlg) dlg.close();
+    });
+  });
+
   // inline copy (commands, code blocks)
   document.querySelectorAll("[data-copy], [data-copy-text]").forEach(function (btn) {
     btn.addEventListener("click", function () {

--- a/docs/index.html
+++ b/docs/index.html
@@ -327,13 +327,25 @@ title: Azure SQL Developer
         <h4>Report a problem <span class="arrow">&rarr;</span></h4>
         <p>Your agent writes the bug report for you, from what it already knows, and hands you a prefilled issue to review. It never files anything without your say-so.</p>
       </a>
+      {% assign one_skills = "azuresql-db-container|Start the engine,azuresql-db-from-sql-server|Convert from SQL Server,azuresql-db-local-to-cloud|Local to cloud,azuresql-db-schema-migration|Schema migrations,azuresql-db-import|Import a database,azuresql-db-rag|RAG and vector search,azuresql-db-ci|CI,azuresql-db-sidecar|Sidecar,azuresql-db-scaffold|Scaffold,azuresql-db-faq|Answer questions,azuresql-db-feedback|Report a problem" | split: "," %}
+      <button class="skill-card skill-card-action" type="button" data-open-modal="single-skill">
+        <span class="skill-tag skill-tag-alt">one skill only</span>
+        <h4>Install a single skill <span class="arrow">&rarr;</span></h4>
+        <p>The command above installs all {{ one_skills | size }}, which is what we recommend: they hand off to each other. Need just one? Grab its install command.</p>
+      </button>
     </div>
+  </div>
 
-    <h4 class="skill-install-title">Install a single skill</h4>
-    <p class="skill-install-lead">The command above installs the whole collection, which is what we recommend: the skills hand off to each other. To take just one, name it.</p>
-    <div class="skill-install">
+  <dialog class="modal" id="single-skill" aria-labelledby="single-skill-title">
+    <div class="modal-head">
+      <div>
+        <h3 id="single-skill-title">Install a single skill</h3>
+        <p>Each skill stands alone, so one is enough to be useful. You only lose the handoffs between them.</p>
+      </div>
+      <button class="modal-close" type="button" data-close-modal aria-label="Close">&times;</button>
+    </div>
+    <div class="modal-body">
       <table class="skill-install-table">
-        {% assign one_skills = "azuresql-db-container|Start the engine,azuresql-db-from-sql-server|Convert from SQL Server,azuresql-db-local-to-cloud|Local to cloud,azuresql-db-schema-migration|Schema migrations,azuresql-db-import|Import a database,azuresql-db-rag|RAG and vector search,azuresql-db-ci|CI,azuresql-db-sidecar|Sidecar,azuresql-db-scaffold|Scaffold,azuresql-db-faq|Answer questions,azuresql-db-feedback|Report a problem" | split: "," %}
         {% for row in one_skills %}
           {% assign parts = row | split: "|" %}
           {% assign sname = parts[0] %}
@@ -347,7 +359,7 @@ title: Azure SQL Developer
         {% endfor %}
       </table>
     </div>
-  </div>
+  </dialog>
 </section>
 
 <!-- ============ USE CASES (JTBD) ============ -->


### PR DESCRIPTION
## The problem

The install table sat directly under the card grid and **repeated all 11 skill names the grid had just listed**, as the last thing on the page before Use Cases. Pure duplication, and it read as clutter.

## The fix (Carlos's design)

The grid gets a **12th card**, "Install a single skill", whose arrow opens a **modal** containing the table.

- The information is **one click away** instead of permanently on screen
- The grid stops ending on an **orphan row of two**: 11 skills + 1 action card fills a clean 4x3
- The action card carries a neutral grey tag ("one skill only") so it reads as an action, not a twelfth skill

Native `<dialog>`: Escape, focus handling, and the backdrop come for free with no library. Closes on the X or on the backdrop.

## One real bug, caught by rendering it

The card was **outside** the `.skill-cards` div, so it stacked full-width below the grid rather than sitting in a cell. I verified the structure programmatically (div balance, card is inside the grid container, 12 cards present) rather than assuming, and rendered both the grid and the open modal before shipping.