### PR TITLE
Add CONTRIBUTING, SUPPORT, and a pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+<!--
+Thanks for contributing. For anything beyond a small documentation fix, please open an
+issue first so we can agree on the approach: see CONTRIBUTING.md.
+-->
+
+## What this changes
+
+<!-- What does this do, and why? If it fixes an issue, write "Fixes #123". -->
+
+## How you verified it
+
+<!--
+Tell us what you actually ran, not what should work.
+
+- Docs or site change: did you build the site locally, or check the rendered page?
+- Command change: did you run the command? On which OS and container runtime?
+- Agent skill change: did you load the skill and give an agent a real task with it?
+-->
+
+## Checklist
+
+- [ ] I opened an issue first, or this is a small documentation fix
+- [ ] Commands I changed are copy-pasteable and I ran them
+- [ ] If I changed a container command, I noted any differences between runtimes (Docker, Podman, nerdctl)
+
+<!-- If you changed anything under skills/ -->
+
+- [ ] Skill frontmatter is still `name` and `description` only
+- [ ] `SKILL.md` is still under 500 lines, with detail in `references/`
+- [ ] No skill references a path outside its own folder
+- [ ] I did not rename a skill (the names are published identifiers)
+
+<!-- See skills/README.md#authoring-standard for the reasoning behind these. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing
+
+Thanks for your interest in Azure SQL Developer. This repository holds the documentation, the ready-made prompts, and the `azuresql-db-*` agent skills for the Private Preview. **The container image itself is not built from this repository**, so code changes here affect the docs, the site, and the skills, not the engine.
+
+## What we are looking for
+
+During the Private Preview, the most valuable contributions are:
+
+- **Bug reports about the container.** Something behaves differently from Azure SQL Database in the cloud, or does not work at all: [file a bug](https://aka.ms/azuresql-developer-bug).
+- **Feedback on the agent skills.** A skill told your agent the wrong thing, or no skill loaded when one should have: [tell us](https://aka.ms/sql-agent-skills-feedback). This is the feedback we are least able to get any other way.
+- **Feature requests.** Something missing that would change how you use it: [request it](https://aka.ms/azuresql-developer-feature-request). Filing one also lets us count how many people need the same thing, which is a real input to what we prioritize.
+- **Documentation fixes.** Typos, unclear steps, broken commands, missing platform notes. Send a pull request.
+
+## Before you open a pull request
+
+Please **open an issue first** for anything beyond a small documentation fix, so we can agree on the approach before you spend time on it.
+
+If you are changing the agent skills in `skills/`, keep these in mind:
+
+- **Frontmatter is `name` and `description` only.** Anything else is agent-specific and breaks portability across Claude Code, GitHub Copilot, Codex, and Cursor.
+- **Descriptions are written in the third person** and name concrete trigger phrases. The description is what the model uses to decide whether to load the skill; it is not documentation for a human.
+- **Keep `SKILL.md` under 500 lines.** Detail belongs in `references/`, which is read only when needed.
+- **A skill never references a path outside its own folder.** Skills install independently, so a path into a sibling skill resolves to nothing.
+- **Every skill stands alone, even where that means repeating a canonical fact.** A user may install one skill rather than the collection.
+- **Do not rename a skill.** The names are published identifiers.
+
+The conventions and the reasoning behind them are in the [skills README](skills/README.md#authoring-standard).
+
+## Building the site locally
+
+The site is Jekyll and is published from `docs/` with GitHub Pages. To preview it:
+
+```bash
+cd docs
+bundle install
+bundle exec jekyll serve
+```
+
+Then open `http://localhost:4000`.
+
+## Style
+
+- Write for a developer who is new to the product. Explain the why, not just the what.
+- Prefer plain language over internal jargon. No severity labels, no codenames.
+- The product is **Azure SQL Developer**. The thing you run is still **a container**: keep the technical language technical.
+- Commands should be copy-pasteable and correct on macOS, Linux, and Windows. Note when a command differs by container runtime.
+
+## Contributor License Agreement
+
+Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit <https://cla.opensource.microsoft.com>.
+
+When you submit a pull request, a CLA bot will automatically determine whether you need to provide a CLA and decorate the PR appropriately (for example, status check, comment). Simply follow the instructions provided by the bot. You will only need to do this once across all repositories using our CLA.
+
+## Code of Conduct
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+## Trademarks
+
+This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft trademarks or logos is subject to and must follow [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general). Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship. Any use of third-party trademarks or logos is subject to those third-parties' policies.

--- a/README.md
+++ b/README.md
@@ -34,11 +34,16 @@ For the first time, developers can build, test, and ship applications against th
 
 - File a bug: [GitHub Issues](https://aka.ms/azuresql-developer-bug)
 - Request a feature: [GitHub Issues](https://aka.ms/azuresql-developer-feature-request)
+- Report a problem with an [agent skill](skills/README.md): [Skill feedback](https://aka.ms/sql-agent-skills-feedback)
 - Ask a question, share a build, suggest an idea: [GitHub Discussions](../../discussions)
 - Connect with the team: [book a session](https://aka.ms/azuresql-developer-meet) or email [azuresqldb-container@microsoft.com](mailto:azuresqldb-container@microsoft.com)
 - Real-time conversation: the private Teams channel shared via the early-access feedback channel
 
-See [Feedback and how to engage](docs/feedback-and-how-to-engage.md) for the full guide on which channel fits which question.
+See [Feedback and how to engage](docs/feedback-and-how-to-engage.md) for the full guide on which channel fits which question, and [SUPPORT.md](SUPPORT.md) for how to get help.
+
+## Contributing
+
+Pull requests are welcome. Read [CONTRIBUTING.md](CONTRIBUTING.md) first: it covers what we are looking for during the Private Preview, how to build the site locally, and the conventions the agent skills follow (which are easy to break in ways that only show up when an agent silently stops loading a skill).
 
 ## License
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,34 @@
+# Support
+
+## How to get help
+
+Azure SQL Developer is in **Private Preview**. It is supported through this repository and the preview channels below, not through standard Azure support.
+
+### Something is broken
+
+- **The container:** it will not start, a query fails, or the engine behaves differently from Azure SQL Database in the cloud. → [File a bug](https://aka.ms/azuresql-developer-bug).
+- **An agent skill:** a skill told your agent the wrong thing, or no skill loaded when one should have. → [Report it here](https://aka.ms/sql-agent-skills-feedback).
+
+Please check [Known limitations](https://microsoft.github.io/azure-sql-database-container/known-limitations.html) first. The behavior may be a documented gap rather than a bug, and the page lists the workaround where one exists.
+
+### Something is missing
+
+[Request a feature](https://aka.ms/azuresql-developer-feature-request). Filing it does two things: it gets tracked, and it lets us count how many people need the same scenario. That number is a real input into what we prioritize for Public Preview.
+
+### You have a question
+
+- **[Documentation](https://microsoft.github.io/azure-sql-database-container/)**, including [Getting started](https://microsoft.github.io/azure-sql-database-container/getting-started.html) and its [troubleshooting section](https://microsoft.github.io/azure-sql-database-container/getting-started.html#troubleshooting).
+- **[GitHub Discussions](https://github.com/microsoft/azure-sql-database-container/discussions)** for open-ended questions, ideas, and showing what you built.
+- **Weekly office hours** for live questions and demos. The invite is shared through the Private Preview channel.
+
+### Fastest path: ask your agent
+
+Install the [agent skills](https://github.com/microsoft/azure-sql-database-container/tree/main/skills) and ask in plain English. They know the registry, the image, the connection model, and the common failures, and they can read your container logs:
+
+```bash
+npx skills add microsoft/azure-sql-database-container
+```
+
+## Support policy
+
+Support for this project is limited to the resources listed above. Azure SQL Developer is for **local development** (development, testing, CI, and demos). It is not a production database and is not covered by an Azure SLA. For production, deploy to [Azure SQL Database](https://learn.microsoft.com/azure/azure-sql/database/) in the Microsoft Azure cloud, which has full Azure support.


### PR DESCRIPTION
Closes #82.

## Why

The repo went public without the community health files a public Microsoft repo is expected to have. **GitHub scores it at 62%.**

The gap is not theoretical: we just took an [external PR](https://github.com/microsoft/azure-sql-database-container/pull/95) with no `CONTRIBUTING` to point the author at, no PR template asking how they verified it, and no stated conventions for the agent skills, which are easy to break in ways that stay invisible until an agent silently stops loading them.

## What's here

| File | What it does |
|---|---|
| **`CONTRIBUTING.md`** | What we actually want during the preview (bugs, skill feedback, feature requests, doc fixes), open an issue before a large PR, how to build the site, and the **skill conventions that matter** — frontmatter is `name` + `description` only, third-person descriptions, under 500 lines, never reference a path outside your own folder, never rename a skill. Links the reasoning in the skills README. Carries the standard Microsoft CLA / Code of Conduct / trademark blocks. |
| **`SUPPORT.md`** | Routes people by **what broke**: container bugs and skill feedback go to different places. Says to check Known limitations first. Points at the agent skills, which can read your container logs and are usually the fastest path. States the support policy (local dev only, no Azure SLA). |
| **`.github/PULL_REQUEST_TEMPLATE.md`** | Asks the one question we failed to ask on #95: **how did you verify this?** Plus a skills-specific checklist. |

## On #81, which I am deliberately *not* acting on

#81 says the repo is missing a LICENSE. **It is not.** `LICENSE` is on `main`, is byte-identical to [Microsoft's standard template](https://github.com/microsoft/repo-templates/blob/main/shared/LICENSE), and GitHub's API reports the detected license as **MIT License**.

That issue is a **false positive from the automation** and should be closed, not fixed. Adding a second license file would be actively wrong.

For the same reason, GitHub's community-profile API reporting `issue_template: MISSING` is a red herring: it only counts the legacy single-file path, and we have four issue forms under `.github/ISSUE_TEMPLATE/`.

## Verified

Every external link in the new files returns 2xx/3xx (14 links), the `skills/README.md#authoring-standard` anchor exists, and `docs/Gemfile` exists so the local-build instructions are real.