### PR TITLE
Repoint the "connect with the team" link to azuresql-developer-meet

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ For the first time, developers can build, test, and ship applications against th
 - File a bug: [GitHub Issues](https://aka.ms/azuresql-developer-bug)
 - Request a feature: [GitHub Issues](https://aka.ms/azuresql-developer-feature-request)
 - Ask a question, share a build, suggest an idea: [GitHub Discussions](../../discussions)
-- Connect with the team: [book a session](https://aka.ms/azuresql-container-meet) or email [azuresqldb-container@microsoft.com](mailto:azuresqldb-container@microsoft.com)
+- Connect with the team: [book a session](https://aka.ms/azuresql-developer-meet) or email [azuresqldb-container@microsoft.com](mailto:azuresqldb-container@microsoft.com)
 - Real-time conversation: the private Teams channel shared via the early-access feedback channel
 
 See [Feedback and how to engage](docs/feedback-and-how-to-engage.md) for the full guide on which channel fits which question.

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -23,7 +23,7 @@
       <a href="https://aka.ms/azuresql-developer-bug" rel="noopener">Report a bug</a>
       <a href="https://aka.ms/azuresql-developer-feature-request" rel="noopener">Request a feature</a>
       <a href="{{ '/feedback-and-how-to-engage.html' | relative_url }}">Feedback and how to engage</a>
-      <a href="https://aka.ms/azuresql-container-meet" rel="noopener">Connect with the team</a>
+      <a href="https://aka.ms/azuresql-developer-meet" rel="noopener">Connect with the team</a>
       <a href="mailto:azuresqldb-container@microsoft.com">Email the team</a>
       <a href="{{ site.public_repo }}/discussions" rel="noopener">GitHub Discussions</a>
     </div>

--- a/docs/feedback-and-how-to-engage.md
+++ b/docs/feedback-and-how-to-engage.md
@@ -29,7 +29,7 @@ Filing a bug or requesting a feature?
 | Share what you built                                       | [GitHub Discussions: Show & Tell](https://github.com/microsoft/azure-sql-database-container/discussions/categories/show-and-tell) |
 | Suggest a direction or pitch an idea                       | [GitHub Discussions: Ideas](https://github.com/microsoft/azure-sql-database-container/discussions/categories/ideas) |
 | Email the team directly                                    | [azuresqldb-container@microsoft.com](mailto:azuresqldb-container@microsoft.com) |
-| Book live time with the team                               | [Connect with the team](https://aka.ms/azuresql-container-meet) |
+| Book live time with the team                               | [Connect with the team](https://aka.ms/azuresql-developer-meet) |
 | Talk to the team in real time                              | Private Teams channel (link shared via the early-access feedback channel) |
 | Demo, ask questions live, hear roadmap updates             | Office hours (calendar invite shared via the early-access feedback channel) |
 
@@ -67,7 +67,7 @@ Discussions move slower than the Teams channel but they are searchable and durab
 Want to reach the team directly?
 
 - **Email:** [azuresqldb-container@microsoft.com](mailto:azuresqldb-container@microsoft.com). Good for anything that does not fit a public issue or discussion: onboarding questions, access, or a quick note to the team.
-- **Book live time:** [aka.ms/azuresql-container-meet](https://aka.ms/azuresql-container-meet). Grab a slot to talk through your scenario, show what you built, or work through a blocker with the team.
+- **Book live time:** [aka.ms/azuresql-developer-meet](https://aka.ms/azuresql-developer-meet). Grab a slot to talk through your scenario, show what you built, or work through a blocker with the team.
 
 For bugs and feature requests, still file on GitHub so the work is tracked and visible to the whole cohort.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -448,7 +448,7 @@ title: Azure SQL Developer
       <p class="lead lead-light">Your bugs and feature requests set the priorities. Reach the team directly, or pick the channel that fits your question.</p>
     </div>
     <div class="engage-cta">
-      <a class="btn btn-primary" href="https://aka.ms/azuresql-container-meet" rel="noopener">Connect with the team</a>
+      <a class="btn btn-primary" href="https://aka.ms/azuresql-developer-meet" rel="noopener">Connect with the team</a>
       <a class="btn btn-ghost-light" href="mailto:azuresqldb-container@microsoft.com">Email the team</a>
     </div>
     <div class="grid-4">


### PR DESCRIPTION
Replaces `aka.ms/azuresql-container-meet` with `aka.ms/azuresql-developer-meet` in **all five** places: the landing page CTA, the site footer, the README, and both references on the feedback page (including the one that displays the slug as its link text, so the visible text changed too).

## Two things worth knowing

**The old link was already dead.** `aka.ms/azuresql-container-meet` 302s to a Bing search fallback, which is what aka.ms serves for an unregistered slug. So "Book live time with the team" has been a broken link on the live site.

**The new slug does not yet point at a booking page.** `aka.ms/azuresql-developer-meet` currently 301s to `aka.ms/azuresql-developer`, which is the site homepage. A user clicking "Book live time with the team" lands back on the docs. This PR is still a strict improvement (dead link becomes a working one), but **the slug needs repointing at the real booking target.**

## While I was in there

Audited every `aka.ms` link in the repo. All nine now resolve, no other dead slugs.