### PR TITLE
Add runtime tabs to homepage quickstart commands

### DIFF
--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -441,7 +441,13 @@ section[id] { scroll-margin-top: 84px; }
 .qstep-body { flex: 1; min-width: 0; }
 .qstep-body h3 { font-size: 1.1rem; margin-bottom: 2px; }
 .qstep-desc { color: var(--muted); font-size: .92rem; margin-bottom: 11px; }
+.qstep-cmd-group { display: flex; flex-direction: column; gap: 8px; }
+.runtime-tabs { display: inline-flex; align-self: flex-start; gap: 2px; background: var(--mist); border: 1px solid var(--line); border-radius: 8px; padding: 3px; }
+.runtime-tab { font-family: var(--font-mono); font-weight: 600; font-size: .72rem; color: var(--muted); background: transparent; border: 0; border-radius: 6px; padding: 5px 12px; cursor: pointer; transition: color .15s ease, background .15s ease, box-shadow .15s ease; }
+.runtime-tab.is-active { background: var(--white); color: var(--ink); box-shadow: var(--shadow); }
+.runtime-tab:hover:not(.is-active) { color: var(--ink); }
 .qstep-cmd { display: flex; align-items: flex-start; gap: 12px; background: var(--ink); border: 1px solid var(--ink-3); border-radius: 10px; padding: 12px 11px 12px 15px; box-shadow: var(--shadow); }
+.qstep-cmd[hidden] { display: none; }
 .qstep-cmd code { flex: 1; min-width: 0; font-family: var(--font-mono); font-size: .82rem; line-height: 1.65; color: #e7eefc; white-space: pre; overflow-x: auto; }
 .qstep-cmd .copy-btn { flex-shrink: 0; }
 .steps-foot { margin-top: 26px; color: var(--muted); font-size: .96rem; }

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -112,6 +112,27 @@
     });
   });
 
+  // ---- quickstart: Docker / Podman / containerd runtime tabs ----
+  document.querySelectorAll("[data-runtime-tabs]").forEach(function (group) {
+    var tabs = group.querySelectorAll(".runtime-tab");
+    var panels = group.querySelectorAll("[data-runtime-panel]");
+    function setRuntime(runtime) {
+      tabs.forEach(function (tab) {
+        var on = tab.getAttribute("data-runtime") === runtime;
+        tab.classList.toggle("is-active", on);
+        tab.setAttribute("aria-selected", on ? "true" : "false");
+      });
+      panels.forEach(function (panel) {
+        panel.hidden = panel.getAttribute("data-runtime-panel") !== runtime;
+      });
+    }
+    tabs.forEach(function (tab) {
+      tab.addEventListener("click", function () {
+        setRuntime(tab.getAttribute("data-runtime"));
+      });
+    });
+  });
+
   // ---- local / cloud connection-string swap ----
   var swap = document.querySelector("[data-swap]");
   if (swap) {

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -113,25 +113,29 @@
   });
 
   // ---- quickstart: Docker / Podman / containerd runtime tabs ----
-  document.querySelectorAll("[data-runtime-tabs]").forEach(function (group) {
-    var tabs = group.querySelectorAll(".runtime-tab");
-    var panels = group.querySelectorAll("[data-runtime-panel]");
-    function setRuntime(runtime) {
-      tabs.forEach(function (tab) {
-        var on = tab.getAttribute("data-runtime") === runtime;
-        tab.classList.toggle("is-active", on);
-        tab.setAttribute("aria-selected", on ? "true" : "false");
+  var runtimeGroups = document.querySelectorAll("[data-runtime-tabs]");
+  function setRuntime(runtime) {
+    runtimeGroups.forEach(function (group) {
+      group.querySelectorAll(".runtime-tab").forEach(function (tab) {
+        tab.classList.toggle("is-active", tab.getAttribute("data-runtime") === runtime);
       });
-      panels.forEach(function (panel) {
+      group.querySelectorAll("[data-runtime-panel]").forEach(function (panel) {
         panel.hidden = panel.getAttribute("data-runtime-panel") !== runtime;
       });
-    }
-    tabs.forEach(function (tab) {
+    });
+    try { localStorage.setItem("runtime", runtime); } catch (e) {}
+  }
+  runtimeGroups.forEach(function (group) {
+    group.querySelectorAll(".runtime-tab").forEach(function (tab) {
       tab.addEventListener("click", function () {
         setRuntime(tab.getAttribute("data-runtime"));
       });
     });
   });
+  try {
+    var savedRuntime = localStorage.getItem("runtime");
+    if (savedRuntime) setRuntime(savedRuntime);
+  } catch (e) {}
 
   // ---- local / cloud connection-string swap ----
   var swap = document.querySelector("[data-swap]");

--- a/docs/index.html
+++ b/docs/index.html
@@ -169,10 +169,10 @@ title: Azure SQL Developer
           <h3>Sign in to the preview registry</h3>
           <p class="qstep-desc">Use the username and password you received when you signed up.</p>
           <div class="qstep-cmd-group" data-runtime-tabs>
-            <div class="runtime-tabs" role="tablist" aria-label="Container runtime">
-              <button class="runtime-tab is-active" type="button" role="tab" aria-selected="true" data-runtime="docker">Docker</button>
-              <button class="runtime-tab" type="button" role="tab" aria-selected="false" data-runtime="podman">Podman</button>
-              <button class="runtime-tab" type="button" role="tab" aria-selected="false" data-runtime="containerd">containerd</button>
+            <div class="runtime-tabs" aria-label="Container runtime">
+              <button class="runtime-tab is-active" type="button" data-runtime="docker">Docker</button>
+              <button class="runtime-tab" type="button" data-runtime="podman">Podman</button>
+              <button class="runtime-tab" type="button" data-runtime="containerd">containerd (nerdctl)</button>
             </div>
             <div class="qstep-cmd" data-runtime-panel="docker">
               <code><span class="cmd-p">$</span> docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io -u &lt;username&gt;</code>
@@ -193,12 +193,12 @@ title: Azure SQL Developer
         <span class="qstep-num">2</span>
         <div class="qstep-body">
           <h3>Start the container</h3>
-          <p class="qstep-desc">Run it on port 1433 with a strong SA password.</p>
+          <p class="qstep-desc">Run it on port 1433 with a strong SA password. On a non-x64 host, add <code>--platform linux/amd64</code> to the run command (see <a href="{{ '/getting-started.html' | relative_url }}#step-2-start-the-container">Getting started</a>).</p>
           <div class="qstep-cmd-group" data-runtime-tabs>
-            <div class="runtime-tabs" role="tablist" aria-label="Container runtime">
-              <button class="runtime-tab is-active" type="button" role="tab" aria-selected="true" data-runtime="docker">Docker</button>
-              <button class="runtime-tab" type="button" role="tab" aria-selected="false" data-runtime="podman">Podman</button>
-              <button class="runtime-tab" type="button" role="tab" aria-selected="false" data-runtime="containerd">containerd</button>
+            <div class="runtime-tabs" aria-label="Container runtime">
+              <button class="runtime-tab is-active" type="button" data-runtime="docker">Docker</button>
+              <button class="runtime-tab" type="button" data-runtime="podman">Podman</button>
+              <button class="runtime-tab" type="button" data-runtime="containerd">containerd (nerdctl)</button>
             </div>
             <div class="qstep-cmd" data-runtime-panel="docker">
               <code><span class="cmd-p">$</span> docker run --name sqldb -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd" \
@@ -224,10 +224,10 @@ title: Azure SQL Developer
           <h3>Connect and query</h3>
           <p class="qstep-desc">No host install needed: the container bundles <a href="https://learn.microsoft.com/sql/tools/sqlcmd/sqlcmd-utility" rel="noopener">sqlcmd</a>. Run your first query with exec.</p>
           <div class="qstep-cmd-group" data-runtime-tabs>
-            <div class="runtime-tabs" role="tablist" aria-label="Container runtime">
-              <button class="runtime-tab is-active" type="button" role="tab" aria-selected="true" data-runtime="docker">Docker</button>
-              <button class="runtime-tab" type="button" role="tab" aria-selected="false" data-runtime="podman">Podman</button>
-              <button class="runtime-tab" type="button" role="tab" aria-selected="false" data-runtime="containerd">containerd</button>
+            <div class="runtime-tabs" aria-label="Container runtime">
+              <button class="runtime-tab is-active" type="button" data-runtime="docker">Docker</button>
+              <button class="runtime-tab" type="button" data-runtime="podman">Podman</button>
+              <button class="runtime-tab" type="button" data-runtime="containerd">containerd (nerdctl)</button>
             </div>
             <div class="qstep-cmd" data-runtime-panel="docker">
               <code><span class="cmd-p">$</span> docker exec sqldb /opt/mssql-tools18/bin/sqlcmd \

--- a/docs/index.html
+++ b/docs/index.html
@@ -168,9 +168,24 @@ title: Azure SQL Developer
         <div class="qstep-body">
           <h3>Sign in to the preview registry</h3>
           <p class="qstep-desc">Use the username and password you received when you signed up.</p>
-          <div class="qstep-cmd">
-            <code><span class="cmd-p">$</span> docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io -u &lt;username&gt;</code>
-            <button class="copy-btn" type="button" data-copy-text="docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io -u <username>"><span class="copy-label">Copy</span></button>
+          <div class="qstep-cmd-group" data-runtime-tabs>
+            <div class="runtime-tabs" role="tablist" aria-label="Container runtime">
+              <button class="runtime-tab is-active" type="button" role="tab" aria-selected="true" data-runtime="docker">Docker</button>
+              <button class="runtime-tab" type="button" role="tab" aria-selected="false" data-runtime="podman">Podman</button>
+              <button class="runtime-tab" type="button" role="tab" aria-selected="false" data-runtime="containerd">containerd</button>
+            </div>
+            <div class="qstep-cmd" data-runtime-panel="docker">
+              <code><span class="cmd-p">$</span> docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io -u &lt;username&gt;</code>
+              <button class="copy-btn" type="button" data-copy-text="docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io -u <username>"><span class="copy-label">Copy</span></button>
+            </div>
+            <div class="qstep-cmd" data-runtime-panel="podman" hidden>
+              <code><span class="cmd-p">$</span> podman login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io -u &lt;username&gt;</code>
+              <button class="copy-btn" type="button" data-copy-text="podman login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io -u <username>"><span class="copy-label">Copy</span></button>
+            </div>
+            <div class="qstep-cmd" data-runtime-panel="containerd" hidden>
+              <code><span class="cmd-p">$</span> nerdctl login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io -u &lt;username&gt;</code>
+              <button class="copy-btn" type="button" data-copy-text="nerdctl login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io -u <username>"><span class="copy-label">Copy</span></button>
+            </div>
           </div>
         </div>
       </div>
@@ -179,10 +194,27 @@ title: Azure SQL Developer
         <div class="qstep-body">
           <h3>Start the container</h3>
           <p class="qstep-desc">Run it on port 1433 with a strong SA password.</p>
-          <div class="qstep-cmd">
-            <code><span class="cmd-p">$</span> docker run -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd" \
+          <div class="qstep-cmd-group" data-runtime-tabs>
+            <div class="runtime-tabs" role="tablist" aria-label="Container runtime">
+              <button class="runtime-tab is-active" type="button" role="tab" aria-selected="true" data-runtime="docker">Docker</button>
+              <button class="runtime-tab" type="button" role="tab" aria-selected="false" data-runtime="podman">Podman</button>
+              <button class="runtime-tab" type="button" role="tab" aria-selected="false" data-runtime="containerd">containerd</button>
+            </div>
+            <div class="qstep-cmd" data-runtime-panel="docker">
+              <code><span class="cmd-p">$</span> docker run --name sqldb -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd" \
     -p 1433:1433 -d sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest</code>
-            <button class="copy-btn" type="button" data-copy-text="docker run -e &quot;ACCEPT_EULA=Y&quot; -e &quot;MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd&quot; \&#10;    -p 1433:1433 -d sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest"><span class="copy-label">Copy</span></button>
+              <button class="copy-btn" type="button" data-copy-text="docker run --name sqldb -e &quot;ACCEPT_EULA=Y&quot; -e &quot;MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd&quot; \&#10;    -p 1433:1433 -d sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest"><span class="copy-label">Copy</span></button>
+            </div>
+            <div class="qstep-cmd" data-runtime-panel="podman" hidden>
+              <code><span class="cmd-p">$</span> podman run --name sqldb -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd" \
+    -p 1433:1433 -d sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest</code>
+              <button class="copy-btn" type="button" data-copy-text="podman run --name sqldb -e &quot;ACCEPT_EULA=Y&quot; -e &quot;MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd&quot; \&#10;    -p 1433:1433 -d sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest"><span class="copy-label">Copy</span></button>
+            </div>
+            <div class="qstep-cmd" data-runtime-panel="containerd" hidden>
+              <code><span class="cmd-p">$</span> nerdctl run --name sqldb -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd" \
+    -p 1433:1433 -d sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest</code>
+              <button class="copy-btn" type="button" data-copy-text="nerdctl run --name sqldb -e &quot;ACCEPT_EULA=Y&quot; -e &quot;MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd&quot; \&#10;    -p 1433:1433 -d sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest"><span class="copy-label">Copy</span></button>
+            </div>
           </div>
         </div>
       </div>
@@ -190,11 +222,28 @@ title: Azure SQL Developer
         <span class="qstep-num">3</span>
         <div class="qstep-body">
           <h3>Connect and query</h3>
-          <p class="qstep-desc">Open a session with <a href="https://learn.microsoft.com/sql/tools/sqlcmd/sqlcmd-utility" rel="noopener">sqlcmd</a> and run your first query.</p>
-          <div class="qstep-cmd">
-            <code><span class="cmd-p">$</span> sqlcmd -S localhost,1433 -U sa -C -h-1 \
-    -Q "SET NOCOUNT ON; SELECT @@VERSION AS Version;"</code>
-            <button class="copy-btn" type="button" data-copy-text="sqlcmd -S localhost,1433 -U sa -C -h-1 \&#10;    -Q &quot;SET NOCOUNT ON; SELECT @@VERSION AS Version;&quot;"><span class="copy-label">Copy</span></button>
+          <p class="qstep-desc">No host install needed: the container bundles <a href="https://learn.microsoft.com/sql/tools/sqlcmd/sqlcmd-utility" rel="noopener">sqlcmd</a>. Run your first query with exec.</p>
+          <div class="qstep-cmd-group" data-runtime-tabs>
+            <div class="runtime-tabs" role="tablist" aria-label="Container runtime">
+              <button class="runtime-tab is-active" type="button" role="tab" aria-selected="true" data-runtime="docker">Docker</button>
+              <button class="runtime-tab" type="button" role="tab" aria-selected="false" data-runtime="podman">Podman</button>
+              <button class="runtime-tab" type="button" role="tab" aria-selected="false" data-runtime="containerd">containerd</button>
+            </div>
+            <div class="qstep-cmd" data-runtime-panel="docker">
+              <code><span class="cmd-p">$</span> docker exec sqldb /opt/mssql-tools18/bin/sqlcmd \
+    -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -Q "SELECT @@VERSION;"</code>
+              <button class="copy-btn" type="button" data-copy-text="docker exec sqldb /opt/mssql-tools18/bin/sqlcmd \&#10;    -S localhost -U sa -P &quot;YourStr0ng_Passw0rd&quot; -C -Q &quot;SELECT @@VERSION;&quot;"><span class="copy-label">Copy</span></button>
+            </div>
+            <div class="qstep-cmd" data-runtime-panel="podman" hidden>
+              <code><span class="cmd-p">$</span> podman exec sqldb /opt/mssql-tools18/bin/sqlcmd \
+    -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -Q "SELECT @@VERSION;"</code>
+              <button class="copy-btn" type="button" data-copy-text="podman exec sqldb /opt/mssql-tools18/bin/sqlcmd \&#10;    -S localhost -U sa -P &quot;YourStr0ng_Passw0rd&quot; -C -Q &quot;SELECT @@VERSION;&quot;"><span class="copy-label">Copy</span></button>
+            </div>
+            <div class="qstep-cmd" data-runtime-panel="containerd" hidden>
+              <code><span class="cmd-p">$</span> nerdctl exec sqldb /opt/mssql-tools18/bin/sqlcmd \
+    -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -Q "SELECT @@VERSION;"</code>
+              <button class="copy-btn" type="button" data-copy-text="nerdctl exec sqldb /opt/mssql-tools18/bin/sqlcmd \&#10;    -S localhost -U sa -P &quot;YourStr0ng_Passw0rd&quot; -C -Q &quot;SELECT @@VERSION;&quot;"><span class="copy-label">Copy</span></button>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Replace single Docker-only command blocks in the quickstart section with tabbed examples for Docker, Podman, and containerd (nerdctl). Users can switch runtimes without hunting for "replace docker with podman" notes, and each tab keeps its own copy button.

- Add runtime tab styles and hidden panel support in main.scss
- Add tab switching logic in main.js with aria-selected updates
- Step 1: registry login for docker, podman, and nerdctl
- Step 2: container run with --name sqldb for all three runtimes
- Step 3: use bundled sqlcmd via exec instead of a host install so user get get going just with the container they've just started,

<img width="885" height="618" alt="image" src="https://github.com/user-attachments/assets/10cace54-eabf-4abe-9f58-137586c92ceb" />

<img width="856" height="641" alt="image" src="https://github.com/user-attachments/assets/4a81c767-524f-4b52-843c-4c1762914b7d" />

<img width="865" height="664" alt="image" src="https://github.com/user-attachments/assets/a1810ed6-7457-4345-bece-aa7538b2894e" />
