### PR TITLE
Add Claude Code and Codex plugin marketplaces

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "azure-sql-developer",
+  "interface": {
+    "displayName": "Azure SQL Developer"
+  },
+  "plugins": [
+    {
+      "name": "azure-sql-developer",
+      "source": {
+        "source": "local",
+        "path": "."
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Databases"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "azure-sql-developer",
+  "owner": {
+    "name": "Microsoft",
+    "url": "https://github.com/microsoft/azure-sql-database-container"
+  },
+  "metadata": {
+    "description": "Agent skills for Azure SQL Developer: the Azure SQL Database engine, running locally in a container."
+  },
+  "plugins": [
+    {
+      "name": "azure-sql-developer",
+      "source": ".",
+      "description": "Eleven skills that teach an AI coding agent to use Azure SQL Developer correctly: start the engine, connect, migrate schemas, import data, scaffold apps, build local RAG, wire CI, run as a sidecar, go local-to-cloud, answer FAQs, and report issues.",
+      "version": "1.0.0"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "azure-sql-developer",
+  "description": "Agent skills for Azure SQL Developer, the Azure SQL Database engine running locally in a container. Teaches your agent to run the engine, connect, migrate, scaffold, build RAG, wire CI, and go local-to-cloud, using the real Private Preview image instead of the SQL Server image.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Microsoft"
+  },
+  "homepage": "https://microsoft.github.io/azure-sql-database-container/",
+  "repository": "https://github.com/microsoft/azure-sql-database-container",
+  "license": "MIT",
+  "keywords": [
+    "azure-sql",
+    "sql-server",
+    "database",
+    "container",
+    "docker",
+    "local-development",
+    "rag",
+    "vector-search"
+  ]
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "azure-sql-developer",
+  "version": "1.0.0",
+  "description": "Agent skills for Azure SQL Developer, the Azure SQL Database engine running locally in a container. Teaches your agent to run the engine, connect, migrate, scaffold, build RAG, wire CI, and go local-to-cloud, using the real Private Preview image instead of the SQL Server image.",
+  "skills": "./skills/",
+  "author": {
+    "name": "Microsoft"
+  },
+  "homepage": "https://microsoft.github.io/azure-sql-database-container/",
+  "repository": "https://github.com/microsoft/azure-sql-database-container",
+  "license": "MIT",
+  "keywords": [
+    "azure-sql",
+    "sql-server",
+    "database",
+    "container",
+    "local-development",
+    "rag"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Run and build against Azure SQL Database, right on your local environment. Try i
 [![Report Bug](https://img.shields.io/badge/Report%20Bug-red?logo=github)](https://aka.ms/azuresql-developer-bug)
 [![Request Feature](https://img.shields.io/badge/Request%20Feature-blue?logo=github)](https://aka.ms/azuresql-developer-feature-request)
 [![Discussions](https://img.shields.io/badge/Discussions-blueviolet?logo=github)](../../discussions)
+[![Skills](https://skills.sh/b/microsoft/azure-sql-database-container)](https://skills.sh/microsoft/azure-sql-database-container)
 
 <a href="https://aka.ms/azuresql-developer-demo">
   <img src="docs/assets/img/Azure SQL Developer cover page.png" alt="Watch the Azure SQL Developer demo" width="760">
@@ -29,6 +30,16 @@ For the first time, developers can build, test, and ship applications against th
 - [Getting Started](docs/getting-started.md)
 - [Known limitations](docs/known-limitations.md)
 - [Feedback and how to engage](docs/feedback-and-how-to-engage.md)
+
+## Agent skills
+
+Point your AI coding agent at Azure SQL Developer and let it start the container, provision the database, scaffold the schema, write the migrations, and build the data layer. The repo ships [11 agent skills](skills/README.md) that work in **Claude Code, Codex, Cursor, and VS Code with GitHub Copilot**:
+
+```bash
+npx skills add microsoft/azure-sql-database-container
+```
+
+Claude Code and Codex users can also install them as a native plugin (`/plugin marketplace add microsoft/azure-sql-database-container`). See the [skills README](skills/README.md) for per-tool install and the full list.
 
 ## Feedback
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -35,6 +35,41 @@ EngineEdition `5` and Edition `'SQL Azure'` are the cloud engine's fingerprint. 
 
 ## INSTALL
 
+These skills work in **Claude Code, Codex, Cursor, and VS Code with GitHub Copilot.** One folder format, all four tools. `npx skills add` works in every one; Claude Code and Codex additionally have a native plugin install with auto-update.
+
+### By tool
+
+**Claude Code:** the native plugin (install + auto-update), or the portable command:
+
+```bash
+# in Claude Code:
+/plugin marketplace add microsoft/azure-sql-database-container
+/plugin install azure-sql-developer@azure-sql-developer
+# or, anywhere:
+npx skills add microsoft/azure-sql-database-container
+```
+
+**Codex:** the native plugin, or the portable command:
+
+```bash
+codex plugin marketplace add microsoft/azure-sql-database-container
+codex plugin add azure-sql-developer@azure-sql-developer
+# or:
+npx skills add microsoft/azure-sql-database-container
+```
+
+**Cursor:**
+
+```bash
+npx skills add microsoft/azure-sql-database-container
+```
+
+**VS Code with GitHub Copilot.** `npx skills add` writes to a folder Copilot already reads, so the skills are available with no extra step. Find them under **Configure Chat → Skills** (or type `/skills` in chat):
+
+```bash
+npx skills add microsoft/azure-sql-database-container
+```
+
 ### `npx skills add` (cross-agent, skills.sh)
 
 The portable way. Works across agents that follow the skills.sh convention. The source is the **repository**, not a skill name:


### PR DESCRIPTION
Makes the repo a **self-hosted plugin marketplace** for both Claude Code and Codex. Users can now install all 11 skills with one command, not only via `npx skills add`.

## The key design choice: the repo IS the plugin

Both Claude and Codex **auto-discover a `skills/` folder in the plugin root**, and ours already exists. So the plugin source is the repo root, and there is **no second copy of the skills** to drift — exactly the trap we hit with the stale lab mirror.

## Install commands unlocked

**Claude Code:**
```
/plugin marketplace add microsoft/azure-sql-database-container
/plugin install azure-sql-developer@azure-sql-developer
```

**Codex:**
```
codex plugin marketplace add microsoft/azure-sql-database-container
codex plugin add azure-sql-developer@azure-sql-developer
```

## Verified end to end, not just written

Both CLIs are installed locally, so I tested for real rather than trusting the schema:

- `claude plugin validate` passes on both the plugin and marketplace manifests.
- Added each marketplace from the local path, installed the plugin, and confirmed the cache contains **all 11 `azuresql-db-*` skills**.
- Claude's `plugin details` reports the full component inventory (11 skills, ~3.3k tokens always-on for the set).

## Reversible

Delete these files to withdraw. Nobody reviews or approves them — they're JSON in our own repo.

Plugin name is `azure-sql-developer` (not `agent-skills` or `claude-*`, which are reserved). canon-check 16/16.