### PR TITLE
Add Cursor plugin manifest for the Cursor Marketplace

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "azure-sql-developer",
+  "version": "1.0.0",
+  "description": "Agent skills for Azure SQL Developer, the Azure SQL Database engine running locally in a container. Teaches your agent to run the engine, connect, migrate, scaffold, build RAG, wire CI, and go local-to-cloud, using the real Private Preview image instead of the SQL Server image.",
+  "skills": "skills/",
+  "author": {
+    "name": "Microsoft"
+  },
+  "homepage": "https://microsoft.github.io/azure-sql-database-container/",
+  "repository": "https://github.com/microsoft/azure-sql-database-container",
+  "license": "MIT",
+  "keywords": [
+    "azure-sql",
+    "sql-server",
+    "database",
+    "container",
+    "local-development",
+    "rag"
+  ]
+}


### PR DESCRIPTION
Adds `.cursor-plugin/plugin.json` so the 11 `azuresql-db-*` skills can be published to the [Cursor Marketplace](https://cursor.com/marketplace).

It mirrors the existing `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json`: same name (`azure-sql-developer`), description, homepage, repository, and keywords. Cursor identifies a plugin by this manifest and discovers skills from the `skills/` path, so it must be in the repo before submitting at `cursor.com/marketplace/publish`.

Validated: JSON parses, `name` is valid lowercase kebab-case, and `skills/` resolves to 11 `SKILL.md` directories.