### PR TITLE
Add WSL containers (wslc) as a supported runtime in docs

### DIFF
--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -135,7 +135,7 @@
     });
   });
 
-  // ---- quickstart: Docker / Podman / containerd runtime tabs ----
+  // ---- quickstart: Docker / Podman / containerd / WSL container runtime tabs ----
   var runtimeGroups = document.querySelectorAll("[data-runtime-tabs]");
   function setRuntime(runtime) {
     runtimeGroups.forEach(function (group) {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -27,7 +27,7 @@ description: "Go from pulling the Azure SQL Developer image to your first query 
 
 Confirm you have:
 
-- A supported container engine installed and running (Docker, Podman, containerd, or Rancher Desktop). See [Prerequisites](prerequisites.md).
+- A supported container engine installed and running (Docker, Podman, containerd, Rancher Desktop, or [WSL containers](https://learn.microsoft.com/en-us/windows/wsl/tutorials/wsl-containers) on Windows). See [Prerequisites](prerequisites.md).
 - Port `1433` available on the host.
 - The registry username and password, provided when you sign up at [aka.ms/sqldbcontainerpreview-signup](https://aka.ms/sqldbcontainerpreview-signup) (pull-only; may be rotated during the preview).
 
@@ -71,7 +71,7 @@ Add a local Azure SQL Database to this project, then scaffold the schema, migrat
 
 ## Manual: run it yourself
 
-Prefer to run it yourself? Three commands take you from pull to query, with Docker or Podman.
+Prefer to run it yourself? Three commands take you from pull to query, with Docker, Podman, or [WSL containers](https://learn.microsoft.com/en-us/windows/wsl/tutorials/wsl-containers) (`wslc`).
 
 ### Step 1: sign in and pull the image
 
@@ -89,7 +89,7 @@ Once you are signed in, pull the image:
 docker pull sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest
 ```
 
-With Podman, replace `docker` with `podman`. The registry path, image tag, and credentials are provisional during Private Preview.
+With Podman, replace `docker` with `podman`. On Windows with [WSL containers](https://learn.microsoft.com/en-us/windows/wsl/tutorials/wsl-containers), replace `docker` with `wslc` (sign-in is `wslc login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io <username>`). The registry path, image tag, and credentials are provisional during Private Preview.
 
 ### Step 2: start the container
 
@@ -157,7 +157,7 @@ docker compose down
 
 ## Troubleshooting
 
-The commands below use `docker`. If you run Podman, containerd, or Rancher Desktop, substitute your own CLI (`podman`, `nerdctl`): the behavior is the same on every runtime.
+The commands below use `docker`. If you run Podman, containerd, Rancher Desktop, or [WSL containers](https://learn.microsoft.com/en-us/windows/wsl/tutorials/wsl-containers), substitute your own CLI (`podman`, `nerdctl`, `wslc`): the behavior is the same on every runtime.
 
 ### Let your AI agent diagnose it
 
@@ -175,8 +175,8 @@ Prefer to work through it yourself? Start below.
 
 Most first-run failures are not the database, they are the runtime. Nothing checks these for you, so check all four:
 
-1. **A container runtime is installed and up to date.** Any modern OCI runtime works: Docker 24+, Podman 5.0+, Rancher Desktop 1.13+, or containerd. Install and setup docs: [Docker](https://docs.docker.com/desktop/), [Podman](https://podman.io/docs/installation), [Rancher Desktop](https://docs.rancherdesktop.io/getting-started/installation/), [containerd](https://github.com/containerd/nerdctl).
-2. **It is actually running.** `docker info` (or `podman info`) must return without an error. A fresh install does not always start the engine for you.
+1. **A container runtime is installed and up to date.** Any modern OCI runtime works: Docker 24+, Podman 5.0+, Rancher Desktop 1.13+, containerd, or [WSL containers](https://learn.microsoft.com/en-us/windows/wsl/tutorials/wsl-containers) (`wslc`, included with WSL). Install and setup docs: [Docker](https://docs.docker.com/desktop/), [Podman](https://podman.io/docs/installation), [Rancher Desktop](https://docs.rancherdesktop.io/getting-started/installation/), [containerd](https://github.com/containerd/nerdctl), [WSL containers](https://learn.microsoft.com/en-us/windows/wsl/tutorials/wsl-containers).
+2. **It is actually running.** `docker info` (or `podman info`, or `wslc version`) must return without an error. A fresh install does not always start the engine for you.
 3. **It is set to run Linux containers.** This is a Linux container. On **Windows**, a runtime set to Windows containers cannot run it: switch it to Linux containers ([Docker](https://docs.docker.com/desktop/setup/install/windows-install/#switch-between-windows-and-linux-containers), [Rancher Desktop](https://docs.rancherdesktop.io/getting-started/installation/)). This is the most common Windows failure.
 4. **It has enough memory.** The engine needs **at least 2 GB** to start, and will use most of what it is given. Allocate **4 GB and 2 CPUs** to the runtime (in Docker Desktop and Rancher Desktop this is under Settings, Resources; Podman machines are sized with `podman machine set --memory`). Too little memory shows up as a container that starts and then dies with no obvious error, which is the hardest failure to diagnose.
 
@@ -273,7 +273,7 @@ This is a known issue in the installer ([vercel-labs/skills#1355](https://github
 ### Still stuck?
 
 1. **Is it a known gap?** Check [Known limitations](known-limitations.md) first. The behavior may be documented rather than broken.
-2. **Is it your runtime, not the container?** If the container never starts, if `docker info` fails, or if the runtime cannot pull any image at all, it is a runtime problem and their documentation will fix it faster than we can: [Docker](https://docs.docker.com/desktop/troubleshoot-and-support/troubleshoot/), [Podman](https://podman.io/docs), [Rancher Desktop](https://docs.rancherdesktop.io/getting-started/installation/).
+2. **Is it your runtime, not the container?** If the container never starts, if `docker info` fails, or if the runtime cannot pull any image at all, it is a runtime problem and their documentation will fix it faster than we can: [Docker](https://docs.docker.com/desktop/troubleshoot-and-support/troubleshoot/), [Podman](https://podman.io/docs), [Rancher Desktop](https://docs.rancherdesktop.io/getting-started/installation/), [WSL containers](https://learn.microsoft.com/en-us/windows/wsl/tutorials/wsl-containers).
 3. **Still nothing? Tell us.** We would rather hear about it than have you work around it in silence.
 
 - **Something wrong with the container:** [report a bug](https://aka.ms/azuresql-developer-bug). Include the image tag, your host OS, your container runtime and version, and the container logs.

--- a/docs/index.html
+++ b/docs/index.html
@@ -173,6 +173,7 @@ title: Azure SQL Developer
               <button class="runtime-tab is-active" type="button" data-runtime="docker">Docker</button>
               <button class="runtime-tab" type="button" data-runtime="podman">Podman</button>
               <button class="runtime-tab" type="button" data-runtime="containerd">containerd (nerdctl)</button>
+              <button class="runtime-tab" type="button" data-runtime="wslc">WSL container</button>
             </div>
             <div class="qstep-cmd" data-runtime-panel="docker">
               <code><span class="cmd-p">$</span> docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io -u &lt;username&gt;</code>
@@ -185,6 +186,10 @@ title: Azure SQL Developer
             <div class="qstep-cmd" data-runtime-panel="containerd" hidden>
               <code><span class="cmd-p">$</span> nerdctl login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io -u &lt;username&gt;</code>
               <button class="copy-btn" type="button" data-copy-text="nerdctl login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io -u <username>"><span class="copy-label">Copy</span></button>
+            </div>
+            <div class="qstep-cmd" data-runtime-panel="wslc" hidden>
+              <code><span class="cmd-p">$</span> wslc login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io &lt;username&gt;</code>
+              <button class="copy-btn" type="button" data-copy-text="wslc login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io <username>"><span class="copy-label">Copy</span></button>
             </div>
           </div>
         </div>
@@ -199,6 +204,7 @@ title: Azure SQL Developer
               <button class="runtime-tab is-active" type="button" data-runtime="docker">Docker</button>
               <button class="runtime-tab" type="button" data-runtime="podman">Podman</button>
               <button class="runtime-tab" type="button" data-runtime="containerd">containerd (nerdctl)</button>
+              <button class="runtime-tab" type="button" data-runtime="wslc">WSL container</button>
             </div>
             <div class="qstep-cmd" data-runtime-panel="docker">
               <code><span class="cmd-p">$</span> docker run --name sqldb -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd" \
@@ -215,6 +221,11 @@ title: Azure SQL Developer
     -p 1433:1433 -d sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest</code>
               <button class="copy-btn" type="button" data-copy-text="nerdctl run --name sqldb -e &quot;ACCEPT_EULA=Y&quot; -e &quot;MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd&quot; \&#10;    -p 1433:1433 -d sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest"><span class="copy-label">Copy</span></button>
             </div>
+            <div class="qstep-cmd" data-runtime-panel="wslc" hidden>
+              <code><span class="cmd-p">$</span> wslc run --name sqldb -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd" \
+    -p 1433:1433 -d sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest</code>
+              <button class="copy-btn" type="button" data-copy-text="wslc run --name sqldb -e &quot;ACCEPT_EULA=Y&quot; -e &quot;MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd&quot; \&#10;    -p 1433:1433 -d sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest"><span class="copy-label">Copy</span></button>
+            </div>
           </div>
         </div>
       </div>
@@ -228,6 +239,7 @@ title: Azure SQL Developer
               <button class="runtime-tab is-active" type="button" data-runtime="docker">Docker</button>
               <button class="runtime-tab" type="button" data-runtime="podman">Podman</button>
               <button class="runtime-tab" type="button" data-runtime="containerd">containerd (nerdctl)</button>
+              <button class="runtime-tab" type="button" data-runtime="wslc">WSL container</button>
             </div>
             <div class="qstep-cmd" data-runtime-panel="docker">
               <code><span class="cmd-p">$</span> docker exec sqldb /opt/mssql-tools18/bin/sqlcmd \
@@ -243,6 +255,11 @@ title: Azure SQL Developer
               <code><span class="cmd-p">$</span> nerdctl exec sqldb /opt/mssql-tools18/bin/sqlcmd \
     -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -Q "SELECT @@VERSION;"</code>
               <button class="copy-btn" type="button" data-copy-text="nerdctl exec sqldb /opt/mssql-tools18/bin/sqlcmd \&#10;    -S localhost -U sa -P &quot;YourStr0ng_Passw0rd&quot; -C -Q &quot;SELECT @@VERSION;&quot;"><span class="copy-label">Copy</span></button>
+            </div>
+            <div class="qstep-cmd" data-runtime-panel="wslc" hidden>
+              <code><span class="cmd-p">$</span> wslc exec sqldb /opt/mssql-tools18/bin/sqlcmd \
+    -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -Q "SELECT @@VERSION;"</code>
+              <button class="copy-btn" type="button" data-copy-text="wslc exec sqldb /opt/mssql-tools18/bin/sqlcmd \&#10;    -S localhost -U sa -P &quot;YourStr0ng_Passw0rd&quot; -C -Q &quot;SELECT @@VERSION;&quot;"><span class="copy-label">Copy</span></button>
             </div>
           </div>
         </div>

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -39,6 +39,7 @@ The container is OCI-compliant and runs on any modern runtime. Tested runtimes:
 - **Podman** 5.0 or later
 - **Rancher Desktop** 1.13 or later
 - **containerd** (via `nerdctl` or Kubernetes)
+- **[WSL containers](https://learn.microsoft.com/en-us/windows/wsl/tutorials/wsl-containers)** (`wslc`, included with WSL on Windows)
 
 Pick the runtime that already works on your machine. The container image and the connection behavior are the same across runtimes.
 


### PR DESCRIPTION
## What this changes

Document wslc alongside Docker, Podman, and containerd so Windows users can follow the same quickstart and getting-started flow with the built-in WSL container CLI.

## How you verified it

Went through the tutorial locally on a machine with the latest WSL installed
<img width="2874" height="1478" alt="image" src="https://github.com/user-attachments/assets/1ffb33cf-bba6-42ec-a2c1-49c8ce5ca3fd" />


Verified docs changes by previewing with Jekyll locally
<img width="1301" height="919" alt="image" src="https://github.com/user-attachments/assets/55e9be0c-e87b-4a7d-9ac0-66bdec851cc8" />


## Checklist

- [ ] I opened an issue first, or this is a small documentation fix
- [ ] Commands I changed are copy-pasteable and I ran them
- [x] If I changed a container command, I noted any differences between runtimes (Docker, Podman, nerdctl)


