### PR TITLE
Add displayName to the Cursor plugin manifest

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "azure-sql-developer",
+  "displayName": "Azure SQL Developer",
   "version": "1.0.0",
   "description": "Agent skills for Azure SQL Developer, the Azure SQL Database engine running locally in a container. Teaches your agent to run the engine, connect, migrate, scaffold, build RAG, wire CI, and go local-to-cloud, using the real Private Preview image instead of the SQL Server image.",
   "skills": "skills/",


### PR DESCRIPTION
Cursor's [plugin template](https://github.com/cursor/plugin-template) lists `displayName` among the required manifest fields. It is the human-readable name shown on the marketplace card; without it the listing falls back to the kebab-case `name` (`azure-sql-developer`). Sets it to `Azure SQL Developer` to match the brand.