### PR TITLE
Centre the GitHub Copilot icon in its tile

### DIFF
--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -366,6 +366,11 @@ section[id] { scroll-margin-top: 84px; }
 .agent h3 { transition: color .15s ease; }
 .agent:hover h3 { color: var(--azure); }
 .agent img { width: 40px; height: 40px; margin: 0 auto 14px; display: block; background: var(--ink); border-radius: 11px; padding: 9px; }
+/* The Copilot mark's ink sits in the upper part of its viewBox, so it reads as
+   floating high in the tile while the other three are centred. Nudge it down
+   optically. Trimming the padding-top and adding it back at the bottom keeps the
+   glyph the same size and only moves it. */
+.agent img.agent-ico-copilot { padding: 7px 9px 11px; }
 .agent h3 { font-size: 1.05rem; margin-bottom: 4px; }
 .agent p { color: var(--muted); font-size: .86rem; }
 .agents-note { text-align: center; margin-top: 22px; color: var(--muted); font-size: .98rem; }

--- a/docs/index.html
+++ b/docs/index.html
@@ -213,7 +213,7 @@ title: Azure SQL Developer
     </div>
     <div class="agents">
       <a class="agent" href="https://docs.github.com/copilot/get-started/quickstart" rel="noopener">
-        <img src="{{ '/assets/img/agents/copilot.svg' | relative_url }}" alt="" width="34" height="34" aria-hidden="true">
+        <img class="agent-ico-copilot" src="{{ '/assets/img/agents/copilot.svg' | relative_url }}" alt="" width="34" height="34" aria-hidden="true">
         <h3>GitHub Copilot</h3>
         <p>App, CLI, and VS Code</p>
       </a>


### PR DESCRIPTION
## The problem

The Copilot mark's ink sits in the **upper part of its 24x24 viewBox**, so with the uniform 9px padding the glyph rode high in its dark tile while Claude, Codex, and Cursor all sat centred.

Rendering the four with a centre line through them makes it unambiguous: the line cuts through the **bottom** of the Copilot glyph and through the **middle** of the other three.

## The fix

Nudged it down optically with asymmetric padding (7px top, 11px bottom) rather than editing the vendor SVG path. The glyph keeps its exact size; only its position changes, and the change is scoped to a single class (`.agent-ico-copilot`) so it cannot affect the other icons.

Verified by rendering before/after with a centre line: all four now sit on the line.