### PR TITLE
Collapse the skill grid to two rows behind a "see more"

### DIFF
--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -463,13 +463,21 @@ section[id] { scroll-margin-top: 84px; }
 /* skill-name label on the agent-skill cards */
 .skill-tag { display: inline-block; font-family: var(--font-mono); font-size: .68rem; color: var(--azure); background: rgba(19,102,224,.07); border: 1px solid rgba(19,102,224,.18); border-radius: 5px; padding: 2px 7px; margin-bottom: 10px; }
 
-/* ---------- "install a single skill" card: a button that reads as a card ----------
-   .skill-card is styled for <a>. A <button> brings its own font, alignment and
-   intrinsic width, so reset those or it spans the grid instead of sitting in a cell. */
-.skill-card-action { font: inherit; text-align: left; cursor: pointer; width: 100%; min-width: 0; margin: 0; appearance: none; }
-.skill-card-action:hover h4 { color: var(--azure); }
-.skill-card-action:hover h4 .arrow { color: var(--azure); transform: translateX(3px); }
-.skill-tag-alt { color: var(--muted); background: var(--mist); border-color: var(--line); }
+/* ---------- collapse the skill grid to two rows ----------
+   Twelve cards is a lot of page for a section most visitors scroll past. Show the
+   first six plus the action card, and reveal the rest on demand. The action card
+   is ordered last so it always sits at the end of the visible set. */
+/* Collapsed: exactly two full rows of six. */
+.skill-cards .skill-card-extra { display: none; }
+.skill-cards.is-open .skill-card-extra { display: block; }
+.skill-more { display: flex; justify-content: center; gap: 10px; margin-top: 22px; flex-wrap: wrap; }
+.skill-more-alt { color: var(--muted); }
+.skill-more-alt:hover { color: var(--azure); }
+.skill-more-btn { display: inline-flex; align-items: center; gap: 8px; font: inherit; font-size: .9rem; font-weight: 500; color: var(--azure); background: var(--white); border: 1px solid var(--line); border-radius: 999px; padding: 9px 20px; cursor: pointer; box-shadow: var(--shadow); transition: border-color .15s ease, background .15s ease; }
+.skill-more-btn:hover { border-color: #c6d6ee; background: var(--mist); }
+.skill-more-btn:focus-visible { outline: 2px solid var(--azure); outline-offset: 2px; }
+.skill-more-ico { font-size: .8em; transition: transform .18s ease; }
+.skill-more-btn[aria-expanded="true"] .skill-more-ico { transform: rotate(180deg); }
 
 /* ---------- modal (native <dialog>) ---------- */
 .modal { width: min(620px, calc(100vw - 32px)); padding: 0; border: 1px solid var(--line); border-radius: var(--radius); box-shadow: var(--shadow-lg); color: inherit; background: var(--white); }

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -44,6 +44,21 @@
     }
   }
 
+  // show/hide the rest of the skill cards
+  document.querySelectorAll("[data-toggle-skills]").forEach(function (btn) {
+    var grid = document.querySelector(".skill-cards");
+    var label = btn.querySelector(".skill-more-label");
+    if (!grid || !label) return;
+    var hidden = grid.querySelectorAll(".skill-card-extra").length;
+    var shown = grid.querySelectorAll(".skill-card:not(.skill-card-extra):not(.skill-card-action)").length;
+    label.textContent = "See all " + (hidden + shown) + " skills";
+    btn.addEventListener("click", function () {
+      var open = grid.classList.toggle("is-open");
+      btn.setAttribute("aria-expanded", open ? "true" : "false");
+      label.textContent = open ? "Show fewer" : "See all " + (hidden + shown) + " skills";
+    });
+  });
+
   // modals (native <dialog>: Escape and focus handling come for free)
   document.querySelectorAll("[data-open-modal]").forEach(function (btn) {
     btn.addEventListener("click", function () {

--- a/docs/index.html
+++ b/docs/index.html
@@ -292,35 +292,35 @@ title: Azure SQL Developer
         <h4>RAG and vector search <span class="arrow">&rarr;</span></h4>
         <p>Native <code>VECTOR</code> type and <code>VECTOR_DISTANCE</code>, with a local embedding model.</p>
       </a>
-      <a class="skill-card" href="{{ site.repo }}/tree/main/skills/azuresql-db-ci" rel="noopener">
+      <a class="skill-card skill-card-extra" href="{{ site.repo }}/tree/main/skills/azuresql-db-ci" rel="noopener">
 
         <span class="skill-tag">azuresql-db-ci</span>
 
         <h4>CI <span class="arrow">&rarr;</span></h4>
         <p>Run the engine as a service in GitHub Actions, with the right readiness and provisioning.</p>
       </a>
-      <a class="skill-card" href="{{ site.repo }}/tree/main/skills/azuresql-db-sidecar" rel="noopener">
+      <a class="skill-card skill-card-extra" href="{{ site.repo }}/tree/main/skills/azuresql-db-sidecar" rel="noopener">
 
         <span class="skill-tag">azuresql-db-sidecar</span>
 
         <h4>Sidecar <span class="arrow">&rarr;</span></h4>
         <p>Add it to a docker compose stack or Dev Container, wired by service name.</p>
       </a>
-      <a class="skill-card" href="{{ site.repo }}/tree/main/skills/azuresql-db-scaffold" rel="noopener">
+      <a class="skill-card skill-card-extra" href="{{ site.repo }}/tree/main/skills/azuresql-db-scaffold" rel="noopener">
 
         <span class="skill-tag">azuresql-db-scaffold</span>
 
         <h4>Scaffold <span class="arrow">&rarr;</span></h4>
         <p>Bootstrap a new app with Azure SQL Developer as the default local database.</p>
       </a>
-      <a class="skill-card" href="{{ site.repo }}/tree/main/skills/azuresql-db-faq" rel="noopener">
+      <a class="skill-card skill-card-extra" href="{{ site.repo }}/tree/main/skills/azuresql-db-faq" rel="noopener">
 
         <span class="skill-tag">azuresql-db-faq</span>
 
         <h4>Answer questions <span class="arrow">&rarr;</span></h4>
         <p>What Azure SQL Developer can and can't do, and why it differs from the cloud: backups, <code>USE</code>, vector index, x64-only, tooling.</p>
       </a>
-      <a class="skill-card" href="{{ site.repo }}/tree/main/skills/azuresql-db-feedback" rel="noopener">
+      <a class="skill-card skill-card-extra" href="{{ site.repo }}/tree/main/skills/azuresql-db-feedback" rel="noopener">
 
         <span class="skill-tag">azuresql-db-feedback</span>
 
@@ -328,11 +328,13 @@ title: Azure SQL Developer
         <p>Your agent writes the bug report for you, from what it already knows, and hands you a prefilled issue to review. It never files anything without your say-so.</p>
       </a>
       {% assign one_skills = "azuresql-db-container|Start the engine,azuresql-db-from-sql-server|Convert from SQL Server,azuresql-db-local-to-cloud|Local to cloud,azuresql-db-schema-migration|Schema migrations,azuresql-db-import|Import a database,azuresql-db-rag|RAG and vector search,azuresql-db-ci|CI,azuresql-db-sidecar|Sidecar,azuresql-db-scaffold|Scaffold,azuresql-db-faq|Answer questions,azuresql-db-feedback|Report a problem" | split: "," %}
-      <button class="skill-card skill-card-action" type="button" data-open-modal="single-skill">
-        <span class="skill-tag skill-tag-alt">one skill only</span>
-        <h4>Install a single skill <span class="arrow">&rarr;</span></h4>
-        <p>The command above installs all {{ one_skills | size }}, which is what we recommend: they hand off to each other. Need just one? Grab its install command.</p>
+    </div>
+    <div class="skill-more">
+      <button class="skill-more-btn" type="button" data-toggle-skills aria-expanded="false">
+        <span class="skill-more-label">See all 11 skills</span>
+        <span class="skill-more-ico" aria-hidden="true">&#8964;</span>
       </button>
+      <button class="skill-more-btn skill-more-alt" type="button" data-open-modal="single-skill">Install a single skill</button>
     </div>
   </div>
 


### PR DESCRIPTION
## The problem

Twelve cards made the Agent skills section very tall, for something most visitors will scroll past.

## The fix

Shows the **first two rows** (six skills). "See all 11 skills" reveals the rest; the label flips to "Show fewer" and the chevron rotates.

**The "Install a single skill" action moved out of the grid** and into the footer row beside the toggle:

- As a twelfth card it was **stranded on its own third row** in the collapsed state, which is the exact orphan-row problem the card was added to solve
- Hiding it behind the toggle would have removed the **only entry point to the modal**
- As a pill button next to "See all 11 skills" it stays reachable and costs no vertical space

The toggle **counts the cards** rather than hard-coding "11", so adding a skill later cannot silently make the label wrong.

## Verified

Rendered both states before shipping (collapsed: 2 rows + 2 buttons; expanded: all 11 + "Show fewer"). Div balance checked, canon-check 16/16.