### PR TITLE
Homepage Skills CTA, plus registry-login and optional-skills clarifications

### DIFF
--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -486,6 +486,8 @@ section[id] { scroll-margin-top: 84px; }
 .skill-cmd { display: flex; align-items: center; gap: 12px; max-width: 560px; margin: 0 auto; background: var(--ink); border: 1px solid var(--ink-3); border-radius: 11px; padding: 11px 11px 11px 16px; text-align: left; box-shadow: var(--shadow); }
 .skill-cmd code { flex: 1; font-family: var(--font-mono); font-size: .86rem; color: #e7eefc; white-space: nowrap; overflow-x: auto; }
 .skill-cmd .copy-btn { flex-shrink: 0; }
+/* the primary call to action to the Agent skills page, centered under the install command */
+.skill-cta { margin-top: 18px; }
 .skill-link { display: inline-block; margin-top: 14px; font-family: var(--font-mono); font-size: .78rem; color: var(--azure); }
 .skill-link:hover { text-decoration: none; opacity: .85; }
 /* skills.sh + browse, one concise centered line */

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,7 +43,15 @@ From here you have two ways to reach your first query. Both end in the same plac
 
 ## Fastest: let your AI agent set it up
 
-Your agent does the whole setup for you: it pulls the image, starts the container, provisions the database, and runs your first query. You install the skills once, then ask in plain English.
+**Sign in to the registry first.** This is the one step your agent cannot do for you: the registry password is a secret it does not have, and the login is an interactive prompt. Run it once yourself, then let the agent take over.
+
+```bash
+docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io -u <username>
+```
+
+The username and password come from [signing up for the Private Preview](https://aka.ms/sqldbcontainerpreview-signup). Skip this and the agent's first pull fails with an authentication error.
+
+Your agent does the rest of the setup for you: it pulls the image, starts the container, provisions the database, and runs your first query. You install the skills once, then ask in plain English.
 
 ```bash
 npx skills add microsoft/azure-sql-database-container

--- a/docs/index.html
+++ b/docs/index.html
@@ -209,7 +209,7 @@ title: Azure SQL Developer
     <div class="section-head">
       <p class="eyebrow"><span class="eyebrow-dot"></span>Built for AI-assisted development</p>
       <h2>Bring your AI coding agent.<a class="head-anchor" href="#ai-agents" aria-label="Link to this section">#</a></h2>
-      <p class="lead">Point your agent at Azure SQL Developer and let it scaffold the schema, write the migrations, and build the data layer against a real local database. The repo ships ready-to-use <a href="{{ site.repo }}/tree/main/skills" rel="noopener">agent skills</a>.</p>
+      <p class="lead">Point your agent at Azure SQL Developer and let it scaffold the schema, write the migrations, and build the data layer against a real local database. The repo ships 11 ready-to-use <a href="{{ '/agent-skills.html' | relative_url }}">agent skills</a>.</p>
     </div>
     <div class="agents">
       <a class="agent" href="https://docs.github.com/copilot/get-started/quickstart" rel="noopener">
@@ -240,9 +240,8 @@ title: Azure SQL Developer
         <code><span class="cmd-p">$</span> npx skills add microsoft/azure-sql-database-container</code>
         <button class="copy-btn" type="button" data-copy-text="npx skills add microsoft/azure-sql-database-container"><span class="copy-label">Copy</span></button>
       </div>
+      <a class="btn btn-primary skill-cta" href="{{ '/agent-skills.html' | relative_url }}">See all 11 skills and per-tool install &rarr;</a>
       <div class="skill-links">
-        <a class="skill-link" href="{{ '/agent-skills.html' | relative_url }}">Install for your agent &rarr;</a>
-        <span class="skill-sep" aria-hidden="true">&middot;</span>
         <a class="skill-link" href="{{ site.repo }}/tree/main/skills" rel="noopener">Browse on GitHub &rarr;</a>
         <span class="skill-sep" aria-hidden="true">&middot;</span>
         <a class="skill-link" href="https://skills.sh/microsoft/azure-sql-database-container" rel="noopener">Open on skills.sh &rarr;</a>

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -10,9 +10,9 @@ description: "Supported host platforms, container runtimes, system resources, an
 - [Supported container runtimes](#supported-container-runtimes)
 - [System resources](#system-resources)
 - [Network and connectivity](#network-and-connectivity)
-- [Agent skill](#agent-skill)
 - [Tooling](#tooling)
 - [Azure account (optional, for local-to-cloud)](#azure-account-optional-for-local-to-cloud)
+- [Agent skills (optional, for AI-driven setup)](#agent-skills-optional-for-ai-driven-setup)
 - [Related content](#related-content)
 
 ## Private Preview access
@@ -58,18 +58,6 @@ If your container runtime's VM is set lower than this, the container may fail to
 - **TDS port:** The container exposes port `1433` by default. Make sure it is not already in use, or remap it in your `docker compose.yml` or run command.
 - **No outbound calls.** The container does not call home. It does not require internet connectivity at runtime.
 
-## Agent skill
-
-If you are driving the container with an AI coding agent (Claude Code, Codex, GitHub Copilot, or Cursor) or from the CLI, install the container skill first. For that workflow it is a hard requirement, more important than any individual tool below: the skill teaches your agent the registry sign-in, image name, ports, connection string, and the local-to-cloud handoff, so a single plain-English prompt is enough.
-
-```bash
-npx skills add microsoft/azure-sql-database-container
-```
-
-> **Check that the skills loaded.** Run `ls .claude/skills/` (Claude Code) and confirm you see the `azuresql-db-*` directories. If that folder is empty while `.agents/skills/` is populated, the installer did not target your agent, and it can report success when this happens. Re-run it naming your agent explicitly, for example `npx skills add microsoft/azure-sql-database-container -a claude-code`. Other agents read from different folders; see the [install matrix](https://github.com/microsoft/azure-sql-database-container/tree/main/skills#install-matrix).
-
-It works across Claude Code, GitHub Copilot, Codex, and Cursor. Browse the skill and ready-made prompts in [agent skills](https://github.com/microsoft/azure-sql-database-container/tree/main/skills). Without it, the agent will not know how to sign in to the registry, which image to run, or how to connect.
-
 ## Tooling
 
 Recommended developer tooling for working with the container:
@@ -85,6 +73,18 @@ The container itself does not require an Azure subscription. The local-to-cloud 
 - A target compute resource for the application: Azure App Service, Azure Container Apps, or Azure Functions, depending on the stack
 
 See the [local-to-cloud skill](https://github.com/microsoft/azure-sql-database-container/tree/main/skills/azuresql-db-local-to-cloud) for the deploy flow. If you do not have an Azure subscription, you can still do all local development and exercise the full inner loop.
+
+## Agent skills (optional, for AI-driven setup)
+
+You do not need these to run the container: the [manual path](getting-started.md#manual-run-it-yourself) is three commands. They matter only if you want an AI coding agent (Claude Code, Codex, GitHub Copilot, or Cursor) or the CLI to do the setup for you. In that case, install the container skills first: they teach your agent the registry sign-in, image name, ports, connection string, and the local-to-cloud handoff, so a single plain-English prompt is enough.
+
+```bash
+npx skills add microsoft/azure-sql-database-container
+```
+
+> **Check that the skills loaded.** Run `ls .claude/skills/` (Claude Code) and confirm you see the `azuresql-db-*` directories. If that folder is empty while `.agents/skills/` is populated, the installer did not target your agent, and it can report success when this happens. Re-run it naming your agent explicitly, for example `npx skills add microsoft/azure-sql-database-container -a claude-code`. Other agents read from different folders; see the [install matrix](https://github.com/microsoft/azure-sql-database-container/tree/main/skills#install-matrix).
+
+Even with the skills installed, sign in to the registry yourself first with `docker login` (see [Private Preview access](#private-preview-access)). The agent cannot do it: the password is a secret it does not have, and the login is interactive. The skills know the sign-in *step*, the image name, and how to connect, but you supply the credentials. See [Agent skills](agent-skills.md) for per-tool install and ready-made prompts.
 
 ## Related content
 


### PR DESCRIPTION
Three related documentation fixes so users can find the skills and set up the container without hitting the registry-login trap.

## Homepage
The "Bring your AI coding agent" section only pointed to the dedicated **Agent skills** page through a small footnote-style link. Add a primary button, **See all 11 skills and per-tool install →**, under the `npx skills add` command, and point the intro "agent skills" link at the page instead of the raw `skills/` folder.

## Getting started
The AI-agent path never told users to run `docker login` first. The agent cannot do it (the password is a secret it does not have, and the login is an interactive prompt), so its first pull fails with an auth error. Add a "Sign in to the registry first" note leading that section.

## Prerequisites
Move the agent-skills entry to the end and mark it **optional**. The container runs fine without any skills (the manual path is three commands); they only matter for AI-driven setup. Also note the registry login stays a user step even with the skills installed.

Built and screenshotted all three sections locally before pushing.