### PR TITLE
Add shareable anchors to doc-page headings

### DIFF
--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -227,6 +227,30 @@ section[id] { scroll-margin-top: 84px; }
 .head-anchor:hover { opacity: 1; text-decoration: none; }
 .section-head-light .head-anchor { color: #fff; }
 @media (hover: none) { .head-anchor { opacity: .4; } }
+
+/* shareable anchors on doc-page headings. Kramdown already emits the ids; the JS
+   adds the visible link and copies the full URL on click. */
+.prose h2, .prose h3 { scroll-margin-top: 84px; position: relative; }
+.prose h2:hover .head-anchor,
+.prose h3:hover .head-anchor,
+.prose .head-anchor:focus-visible { opacity: .6; }
+.prose .head-anchor { position: relative; cursor: pointer; }
+.prose .head-anchor.is-copied { opacity: 1; }
+.prose .head-anchor.is-copied::after {
+  content: "Link copied";
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 8px);
+  transform: translateX(-50%);
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: .7rem;
+  font-weight: 500;
+  color: var(--on-dark);
+  background: var(--ink);
+  border-radius: 6px;
+  padding: 4px 9px;
+}
 .section-head .lead { color: var(--muted); font-size: 1.1rem; margin-top: 14px; }
 .section-head-center { max-width: 720px; margin-left: auto; margin-right: auto; text-align: center; }
 .section-head-center .eyebrow { justify-content: center; }

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -44,6 +44,29 @@
     }
   }
 
+  // shareable anchors on doc-page headings (kramdown already gives them ids)
+  document.querySelectorAll(".prose h2[id], .prose h3[id]").forEach(function (h) {
+    if (h.querySelector(".head-anchor")) return;
+    var a = document.createElement("a");
+    a.className = "head-anchor";
+    a.href = "#" + h.id;
+    a.setAttribute("aria-label", "Link to this section");
+    a.textContent = "#";
+    a.addEventListener("click", function (e) {
+      e.preventDefault();
+      var url = location.origin + location.pathname + "#" + h.id;
+      history.replaceState(null, "", "#" + h.id);
+      // copy the full link, but flash a tooltip rather than swapping the "#" for
+      // "Copied", which would reflow the heading
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(url).catch(function () {});
+      }
+      a.classList.add("is-copied");
+      setTimeout(function () { a.classList.remove("is-copied"); }, 1600);
+    });
+    h.appendChild(a);
+  });
+
   // show/hide the rest of the skill cards
   document.querySelectorAll("[data-toggle-skills]").forEach(function (btn) {
     var grid = document.querySelector(".skill-cards");


### PR DESCRIPTION
Asked for after a Private Preview participant wanted to link someone straight to a section.

## The ids already existed

Kramdown emits them on every heading, so `getting-started.html#manual-run-it-yourself` **already worked**. There was simply no way to *get* that link out of the page without reading the HTML.

## What changed

Every `h2` and `h3` in the docs now gets a `#` on hover. Clicking it:

- copies the **full URL** to the clipboard (not just the fragment)
- flashes a **"Link copied"** tooltip rather than swapping the `#` for the word "Copied", which would reflow the heading
- updates the address bar without a jump

Reuses the `.head-anchor` style the landing page already had, so it looks native.

Also sets `scroll-margin-top` on prose headings, so a heading you link to directly doesn't land **underneath the sticky nav**.

Rendered against the real deployed page HTML before shipping.