### PR TITLE
Add DAB and Azure Functions builder skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "azure-sql-developer",
       "source": ".",
-      "description": "Eleven skills that teach an AI coding agent to use Azure SQL Developer correctly: start the engine, connect, migrate schemas, import data, scaffold apps, build local RAG, wire CI, run as a sidecar, go local-to-cloud, answer FAQs, and report issues.",
+      "description": "Thirteen skills that teach an AI coding agent to use Azure SQL Developer correctly: start the engine, connect, migrate schemas, import data, scaffold apps, build local RAG, wire CI, run as a sidecar, go local-to-cloud, build no-code REST/GraphQL APIs with Data API Builder, build serverless and event-driven Azure Functions, answer FAQs, and report issues.",
       "version": "1.0.0"
     }
   ]

--- a/.github/ISSUE_TEMPLATE/skill_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/skill_feedback.yml
@@ -25,6 +25,8 @@ body:
         - azuresql-db-ci
         - azuresql-db-sidecar
         - azuresql-db-scaffold
+        - azuresql-db-dab
+        - azuresql-db-functions
         - azuresql-db-faq
         - azuresql-db-feedback
         - The collection as a whole (install, discovery, or the wrong skill loaded)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ For the first time, developers can build, test, and ship applications against th
 
 ## Agent skills
 
-Point your AI coding agent at Azure SQL Developer and let it start the container, provision the database, scaffold the schema, write the migrations, and build the data layer. The repo ships [11 agent skills](docs/agent-skills.md) that work in **Claude Code, Codex, Cursor, and VS Code with GitHub Copilot**:
+Point your AI coding agent at Azure SQL Developer and let it start the container, provision the database, scaffold the schema, write the migrations, and build the data layer. The repo ships [13 agent skills](docs/agent-skills.md) that work in **Claude Code, Codex, Cursor, and VS Code with GitHub Copilot**:
 
 ```bash
 npx skills add microsoft/azure-sql-database-container

--- a/docs/agent-skills.md
+++ b/docs/agent-skills.md
@@ -34,7 +34,7 @@ For the native plugin install (Claude Code and Codex), a single skill, or per-to
 
 ## The skills
 
-Eleven skills ship in the collection. Each one stands alone and teaches your agent one job; the collection routes between them.
+Thirteen skills ship in the collection. Each one stands alone and teaches your agent one job; the collection routes between them.
 
 <div class="skill-cards">
   <a class="skill-card" href="{{ site.repo }}/tree/main/skills/azuresql-db-container" rel="noopener">
@@ -82,6 +82,16 @@ Eleven skills ship in the collection. Each one stands alone and teaches your age
     <h4>Scaffold <span class="arrow">&rarr;</span></h4>
     <p>Bootstrap a new app with Azure SQL Developer as the default local database.</p>
   </a>
+  <a class="skill-card" href="{{ site.repo }}/tree/main/skills/azuresql-db-dab" rel="noopener">
+    <span class="skill-tag">azuresql-db-dab</span>
+    <h4>REST + GraphQL API <span class="arrow">&rarr;</span></h4>
+    <p>Instant no-code REST and GraphQL over your tables with Data API Builder. Also serves DAB's built-in MCP endpoint.</p>
+  </a>
+  <a class="skill-card" href="{{ site.repo }}/tree/main/skills/azuresql-db-functions" rel="noopener">
+    <span class="skill-tag">azuresql-db-functions</span>
+    <h4>Serverless + event-driven <span class="arrow">&rarr;</span></h4>
+    <p>Azure Functions over the engine: HTTP CRUD via SQL bindings, and the SQL trigger (Change Tracking) for reacting to row changes locally.</p>
+  </a>
   <a class="skill-card" href="{{ site.repo }}/tree/main/skills/azuresql-db-faq" rel="noopener">
     <span class="skill-tag">azuresql-db-faq</span>
     <h4>Answer questions <span class="arrow">&rarr;</span></h4>
@@ -92,7 +102,7 @@ Eleven skills ship in the collection. Each one stands alone and teaches your age
     <h4>Report a problem <span class="arrow">&rarr;</span></h4>
     <p>Your agent writes the bug report for you, from what it already knows, and hands you a prefilled issue to review. It never files anything without your say-so.</p>
   </a>
-  {% assign one_skills = "azuresql-db-container|Start the engine,azuresql-db-from-sql-server|Convert from SQL Server,azuresql-db-local-to-cloud|Local to cloud,azuresql-db-schema-migration|Schema migrations,azuresql-db-import|Import a database,azuresql-db-rag|RAG and vector search,azuresql-db-ci|CI,azuresql-db-sidecar|Sidecar,azuresql-db-scaffold|Scaffold,azuresql-db-faq|Answer questions,azuresql-db-feedback|Report a problem" | split: "," %}
+  {% assign one_skills = "azuresql-db-container|Start the engine,azuresql-db-from-sql-server|Convert from SQL Server,azuresql-db-local-to-cloud|Local to cloud,azuresql-db-schema-migration|Schema migrations,azuresql-db-import|Import a database,azuresql-db-rag|RAG and vector search,azuresql-db-ci|CI,azuresql-db-sidecar|Sidecar,azuresql-db-scaffold|Scaffold,azuresql-db-dab|REST + GraphQL API,azuresql-db-functions|Serverless + event-driven,azuresql-db-faq|Answer questions,azuresql-db-feedback|Report a problem" | split: "," %}
 </div>
 <div class="skill-more">
   <button class="skill-more-btn skill-more-alt" type="button" data-open-modal="single-skill">Install a single skill</button>
@@ -136,7 +146,7 @@ Install as a native plugin. In Claude Code, run:
 /plugin install azure-sql-developer@azure-sql-developer
 ```
 
-The first command registers this repository as a plugin marketplace; the second installs the `azure-sql-developer` plugin, which contains all 11 skills. Run `/plugin` any time to manage it, and `/reload-plugins` to activate it in the current session. The portable `npx skills add microsoft/azure-sql-database-container` works too.
+The first command registers this repository as a plugin marketplace; the second installs the `azure-sql-developer` plugin, which contains all 13 skills. Run `/plugin` any time to manage it, and `/reload-plugins` to activate it in the current session. The portable `npx skills add microsoft/azure-sql-database-container` works too.
 
 ### Codex
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -289,6 +289,8 @@ Pick a job and let your AI coding agent build it against Azure SQL Developer. Ea
 - [Develop offline]({{ '/prompts/offline.md' | relative_url }}): demos, classes, and workshops with no internet.
 - [Drop in as a sidecar]({{ '/prompts/sidecar.md' | relative_url }}): add it to a docker compose stack or Dev Container.
 - [Scaffold new projects]({{ '/prompts/templates.md' | relative_url }}): start a new .NET Aspire, FastAPI, Next.js, or NestJS project.
+- [Instant REST + GraphQL API]({{ '/prompts/dab.md' | relative_url }}): expose your tables as a no-code API (and an MCP endpoint) with Data API Builder.
+- [Serverless and event-driven]({{ '/prompts/functions.md' | relative_url }}): an Azure Functions HTTP API with the Azure SQL bindings, plus the SQL trigger for reacting to row changes locally.
 
 Haven't installed the skill yet? See [Agent skill](prerequisites.md#agent-skill).
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -258,7 +258,7 @@ title: Azure SQL Developer
     <div class="section-head">
       <p class="eyebrow"><span class="eyebrow-dot"></span>Built for AI-assisted development</p>
       <h2>Bring your AI coding agent.<a class="head-anchor" href="#ai-agents" aria-label="Link to this section">#</a></h2>
-      <p class="lead">Point your agent at Azure SQL Developer and let it scaffold the schema, write the migrations, and build the data layer against a real local database. The repo ships 11 ready-to-use <a href="{{ '/agent-skills.html' | relative_url }}">agent skills</a>.</p>
+      <p class="lead">Point your agent at Azure SQL Developer and let it scaffold the schema, write the migrations, and build the data layer against a real local database. The repo ships 13 ready-to-use <a href="{{ '/agent-skills.html' | relative_url }}">agent skills</a>.</p>
     </div>
     <div class="agents">
       <a class="agent" href="https://docs.github.com/copilot/get-started/quickstart" rel="noopener">
@@ -289,7 +289,7 @@ title: Azure SQL Developer
         <code><span class="cmd-p">$</span> npx skills add microsoft/azure-sql-database-container</code>
         <button class="copy-btn" type="button" data-copy-text="npx skills add microsoft/azure-sql-database-container"><span class="copy-label">Copy</span></button>
       </div>
-      <a class="btn btn-primary skill-cta" href="{{ '/agent-skills.html' | relative_url }}">See all 11 skills and per-tool install &rarr;</a>
+      <a class="btn btn-primary skill-cta" href="{{ '/agent-skills.html' | relative_url }}">See all 13 skills and per-tool install &rarr;</a>
       <div class="skill-links">
         <a class="skill-link" href="{{ site.repo }}/tree/main/skills" rel="noopener">Browse on GitHub &rarr;</a>
         <span class="skill-sep" aria-hidden="true">&middot;</span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -373,6 +373,24 @@ title: Azure SQL Developer
           <a class="card-view" href="{{ site.repo }}/blob/main/docs/prompts/templates.md" rel="noopener">View</a>
         </div>
       </article>
+      <article class="card">
+        <span class="tag">rest / graphql</span>
+        <h3>Instant API over your tables</h3>
+        <p>Generate a no-code REST and GraphQL API over the local engine with Data API Builder. Point it at your tables, and get an MCP endpoint from the same config too.</p>
+        <div class="card-actions">
+          <button class="card-prompt" type="button" data-prompt="{{ '/prompts/dab.md' | relative_url }}"><span class="card-prompt-ico" aria-hidden="true"></span><span class="copy-label">Copy prompt</span></button>
+          <a class="card-view" href="{{ site.repo }}/blob/main/docs/prompts/dab.md" rel="noopener">View</a>
+        </div>
+      </article>
+      <article class="card">
+        <span class="tag">serverless</span>
+        <h3>Serverless and event-driven</h3>
+        <p>Build an Azure Functions HTTP API with the Azure SQL bindings, and react to row changes locally with the SQL trigger (Change Tracking). No cloud services required.</p>
+        <div class="card-actions">
+          <button class="card-prompt" type="button" data-prompt="{{ '/prompts/functions.md' | relative_url }}"><span class="card-prompt-ico" aria-hidden="true"></span><span class="copy-label">Copy prompt</span></button>
+          <a class="card-view" href="{{ site.repo }}/blob/main/docs/prompts/functions.md" rel="noopener">View</a>
+        </div>
+      </article>
     </div>
   </div>
 </section>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -9,7 +9,7 @@ _Last updated: July 2026._
 - [Goals of the Private Preview](https://microsoft.github.io/azure-sql-database-container/goals-of-the-private-preview.html): what this preview sets out to learn and validate.
 - [Prerequisites](https://microsoft.github.io/azure-sql-database-container/prerequisites.html): supported hosts, container runtimes, system resources, and tooling.
 - [Getting started](https://microsoft.github.io/azure-sql-database-container/getting-started.html): pull the image, start the container, and run your first query in under a minute.
-- [Agent skills](https://microsoft.github.io/azure-sql-database-container/agent-skills.html): install the skills in Claude Code, Codex, Cursor, or VS Code with GitHub Copilot, and what each of the 11 skills does.
+- [Agent skills](https://microsoft.github.io/azure-sql-database-container/agent-skills.html): install the skills in Claude Code, Codex, Cursor, or VS Code with GitHub Copilot, and what each of the 13 skills does.
 - [Known limitations](https://microsoft.github.io/azure-sql-database-container/known-limitations.html): current gaps and workarounds.
 - [Feedback and how to engage](https://microsoft.github.io/azure-sql-database-container/feedback-and-how-to-engage.html): GitHub Issues and Discussions, the team email, and office hours.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -22,6 +22,8 @@ Copy-and-run prompts to hand your AI coding agent, each building a scenario agai
 - [Develop offline](https://github.com/microsoft/azure-sql-database-container/blob/main/docs/prompts/offline.md)
 - [Drop in as a sidecar](https://github.com/microsoft/azure-sql-database-container/blob/main/docs/prompts/sidecar.md)
 - [Scaffold a new project](https://github.com/microsoft/azure-sql-database-container/blob/main/docs/prompts/templates.md)
+- [Instant REST + GraphQL API with Data API Builder](https://github.com/microsoft/azure-sql-database-container/blob/main/docs/prompts/dab.md)
+- [Serverless and event-driven with Azure Functions](https://github.com/microsoft/azure-sql-database-container/blob/main/docs/prompts/functions.md)
 - [Agent skills for Claude Code, GitHub Copilot, Codex, and Cursor](https://github.com/microsoft/azure-sql-database-container/tree/main/skills)
 
 ## Key facts

--- a/docs/prompts/dab.md
+++ b/docs/prompts/dab.md
@@ -1,0 +1,70 @@
+# AI Prompt: Add an instant REST + GraphQL API over Azure SQL Developer with Data API Builder
+
+**Role:** You are an expert agent standing up a no-code REST and GraphQL API over the project's local Azure SQL Developer database using Microsoft Data API Builder (DAB).
+
+**Purpose:** Expose existing tables as a working API - REST at `/api/<Entity>` and GraphQL at `/graphql` - driven entirely by `dab-config.json`, with the connection string supplied through an environment variable and no application code. Optionally expose DAB's built-in MCP endpoint (an API surface DAB provides, not a standalone SQL MCP server).
+
+**Scope:** Assumes the Azure SQL Developer container is running and the application database (`appdb`) exists with at least one table. If it is not running, start it and provision `appdb` first (the engine does not auto-create databases).
+
+Read the entire instruction set before executing.
+
+---
+
+## Instructions
+
+### 1. Confirm the database is ready
+
+The database is the Azure SQL engine image `sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest` (`SERVERPROPERTY('EngineEdition')` = 5), not `mcr.microsoft.com/mssql/server`. `appdb` must already exist on a master connection, with a table to expose (seed one if needed).
+
+### 2. Provide the connection string via an environment variable
+
+```bash
+export SQL_CONNECTION_STRING="Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true"
+```
+
+Use `User Id=` / `Password=` / `Database=` and `TrustServerCertificate=true` (self-signed cert). Never write the connection string into `dab-config.json`.
+
+### 3. Initialize DAB and add entities
+
+```bash
+dotnet tool install --global Microsoft.DataApiBuilder    # once; needs .NET 8
+
+dab init --database-type mssql \
+  --connection-string "@env('SQL_CONNECTION_STRING')" \
+  --host-mode Development
+dab add Book --source dbo.Books --source.type table --permissions "anonymous:*"
+```
+
+Add one `dab add` per table. The entity name is the API path; `--source` is the real `schema.table`. Declare relationships with `dab update <Entity> --relationship <name> --target.entity <Target> --cardinality one|many --relationship.fields "src:tgt"`.
+
+### 4. Start and confirm
+
+```bash
+dab start        # http://localhost:5000
+curl http://localhost:5000/api/Book
+curl -s http://localhost:5000/graphql -H 'Content-Type: application/json' \
+  -d '{"query":"{ books { items { id title } } }"}'
+```
+
+REST is at `/api/<Entity>`, GraphQL at `/graphql`, OpenAPI at `/api/openapi`, Swagger UI at `/swagger` (Development mode), health at `/health`.
+
+### 5. (Optional) MCP endpoint
+
+DAB (v1.7+; use the latest 2.x) also serves an MCP endpoint at `http://localhost:5000/mcp` from the same config, enabled by default. Present it as a DAB-provided API surface over your entities, governed by the same permissions - not as a standalone Microsoft SQL MCP server. Scope it with `runtime.mcp.dml-tools` (globally) or `dab update <Entity> --mcp.dml-tools false` (per entity).
+
+---
+
+## Validation rules
+
+- The database is the Azure SQL engine (EngineEdition=5), never the SQL Server image.
+- `appdb` exists before `dab start`; DAB connects with `Database=appdb` and `TrustServerCertificate=true`.
+- The connection string is provided via `@env('SQL_CONNECTION_STRING')`, not hardcoded in `dab-config.json`.
+- `dab start` serves REST at `/api/<Entity>` and GraphQL at `/graphql`; a `GET` on an entity returns rows.
+- If the MCP endpoint is exposed, it is described as a DAB API surface, not a standalone SQL MCP server.
+
+## Do not
+
+- Do not use the SQL Server image `mcr.microsoft.com/mssql/server`.
+- Do not hardcode the connection string or SA password into `dab-config.json`.
+- Do not ship `anonymous:*` permissions beyond local development.
+- Do not present DAB's MCP endpoint as a standalone Microsoft SQL MCP server.

--- a/docs/prompts/functions.md
+++ b/docs/prompts/functions.md
@@ -1,0 +1,82 @@
+# AI Prompt: Build a serverless API and event-driven handlers over Azure SQL Developer with Azure Functions
+
+**Role:** You are an expert agent building Azure Functions over the project's local Azure SQL Developer database using the first-party Azure SQL bindings.
+
+**Purpose:** Create HTTP CRUD endpoints (SQL input/output bindings) and, where the app needs to react to data changes, an event-driven handler using the SQL trigger binding (backed by Change Tracking). Everything runs locally against the container; no cloud services.
+
+**Scope:** Assumes the Azure SQL Developer container is running and `appdb` exists. If it is not running, start it and provision `appdb` first (the engine does not auto-create databases). Change Event Streaming (CES) is cloud-only and out of scope for local work.
+
+Read the entire instruction set before executing.
+
+---
+
+## Instructions
+
+### 1. Confirm the database and set the connection string
+
+The database is the Azure SQL engine image `sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest` (EngineEdition=5), not `mcr.microsoft.com/mssql/server`. Put the connection string in `local.settings.json` under the setting name `SqlConnectionString`:
+
+```json
+{
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+    "SqlConnectionString": "Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true"
+  }
+}
+```
+
+Bindings reference it via `ConnectionStringSetting` / `connectionStringSetting` (not `Connection`).
+
+### 2. Install the SQL extension
+
+- .NET isolated: `dotnet add package Microsoft.Azure.Functions.Worker.Extensions.Sql`
+- JS/TS/Python/PowerShell: the `host.json` extension bundle `[4.0.0, 5.0.0)`
+
+### 3. HTTP API with input/output bindings
+
+Scaffold (`func init`, `func new`), then add a SQL **input** binding to read and a SQL **output** binding to upsert. Output-binding target tables must have a **primary key** (the binding upserts via `MERGE`) and the database compat level must be **130+**.
+
+### 4. Event-driven with the SQL trigger (the local mechanism)
+
+Enable Change Tracking on `appdb` and the table, then bind a function to the changes:
+
+```sql
+ALTER DATABASE appdb SET CHANGE_TRACKING = ON (CHANGE_RETENTION = 2 DAYS, AUTO_CLEANUP = ON);
+ALTER TABLE dbo.ToDo ENABLE CHANGE_TRACKING;
+```
+
+```csharp
+[Function("ToDoTrigger")]
+public static void Run(
+    [SqlTrigger("[dbo].[ToDo]", "SqlConnectionString")]
+    IReadOnlyList<SqlChange<ToDoItem>> changes, FunctionContext context)
+{ /* each change has .Item and .Operation (Insert/Update/Delete) */ }
+```
+
+The trigger creates an internal `az_func` schema + leases table; as `sa` locally the permissions are already satisfied.
+
+### 5. Run and confirm
+
+```bash
+func start        # http://localhost:7071/api/<route>
+curl http://localhost:7071/api/todo
+# insert a row and watch the trigger function log the Insert change
+```
+
+---
+
+## Validation rules
+
+- The database is the Azure SQL engine (EngineEdition=5), never the SQL Server image.
+- `appdb` exists before the function app runs; `SqlConnectionString` uses `Database=appdb` and `TrustServerCertificate=true`.
+- The connection string lives in `local.settings.json` / app settings, not in code.
+- Output-binding target tables have a primary key and compat level 130+.
+- Event-driven uses the SQL trigger with Change Tracking enabled on the database and table; CES is not used locally.
+
+## Do not
+
+- Do not use the SQL Server image `mcr.microsoft.com/mssql/server`.
+- Do not attempt to run Change Event Streaming (CES) locally; it is unsupported on the local engine and streams only to Azure Event Hubs.
+- Do not use an output binding against a table with no primary key or below compat level 130.
+- Do not commit `local.settings.json`; it holds the connection string and SA password.

--- a/skills/README.md
+++ b/skills/README.md
@@ -28,6 +28,8 @@ EngineEdition `5` and Edition `'SQL Azure'` are the cloud engine's fingerprint. 
 | **azuresql-db-ci** | Run the engine in continuous integration: ephemeral container, ready-wait, provision, seed, test, tear down. Fails closed on the wrong image. |
 | **azuresql-db-sidecar** | Run the engine as a sidecar alongside an app (compose-style), with `platform: linux/amd64` on non-x64 hosts and a single `SQL_CONNECTION_STRING` contract. |
 | **azuresql-db-scaffold** | Scaffold a new app wired to the engine: connection string via one `SQL_CONNECTION_STRING` env var, provisioning step, and seed step in the correct order. |
+| **azuresql-db-dab** | Stand up an instant no-code REST + GraphQL API over the engine with Data API Builder (DAB): `dab init`/`add`/`start`, `@env()` connection, entities and relationships. Also serves DAB's built-in MCP endpoint (a DAB API surface, not a standalone SQL MCP server). |
+| **azuresql-db-functions** | Build a serverless API and event-driven handlers with Azure Functions + the Azure SQL bindings: HTTP CRUD via input/output bindings, and the SQL trigger (Change Tracking) as the local event-driven mechanism. CES is cloud-only. |
 | **azuresql-db-faq** | Answer questions about what the container can and cannot do, and why it differs from the cloud (backups, `USE`, vector index, GUI tooling, registry). Sorts each into engine vs. managed-service vs. SQL Server, and links the live Known limitations. |
 | **azuresql-db-feedback** | Report a bug or request a feature without leaving the agent. Builds a complete, prefilled GitHub issue from context the agent already has (image tag, host OS, runtime, the failing command, the error), redacts secrets, and hands it to you to review and submit. It never submits anything without your explicit confirmation. |
 
@@ -99,6 +101,8 @@ npx skills add microsoft/azure-sql-database-container --skill <skill-name>
 | **azuresql-db-ci** | `npx skills add microsoft/azure-sql-database-container --skill azuresql-db-ci` |
 | **azuresql-db-sidecar** | `npx skills add microsoft/azure-sql-database-container --skill azuresql-db-sidecar` |
 | **azuresql-db-scaffold** | `npx skills add microsoft/azure-sql-database-container --skill azuresql-db-scaffold` |
+| **azuresql-db-dab** | `npx skills add microsoft/azure-sql-database-container --skill azuresql-db-dab` |
+| **azuresql-db-functions** | `npx skills add microsoft/azure-sql-database-container --skill azuresql-db-functions` |
 | **azuresql-db-faq** | `npx skills add microsoft/azure-sql-database-container --skill azuresql-db-faq` |
 | **azuresql-db-feedback** | `npx skills add microsoft/azure-sql-database-container --skill azuresql-db-feedback` |
 

--- a/skills/azuresql-db-container/SKILL.md
+++ b/skills/azuresql-db-container/SKILL.md
@@ -181,6 +181,8 @@ Provisioning and identity are settled here. Route the actual task:
 - `azuresql-db-ci`: use the engine as a CI service / test database.
 - `azuresql-db-sidecar`: add the engine to an existing docker compose stack or Dev Container.
 - `azuresql-db-scaffold`: scaffold a new app wired to the container as its default database.
+- `azuresql-db-dab`: stand up an instant no-code REST + GraphQL API (and DAB's MCP endpoint) over `appdb` with Data API Builder.
+- `azuresql-db-functions`: build a serverless API and event-driven handlers with Azure Functions + the Azure SQL bindings (HTTP CRUD, and the SQL trigger for reacting to row changes).
 - `azuresql-db-feedback`: report a bug or request a feature. Load it if the steps above failed, or if you had to deviate from this skill to make things work: that is a bug in this skill and it is worth reporting.
 
 ## When it works

--- a/skills/azuresql-db-dab/SKILL.md
+++ b/skills/azuresql-db-dab/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: azuresql-db-dab
+description: >-
+  Stands up an instant no-code REST + GraphQL API over the local Azure SQL
+  Developer using Microsoft Data API Builder (DAB). Use when a user wants to
+  "expose my table as an API", "add a REST API over the database", "generate a
+  GraphQL API", "put an API in front of SQL", "CRUD API without writing code",
+  or "dab init / dab-config.json". Also the way to serve a built-in MCP endpoint
+  FROM the database via DAB (an API surface DAB provides, not a separate SQL MCP
+  server). Prefer this over hand-writing a controller/ORM API when the user just
+  needs REST or GraphQL over existing tables. Triggers include "Data API
+  Builder", "dab start", "instant API over Azure SQL", "expose entities as
+  REST/GraphQL". Reach for this even when the user only says "give me an API for
+  this database".
+---
+
+# Azure SQL Developer: instant REST + GraphQL API with Data API Builder
+
+Generate a full REST **and** GraphQL API over the local **Azure SQL Developer**
+(Private Preview) with no application code, using **Data API Builder (DAB)** -
+Microsoft's first-party open-source engine. You describe tables as entities in
+`dab-config.json`; DAB serves them. DAB connects over the normal TDS protocol
+with a plain connection string, so **no change tracking or special engine
+feature is needed.**
+
+## Load-bearing facts (inlined; full engine detail in azuresql-db-container)
+
+- This is the **Azure SQL Database engine** (Private Preview), not the SQL Server
+  image `mcr.microsoft.com/mssql/server`. `SERVERPROPERTY('EngineEdition')`
+  returns `5`, `SERVERPROPERTY('Edition')` returns `'SQL Azure'`.
+- Image: `sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest`
+  (x64, `linux/amd64`). Registry is private: sign in first with
+  `docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io` using the shared
+  pull-only credentials from https://aka.ms/sqldbcontainerpreview-signup (they
+  may rotate). Registry and tag are provisional during Private Preview.
+- Required env: `ACCEPT_EULA=Y` and a complex `MSSQL_SA_PASSWORD` (8+ chars,
+  upper/lower/digit/symbol). Engine listens on 1433.
+- The engine does **NOT** auto-create databases. Run `CREATE DATABASE appdb` on
+  a **master** connection before DAB connects with `Database=appdb`. Do not use
+  `USE` to switch databases (in a user-database SDS session it returns
+  `Msg 40508`); select the database in the connection string.
+- On a non-x64 host add `--platform linux/amd64`.
+
+For the full engine model (readiness loop, vectors, troubleshooting) see the
+**azuresql-db-container** skill. To start the container and provision `appdb`
+first, use **azuresql-db-container** or **azuresql-db-scaffold**.
+
+## Step 1: install DAB
+
+Two supported ways. Pick the CLI for local dev; pick the container to wire DAB
+into a compose stack (see [references/dab-snippets.md](references/dab-snippets.md)).
+
+```bash
+# CLI (.NET 8 required): installs the `dab` command
+dotnet tool install --global Microsoft.DataApiBuilder
+# update later with: dotnet tool update --global Microsoft.DataApiBuilder
+
+# Container image (alternative):
+#   mcr.microsoft.com/azure-databases/data-api-builder:latest
+```
+
+## Step 2: point DAB at the container over one env var
+
+DAB reads the connection string from an environment variable via the `@env()`
+indirection, so no secret is written into `dab-config.json`. Reuse the same
+single `SQL_CONNECTION_STRING` contract the other skills use (replace `1433`
+with the host port your container chose if 1433 was occupied):
+
+```bash
+export SQL_CONNECTION_STRING="Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true"
+```
+
+`TrustServerCertificate=true` is required for the container's self-signed cert.
+Use `User Id=` / `Password=` / `Database=` (not `Uid=` / `Pwd=`).
+
+## Step 3: init, add entities, start
+
+```bash
+# Initialize config in Development mode (enables Swagger + friendlier errors).
+dab init --database-type mssql \
+  --connection-string "@env('SQL_CONNECTION_STRING')" \
+  --host-mode Development
+
+# Expose a table as an entity. Repeat per table.
+# --permissions is role:actions; "anonymous:*" allows all actions with no auth (dev only).
+dab add Book --source dbo.Books --source.type table --permissions "anonymous:*"
+
+# Serve REST + GraphQL (and the MCP endpoint) on http://localhost:5000
+dab start
+```
+
+`appdb` is just the example database name and `Book`/`dbo.Books` the example
+entity/table; substitute your own. The entity name (`Book`) is what appears in
+the API path; the `--source` is the real `schema.table`.
+
+## Step 4: use the API
+
+With `dab start` running (default port **5000**):
+
+- **REST:** `GET http://localhost:5000/api/Book` (list), `/api/Book/id/1` (by
+  key), plus `POST` / `PATCH` / `PUT` / `DELETE`. Query with
+  `?$filter=`, `$select=`, `$orderby=`, `$first=`, `$after=` (OData-style).
+- **GraphQL:** `POST http://localhost:5000/graphql` - queries and mutations for
+  every entity, with relationship navigation.
+- **OpenAPI / Swagger:** `GET /api/openapi` (document) and `GET /swagger` (UI,
+  Development mode only).
+- **Health:** `GET /health`.
+
+```bash
+curl http://localhost:5000/api/Book
+curl -s http://localhost:5000/graphql -H 'Content-Type: application/json' \
+  -d '{"query":"{ books { items { id title } } }"}'
+```
+
+## Relationships, config detail
+
+DAB exposes related entities (e.g. an author's books) once you declare the
+relationship. Config schema, permissions/policies, `@env()`, REST/GraphQL
+options, and the exact `dab update --relationship` syntax are in
+[references/dab-config-reference.md](references/dab-config-reference.md).
+
+## MCP endpoint (a DAB feature, not a separate SQL MCP server)
+
+DAB (version 1.7+; use the latest 2.x) **also serves a built-in MCP endpoint
+from the same `dab-config.json`**, at `http://localhost:5000/mcp` by default,
+enabled by default. This is an additional API surface Data API Builder provides
+over your configured entities - it is not, and should not be presented as, a
+standalone "MSSQL MCP server." How to point an MCP client at it and how to
+scope the exposed tools is in [references/dab-mcp.md](references/dab-mcp.md).
+
+## Validation rules
+
+- The database engine is the container image above (EngineEdition=5), never
+  `mcr.microsoft.com/mssql/server`.
+- `appdb` exists (created on a master connection) BEFORE `dab start`; DAB's
+  connection string uses `Database=appdb` and `TrustServerCertificate=true`.
+- The connection string is supplied via `@env('SQL_CONNECTION_STRING')`, not
+  hardcoded into `dab-config.json`.
+- `dab start` serves REST at `/api/<Entity>` and GraphQL at `/graphql`; a `GET`
+  on the entity returns rows from the container.
+- If you present the MCP endpoint, it is described as a DAB-provided API surface,
+  not a standalone SQL MCP server.
+- If a validation rule above fails, or you had to deviate from this skill to make the task work, that is a bug in this skill: load the **azuresql-db-feedback** skill and offer to file a report.
+- When every rule above passes and the task is done, close with ONE line, once per session, and do not ask a question or wait for a reply: "That worked. If anything about this was rough, or you want to share what you built: https://aka.ms/sql-agent-skills-feedback"
+
+## Do not
+
+- Do not use the SQL Server image `mcr.microsoft.com/mssql/server`; this is the Azure SQL engine.
+- Do not expect DAB to create `appdb`; provision it on a master connection first.
+- Do not hardcode the connection string (or the SA password) into `dab-config.json`; use `@env('SQL_CONNECTION_STRING')`.
+- Do not ship `anonymous:*` permissions to production; it is unauthenticated full CRUD for local dev only.
+- Do not describe DAB's MCP endpoint as a standalone Microsoft SQL MCP server; it is an API surface DAB provides.
+- Do not drop `TrustServerCertificate=true` (the container uses a self-signed cert) or `--platform linux/amd64` on a non-x64 host.
+
+## References
+
+- [references/dab-config-reference.md](references/dab-config-reference.md): the `dab-config.json` structure, `@env()` connection handling, entity/permission/policy options, REST and GraphQL settings, and the `dab update --relationship` syntax for one-to-many and many-to-many.
+- [references/dab-snippets.md](references/dab-snippets.md): copy-paste recipes - CLI end-to-end, running DAB as a container against the SQL container (shared network / `host.docker.internal`), a compose service, and sample REST/GraphQL calls.
+- [references/dab-mcp.md](references/dab-mcp.md): DAB's built-in MCP endpoint - how to enable/scope it in config, the default `/mcp` path, and how to connect an MCP client. Framed as a DAB API surface, not a standalone SQL MCP server.

--- a/skills/azuresql-db-dab/references/dab-config-reference.md
+++ b/skills/azuresql-db-dab/references/dab-config-reference.md
@@ -1,0 +1,131 @@
+# Data API Builder config reference (`dab-config.json`)
+
+## Contents
+
+- Config shape
+- Connection via `@env()`
+- Entities and sources
+- Permissions and policies
+- REST and GraphQL options
+- Relationships (`dab update --relationship`)
+- Regenerating vs hand-editing
+
+## Config shape
+
+`dab init` writes a `dab-config.json` with two top-level areas: `data-source`
+(how DAB connects) and `entities` (what it exposes). A minimal file looks like:
+
+```json
+{
+  "$schema": "https://github.com/Azure/data-api-builder/releases/latest/download/dab.draft.schema.json",
+  "data-source": {
+    "database-type": "mssql",
+    "connection-string": "@env('SQL_CONNECTION_STRING')"
+  },
+  "runtime": {
+    "rest": { "enabled": true, "path": "/api" },
+    "graphql": { "enabled": true, "path": "/graphql" },
+    "host": { "mode": "development" }
+  },
+  "entities": {
+    "Book": {
+      "source": { "object": "dbo.Books", "type": "table" },
+      "permissions": [
+        { "role": "anonymous", "actions": [{ "action": "*" }] }
+      ]
+    }
+  }
+}
+```
+
+Prefer changing the file through the CLI (`dab add` / `dab update`) so it stays
+schema-valid; see "Regenerating vs hand-editing" below.
+
+## Connection via `@env()`
+
+`--connection-string "@env('SQL_CONNECTION_STRING')"` stores the *indirection*,
+not the secret, in the file. DAB resolves `@env('NAME')` from the environment at
+`dab start`. Keep the value in `SQL_CONNECTION_STRING`:
+
+```
+Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true
+```
+
+`database-type` is `mssql` for the Azure SQL engine (the same value used for
+Azure SQL Database in the cloud - parity is the point).
+
+## Entities and sources
+
+- `dab add <EntityName> --source <schema.table> --source.type table --permissions "<role>:<actions>"`.
+- The **entity name** is the API identity (`/api/Book`, GraphQL `book`/`books`);
+  the **source** is the real database object (`dbo.Books`).
+- `--source.type` is `table`, `view`, or `stored-procedure`. Views and keyless
+  tables need `--source.key-fields "id"`.
+- Rename exposed fields with `dab update <Entity> --map "db_col:apiName,..."`.
+
+## Permissions and policies
+
+- `--permissions` is `role:actions`. Actions are `create,read,update,delete` or
+  `*`. Example dev value: `anonymous:*` (no auth, full CRUD - local only).
+  Tighten to e.g. `anonymous:read` or an `authenticated:*` role for anything
+  shared.
+- Column-level: `dab update <Entity> --permissions "anonymous:read" --fields.include "id,title"` (or `--fields.exclude`).
+- Row-level: `--policy-database "region eq 'US'"` (OData filter appended to the
+  query) and `--policy-request "@claims.role == 'admin'"` (evaluated before the
+  query).
+
+## REST and GraphQL options
+
+- Defaults: REST at `/api`, GraphQL at `/graphql`. Change per entity with
+  `dab update <Entity> --rest <path|true|false>` and
+  `--graphql <singular:plural|true|false>`.
+- OpenAPI document at `/api/openapi`; Swagger UI at `/swagger` (Development host
+  mode only). Health at `/health`.
+- Host mode: `--host-mode Development` enables Swagger and detailed errors;
+  `Production` (the default) disables them. Use Development locally.
+
+## Relationships (`dab update --relationship`)
+
+Declare relationships so REST/GraphQL can navigate between entities. The flags
+(confirmed in the DAB CLI reference):
+
+One-to-many / one-to-one (direct FK), giving DAB the field mapping
+`sourceField:targetField`:
+
+```bash
+# A User has one Profile (Profile.user_id -> User.id)
+dab update User \
+  --relationship profile \
+  --target.entity Profile \
+  --cardinality one \
+  --relationship.fields "id:user_id"
+
+# A Category has many Books (Book.category_id -> Category.id)
+dab update Category \
+  --relationship books \
+  --target.entity Book \
+  --cardinality many \
+  --relationship.fields "id:category_id"
+```
+
+Many-to-many through a linking table:
+
+```bash
+dab update Book \
+  --relationship authors \
+  --target.entity Author \
+  --cardinality many \
+  --relationship.fields "id:id" \
+  --linking.object dbo.books_authors \
+  --linking.source.fields book_id \
+  --linking.target.fields author_id
+```
+
+Both related entities must already exist (`dab add`) before you relate them.
+
+## Regenerating vs hand-editing
+
+`dab-config.json` is generated. Prefer `dab add` / `dab update` over editing the
+JSON by hand so it stays schema-valid; the `$schema` line enables editor
+validation if you must edit. `dab validate` checks the file, and
+`dab start` fails fast on an invalid config.

--- a/skills/azuresql-db-dab/references/dab-mcp.md
+++ b/skills/azuresql-db-dab/references/dab-mcp.md
@@ -1,0 +1,81 @@
+# DAB's built-in MCP endpoint
+
+## Framing (read this first)
+
+Data API Builder (version 1.7+; use the latest 2.x) can serve a **Model Context
+Protocol (MCP) endpoint from the same `dab-config.json`**, over the entities you
+already configured. Present it as **an additional API surface that DAB provides**
+- alongside its REST and GraphQL surfaces - **not** as a standalone "MSSQL MCP
+server." An MCP client that connects to DAB is talking to your DAB API, which
+happens to sit in front of the Azure SQL engine. Everything DAB's permissions
+and policies enforce for REST/GraphQL applies to the MCP surface too.
+
+## Contents
+
+- Where it lives
+- Enabling / disabling it
+- Scoping which entities and operations are exposed
+- Connecting an MCP client
+- stdio mode
+
+## Where it lives
+
+With `dab start` running, the MCP endpoint is at:
+
+```
+http://localhost:5000/mcp
+```
+
+It is **enabled by default**. It uses streamable HTTP and pins the MCP protocol
+version `2025-06-18`.
+
+## Enabling / disabling it
+
+Controlled under `runtime.mcp` in `dab-config.json`:
+
+```json
+"runtime": {
+  "mcp": {
+    "enabled": true,
+    "path": "/mcp",
+    "dml-tools": {
+      "create-record": true,
+      "read-records": true,
+      "update-record": true,
+      "delete-record": true
+    }
+  }
+}
+```
+
+CLI toggles on `dab start`: `--mcp.enabled true|false` and `--mcp.path /mcp`.
+Set `enabled: false` (or `--mcp.enabled false`) to turn the surface off entirely.
+
+## Scoping which entities and operations are exposed
+
+- Global DML tools are the `runtime.mcp.dml-tools` flags above (turn off, say,
+  `delete-record` to make the whole surface read/write-but-no-delete).
+- Per entity: `dab update <Entity> --mcp.dml-tools false` removes that entity
+  from the MCP DML tools while leaving it on REST/GraphQL.
+- Because MCP goes through the same entity permissions, a read-only surface is
+  just `anonymous:read` (or an authenticated role) on the entities - the MCP
+  client cannot do more than the entity's permissions allow.
+
+## Connecting an MCP client
+
+Point any MCP client that supports streamable HTTP at
+`http://localhost:5000/mcp`. The client discovers tools generated from your
+entities (read/create/update/delete per the `dml-tools` and per-entity
+permissions). This is the "the database is available to my agent as tools"
+story - delivered *by DAB as an API feature*, so you get REST, GraphQL, and MCP
+from one config with one set of permissions.
+
+## stdio mode
+
+For clients that spawn a local process instead of connecting over HTTP:
+
+```bash
+dab start --mcp-stdio            # optionally: --mcp-stdio role:<role>
+```
+
+This runs DAB's MCP surface over stdio using the same `dab-config.json`.

--- a/skills/azuresql-db-dab/references/dab-snippets.md
+++ b/skills/azuresql-db-dab/references/dab-snippets.md
@@ -1,0 +1,110 @@
+# Data API Builder snippets
+
+## Contents
+
+- End-to-end with the CLI
+- DAB as a container against the SQL container
+- DAB as a compose service
+- Sample REST calls
+- Sample GraphQL calls
+- Seeding a table to return rows
+
+## End-to-end with the CLI
+
+Assumes the container is running and `appdb` is provisioned (see
+**azuresql-db-container** / **azuresql-db-scaffold**), with a `dbo.Books` table.
+
+```bash
+dotnet tool install --global Microsoft.DataApiBuilder   # once; needs .NET 8
+
+export SQL_CONNECTION_STRING="Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true"
+
+dab init --database-type mssql \
+  --connection-string "@env('SQL_CONNECTION_STRING')" \
+  --host-mode Development
+dab add Book --source dbo.Books --source.type table --permissions "anonymous:*"
+dab start            # http://localhost:5000
+```
+
+## DAB as a container against the SQL container
+
+DAB in its own container must reach the SQL container over the Docker network,
+so the host is the **service/container name**, not `localhost`. Put both on one
+network:
+
+```bash
+docker network create appnet 2>/dev/null
+
+# SQL engine on the network (name: sqldb)
+docker run -d --name sqldb --network appnet --platform linux/amd64 \
+  -e ACCEPT_EULA=Y -e MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd \
+  -p 1433:1433 sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest
+# ... wait for ready + CREATE DATABASE appdb (see azuresql-db-container) ...
+
+# DAB on the same network; connection host is sqldb, not localhost
+docker run -d --name dab --network appnet -p 5000:5000 \
+  -e SQL_CONNECTION_STRING="Server=sqldb,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true" \
+  -v "$PWD/dab-config.json:/App/dab-config.json" \
+  mcr.microsoft.com/azure-databases/data-api-builder:latest
+```
+
+If the SQL engine runs on the host instead, DAB-in-a-container reaches it at
+`host.docker.internal,1433`.
+
+## DAB as a compose service
+
+Add DAB alongside the `sqldb` sidecar (see **azuresql-db-sidecar** for the
+engine service + `sqldb-init`). Host is the service name `sqldb`:
+
+```yaml
+services:
+  # sqldb: ...        (engine, see azuresql-db-sidecar)
+  # sqldb-init: ...   (creates appdb, see azuresql-db-sidecar)
+
+  dab:
+    image: mcr.microsoft.com/azure-databases/data-api-builder:latest
+    depends_on:
+      sqldb-init:
+        condition: service_completed_successfully
+    environment:
+      SQL_CONNECTION_STRING: "Server=sqldb,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true"
+    ports:
+      - "5000:5000"
+    volumes:
+      - ./dab-config.json:/App/dab-config.json:ro
+```
+
+## Sample REST calls
+
+```bash
+curl http://localhost:5000/api/Book                         # list
+curl http://localhost:5000/api/Book/id/1                    # by primary key
+curl "http://localhost:5000/api/Book?\$filter=title eq 'Dune'&\$select=id,title"
+curl -X POST http://localhost:5000/api/Book \
+  -H 'Content-Type: application/json' -d '{"title":"New Title"}'
+```
+
+## Sample GraphQL calls
+
+```bash
+curl -s http://localhost:5000/graphql \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"{ books(first:5) { items { id title } } }"}'
+
+# mutation
+curl -s http://localhost:5000/graphql \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"mutation { createBook(item:{ title:\"New\" }) { id title } }"}'
+```
+
+## Seeding a table to return rows
+
+DAB serves whatever is in the table; to see non-empty results, seed after
+`appdb` exists:
+
+```bash
+docker exec -i sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa \
+  -P YourStr0ng_Passw0rd -C -b -d appdb -Q \
+  "IF OBJECT_ID('dbo.Books') IS NULL CREATE TABLE dbo.Books(id INT IDENTITY PRIMARY KEY, title NVARCHAR(200));
+   INSERT INTO dbo.Books(title) VALUES (N'Dune'),(N'Neuromancer');"
+```

--- a/skills/azuresql-db-feedback/references/issue-fields.md
+++ b/skills/azuresql-db-feedback/references/issue-fields.md
@@ -61,6 +61,8 @@ Title prefix is `[Skill]: ` (preserve it).
 - `azuresql-db-ci`
 - `azuresql-db-sidecar`
 - `azuresql-db-scaffold`
+- `azuresql-db-dab`
+- `azuresql-db-functions`
 - `azuresql-db-faq`
 - `azuresql-db-feedback`
 - `The collection as a whole (install, discovery, or the wrong skill loaded)`

--- a/skills/azuresql-db-functions/SKILL.md
+++ b/skills/azuresql-db-functions/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: azuresql-db-functions
+description: >-
+  Builds a serverless API and event-driven handlers over the local Azure SQL
+  Developer using Azure Functions with the Azure SQL bindings. Use when a user
+  wants "a serverless API over SQL", "Azure Functions with a database", "HTTP
+  CRUD with SQL input/output bindings", "run code when a row changes", "react to
+  inserts/updates/deletes", "event-driven on Azure SQL", or "SQL trigger
+  function". The Azure SQL trigger binding (backed by Change Tracking) is the
+  local event-driven mechanism; Change Event Streaming (CES) is cloud-only and
+  cannot run against the local container. Triggers include "func start with
+  SQL", "SqlTrigger", "SqlInput/SqlOutput binding", "local.settings.json
+  SqlConnectionString". Reach for this when building serverless endpoints or
+  change-driven logic on the local Azure SQL engine.
+---
+
+# Azure SQL Developer: serverless API + event-driven with Azure Functions
+
+Build HTTP CRUD endpoints and change-driven handlers over the local **Azure SQL
+Developer** (Private Preview) using **Azure Functions** and the first-party
+**Azure SQL bindings**. Two capabilities:
+
+- **API:** HTTP-triggered functions with SQL **input** and **output** bindings
+  (read and upsert with no ADO.NET boilerplate).
+- **Event-driven (local):** the SQL **trigger** binding fires a function when
+  rows are inserted/updated/deleted. It is backed by **Change Tracking**, runs
+  fully locally against the container, and needs no cloud services.
+
+> Event-driven note: Azure SQL **Change Event Streaming (CES)** is the *cloud*
+> path for streaming row changes, and it **cannot run against the local
+> container** (it is unsupported on the Linux engine and streams only to Azure
+> Event Hubs public endpoints). Locally, use the SQL trigger below. See
+> [references/event-driven.md](references/event-driven.md).
+
+## Load-bearing facts (inlined; full engine detail in azuresql-db-container)
+
+- This is the **Azure SQL Database engine** (Private Preview), not the SQL Server
+  image `mcr.microsoft.com/mssql/server`. `SERVERPROPERTY('EngineEdition')`
+  returns `5`, `SERVERPROPERTY('Edition')` returns `'SQL Azure'`.
+- Image: `sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest`
+  (x64, `linux/amd64`). Registry is private: sign in first with
+  `docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io` using the shared
+  pull-only credentials from https://aka.ms/sqldbcontainerpreview-signup (they
+  may rotate). Registry and tag are provisional during Private Preview.
+- Required env: `ACCEPT_EULA=Y` and a complex `MSSQL_SA_PASSWORD` (8+ chars,
+  upper/lower/digit/symbol). Engine listens on 1433.
+- The engine does **NOT** auto-create databases. Run `CREATE DATABASE appdb` on
+  a **master** connection before the function app connects with `Database=appdb`.
+  Do not use `USE` to switch databases; select it in the connection string.
+- On a non-x64 host add `--platform linux/amd64`.
+
+For the full engine model (readiness loop, vectors, troubleshooting) see the
+**azuresql-db-container** skill; to start the container and provision `appdb`,
+use **azuresql-db-container** or **azuresql-db-scaffold**.
+
+## Step 1: the connection string setting
+
+The bindings read the connection string from an app setting. Use the name
+`SqlConnectionString` (the docs' convention). In `local.settings.json`:
+
+```json
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+    "SqlConnectionString": "Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true"
+  }
+}
+```
+
+`TrustServerCertificate=true` is required for the container's self-signed cert.
+Set `FUNCTIONS_WORKER_RUNTIME` to your language (`dotnet-isolated`, `node`,
+`python`, `powershell`, `java`). Bindings reference this setting name via
+`ConnectionStringSetting` (C#/Java), `connectionStringSetting` (function.json), or
+`connection_string_setting` (Python v2 decorator) - **not** `Connection` (that
+keyword is for Storage/Event Hubs bindings).
+
+## Step 2: install the SQL extension
+
+- **.NET isolated worker:** add the NuGet package.
+
+  ```bash
+  dotnet add package Microsoft.Azure.Functions.Worker.Extensions.Sql
+  ```
+
+- **JavaScript / TypeScript / Python / PowerShell / Java:** use the extension
+  bundle in `host.json` (Java also adds the `azure-functions-java-library-sql`
+  Maven package):
+
+  ```json
+  {
+    "version": "2.0",
+    "extensionBundle": {
+      "id": "Microsoft.Azure.Functions.ExtensionBundle",
+      "version": "[4.0.0, 5.0.0)"
+    }
+  }
+  ```
+
+## Step 3: HTTP API with SQL input/output bindings
+
+Scaffold a project and add functions:
+
+```bash
+func init MyApi --worker-runtime dotnet-isolated   # or: node / python / ...
+cd MyApi
+func new --name Books                              # pick an HTTP trigger template
+```
+
+Then wire the SQL bindings into the function. Per-language snippets (HTTP GET via
+input binding, HTTP POST upsert via output binding) are in
+[references/functions-snippets.md](references/functions-snippets.md); binding
+attribute/`function.json` fields are in
+[references/functions-bindings-reference.md](references/functions-bindings-reference.md).
+
+Output-binding requirements: the target table must have a **primary key**
+(the binding upserts via `MERGE`), and the database **compatibility level must
+be 130+** (the binding uses `OPENJSON`). The engine is fully capable; just
+ensure the table has a PK.
+
+Run it:
+
+```bash
+func start        # HTTP endpoints on http://localhost:7071/api/<name>
+```
+
+## Step 4: event-driven with the SQL trigger (the local mechanism)
+
+The SQL trigger fires your function when rows change. It requires **Change
+Tracking** on the database and table. Enable it once (on `appdb`, not `master`):
+
+```sql
+ALTER DATABASE appdb
+  SET CHANGE_TRACKING = ON (CHANGE_RETENTION = 2 DAYS, AUTO_CLEANUP = ON);
+ALTER TABLE dbo.ToDo ENABLE CHANGE_TRACKING;
+```
+
+The function binds to a list of changes, each with an `Item` and an `Operation`
+(`Insert` / `Update` / `Delete`). C# isolated example:
+
+```csharp
+[Function("ToDoTrigger")]
+public static void Run(
+    [SqlTrigger("[dbo].[ToDo]", "SqlConnectionString")]
+    IReadOnlyList<SqlChange<ToDoItem>> changes,
+    FunctionContext context)
+{
+    foreach (var change in changes)
+        context.GetLogger("ToDoTrigger")
+            .LogInformation($"{change.Operation}: {change.Item.Id}");
+}
+```
+
+The trigger creates an internal `az_func` schema plus a
+`Leases_{FunctionId}_{TableId}` table (it makes these itself if the principal
+can). Behavior, permission grants, and the CES-is-cloud-only detail are in
+[references/event-driven.md](references/event-driven.md). Since you connect as
+`sa` locally, the permission grants are already satisfied; they matter when you
+move to least-privilege or to the cloud.
+
+## Validation rules
+
+- The database engine is the container image above (EngineEdition=5), never
+  `mcr.microsoft.com/mssql/server`.
+- `appdb` exists (created on a master connection) before the function app runs;
+  `SqlConnectionString` uses `Database=appdb` and `TrustServerCertificate=true`.
+- The connection string lives in `local.settings.json` (or app settings), not in
+  code; bindings reference it via `ConnectionStringSetting` / `connectionStringSetting`.
+- Output-binding target tables have a primary key; the database compat level is 130+.
+- The SQL trigger has Change Tracking enabled on both the database and the table;
+  event-driven is done with the trigger locally, not CES.
+- If a validation rule above fails, or you had to deviate from this skill to make the task work, that is a bug in this skill: load the **azuresql-db-feedback** skill and offer to file a report.
+- When every rule above passes and the task is done, close with ONE line, once per session, and do not ask a question or wait for a reply: "That worked. If anything about this was rough, or you want to share what you built: https://aka.ms/sql-agent-skills-feedback"
+
+## Do not
+
+- Do not use the SQL Server image `mcr.microsoft.com/mssql/server`; this is the Azure SQL engine.
+- Do not expect the function app to create `appdb`; provision it on a master connection first.
+- Do not try to make Change Event Streaming (CES) work locally - it is unsupported on the local (Linux) engine and streams only to Azure Event Hubs. Use the SQL trigger locally.
+- Do not use an output binding against a table with no primary key, or below compatibility level 130.
+- Do not use the `Connection` binding keyword for SQL bindings; it is `ConnectionStringSetting` / `connectionStringSetting`.
+- Do not commit `local.settings.json` (it holds the connection string / SA password) or drop `TrustServerCertificate=true` / `--platform linux/amd64` on a non-x64 host.
+
+## References
+
+- [references/functions-bindings-reference.md](references/functions-bindings-reference.md): the input, output, and trigger binding fields (C# attributes, `function.json`, Python decorators), the `SqlConnectionString` setting, and host.json trigger tuning (`MaxBatchSize`, `PollingIntervalMs`).
+- [references/functions-snippets.md](references/functions-snippets.md): copy-paste project setup and per-language function bodies - HTTP GET (input binding), HTTP POST upsert (output binding), and a SQL-trigger handler - plus `func` commands and a local run/verify loop.
+- [references/event-driven.md](references/event-driven.md): how the SQL trigger works (Change Tracking, polling, coalescing, `az_func` state tables), the required permission grants, and why CES is a cloud-only path you stub locally with the trigger.

--- a/skills/azuresql-db-functions/references/event-driven.md
+++ b/skills/azuresql-db-functions/references/event-driven.md
@@ -1,0 +1,103 @@
+# Event-driven on Azure SQL: the SQL trigger locally, CES in the cloud
+
+## Contents
+
+- The local mechanism: SQL trigger + Change Tracking
+- Enabling Change Tracking
+- How the trigger behaves (polling, coalescing, order)
+- Internal state (`az_func` schema, leases)
+- Least-privilege permission grants
+- Why Change Event Streaming (CES) is cloud-only
+- Choosing a path
+
+## The local mechanism: SQL trigger + Change Tracking
+
+For local, first-party, zero-cloud event-driven work, use the **Azure Functions
+SQL trigger**. It is backed by SQL **Change Tracking**: the trigger polls the
+change-tracking system tables and invokes your function with the rows that
+changed. It connects with the same `SqlConnectionString` and runs entirely
+against the local container.
+
+## Enabling Change Tracking
+
+Two statements, on `appdb` (never `master`) and the monitored table:
+
+```sql
+ALTER DATABASE appdb
+  SET CHANGE_TRACKING = ON (CHANGE_RETENTION = 2 DAYS, AUTO_CLEANUP = ON);
+
+ALTER TABLE dbo.ToDo ENABLE CHANGE_TRACKING;
+```
+
+`CHANGE_RETENTION` bounds how far back changes are kept: if the function is
+stopped longer than the retention window, older changes are lost. `AUTO_CLEANUP`
+removes change history past retention.
+
+## How the trigger behaves (polling, coalescing, order)
+
+- **Polling, not push.** A loop gets up to `MaxBatchSize` changes (default 100),
+  invokes the function, waits `PollingIntervalMs` (default 1000 ms), repeats.
+- **Coalesced.** Between polls, multiple changes to the *same row* collapse to a
+  single entry showing the difference from the last processed state - you see
+  the latest state, not every intermediate one.
+- **Order.** Oldest changes first, following `CHANGETABLE` order.
+- **No old-vs-new values.** You get the current row (`Item`) and the
+  `Operation` (Insert/Update/Delete), keyed by primary key - Change Tracking
+  records *that* a row changed, not the before image. (For full before/after
+  column values you would need CDC + Debezium; see "Choosing a path".)
+- **Requires a primary key** on the monitored table.
+
+## Internal state (`az_func` schema, leases)
+
+Each trigger has a change-tracking table and a **leases** table in an internal
+`az_func` schema, named `Leases_{FunctionId}_{TableId}`. The trigger creates
+them if they don't exist and the principal has permission. The leases table adds
+bookkeeping columns (`_az_func_ChangeVersion`, `_az_func_AttemptCount`,
+`_az_func_LeaseExpirationTime`) that make delivery resilient across restarts.
+
+## Least-privilege permission grants
+
+Connecting as `sa` locally satisfies all of this automatically. When you move to
+a least-privilege principal (or to the cloud), the trigger needs more than
+`db_datareader`/`db_datawriter`:
+
+```sql
+GRANT CREATE TABLE TO [<principal>];
+GRANT CREATE SCHEMA TO [<principal>];
+
+GRANT SELECT ON [dbo].[ToDo] TO [<principal>];
+GRANT VIEW CHANGE TRACKING ON [dbo].[ToDo] TO [<principal>];
+
+CREATE SCHEMA az_func;
+GO
+GRANT ALTER ON SCHEMA::az_func TO [<principal>];
+GRANT SELECT, INSERT, UPDATE, DELETE ON SCHEMA::az_func TO [<principal>];
+```
+
+## Why Change Event Streaming (CES) is cloud-only
+
+CES is the native Azure SQL feature that streams row-change events to a
+destination. It is the right choice **in the cloud**, but it **cannot run
+against the local container**, for two independent reasons:
+
+1. **Engine/OS:** CES is unsupported on the Linux SQL engine, and every local
+   Azure SQL container runs the Linux engine - so the container has CES disabled.
+2. **Destination:** CES streams **only to Azure Event Hubs public endpoints**
+   (AMQP or the Event Hubs Kafka facade). It rejects private/service endpoints
+   and generic Kafka, and cannot authenticate to a local Event Hubs emulator.
+
+So there is no way to make CES work purely locally. Treat CES as a **production
+integration** you enable when the app runs against Azure SQL Database / Managed
+Instance with a real Event Hubs namespace, and **stub it locally with the SQL
+trigger**. If you want the consumer to look the same in both places, shape the
+trigger's output like CES's CloudEvents payload.
+
+## Choosing a path
+
+- **Local "react to row changes" (default):** SQL trigger (this skill). First
+  party, local, no cloud.
+- **Production streaming to Event Hubs (AMQP or its Kafka-facade consumers):**
+  CES, once deployed to Azure SQL DB/MI. Cloud only.
+- **Full before/after change capture locally (audit/replication fidelity):** CDC
+  + the Debezium SQL Server connector into a local Kafka - heavier, but gives
+  before/after images the trigger does not. Out of scope for this skill.

--- a/skills/azuresql-db-functions/references/functions-bindings-reference.md
+++ b/skills/azuresql-db-functions/references/functions-bindings-reference.md
@@ -1,0 +1,103 @@
+# Azure SQL bindings reference
+
+## Contents
+
+- The three bindings
+- Connection setting
+- Input binding fields
+- Output binding fields
+- Trigger binding fields
+- host.json trigger tuning
+
+## The three bindings
+
+| Binding | Direction | Use |
+| --- | --- | --- |
+| SQL input | in | Read rows (a query or a stored procedure) into the function |
+| SQL output | out | Upsert one or more rows (via `MERGE`) |
+| SQL trigger | (trigger) | Fire the function when rows change (Change Tracking) |
+
+Install: `.NET` isolated → NuGet `Microsoft.Azure.Functions.Worker.Extensions.Sql`;
+JS/TS/Python/PowerShell → the `host.json` extension bundle `[4.0.0, 5.0.0)`;
+Java → the bundle plus Maven `azure-functions-java-library-sql`.
+
+## Connection setting
+
+Every binding names an app setting that holds the connection string. The docs'
+convention is `SqlConnectionString` in `local.settings.json`. Reference it via:
+
+- C# / Java attribute property: `ConnectionStringSetting = "SqlConnectionString"`
+- `function.json` (JS/PowerShell/Python v1): `"connectionStringSetting": "SqlConnectionString"`
+- Python v2 decorator: `connection_string_setting="SqlConnectionString"`
+
+It is **not** the `Connection` property (that belongs to Storage/Event Hubs
+bindings). Locally the value is the container connection string with
+`TrustServerCertificate=true`.
+
+## Input binding fields
+
+| Field | Meaning |
+| --- | --- |
+| `CommandText` | The T-SQL query, table name, or stored procedure |
+| `CommandType` | `Text` (query, default) or `StoredProcedure` |
+| `Parameters` | Parameters passed to the command (e.g. from route/query) |
+| `ConnectionStringSetting` | The app setting name (`SqlConnectionString`) |
+
+Bind the input to a collection of your row type; the function receives the query
+result.
+
+## Output binding fields
+
+| Field | Meaning |
+| --- | --- |
+| `CommandText` | The target table, e.g. `dbo.ToDo` |
+| `ConnectionStringSetting` | The app setting name (`SqlConnectionString`) |
+
+The output binding **upserts** with `MERGE`, so:
+
+- the target table **must have a primary key** (one or more columns);
+- the database **compatibility level must be 130+** (it uses `OPENJSON`);
+- it needs `SELECT` (plus insert/update) on the table;
+- `NTEXT` / `TEXT` / `IMAGE` target columns are unsupported.
+
+Assign the rows to the output parameter; the binding writes them on return.
+
+## Trigger binding fields
+
+| Field | Meaning |
+| --- | --- |
+| `TableName` | The monitored table, e.g. `[dbo].[ToDo]` |
+| `ConnectionStringSetting` | The app setting name (`SqlConnectionString`) |
+| `LeasesTableName` | Optional; defaults to `Leases_{FunctionId}_{TableId}` in schema `az_func` |
+
+The parameter type is a list of change objects, each exposing:
+
+- `Item` - the changed row, typed to your model (matches the table schema);
+- `Operation` - `Insert`, `Update`, or `Delete` (from `SqlChangeOperation`).
+
+C# isolated attribute: `[SqlTrigger("[dbo].[ToDo]", "SqlConnectionString")]`
+bound to `IReadOnlyList<SqlChange<T>>`. `function.json` equivalent: `"type":
+"sqlTrigger"`, `"direction": "in"`, `"tableName"`, `"connectionStringSetting"`.
+
+Requires Change Tracking on the database and table (see event-driven.md).
+
+## host.json trigger tuning
+
+Under `extensions.Sql`:
+
+| Setting | Default | Meaning |
+| --- | --- | --- |
+| `MaxBatchSize` | 100 | Max changes delivered per invocation |
+| `PollingIntervalMs` | 1000 | Delay between polls (ms) |
+| `MaxChangesPerWorker` | 1000 | Pending-change ceiling per worker (scaling) |
+
+```json
+{
+  "version": "2.0",
+  "extensions": { "Sql": { "MaxBatchSize": 300, "PollingIntervalMs": 1000 } }
+}
+```
+
+The same values can be set in `local.settings.json` as
+`Sql_Trigger_MaxBatchSize`, `Sql_Trigger_PollingIntervalMs`,
+`Sql_Trigger_MaxChangesPerWorker`.

--- a/skills/azuresql-db-functions/references/functions-snippets.md
+++ b/skills/azuresql-db-functions/references/functions-snippets.md
@@ -1,0 +1,136 @@
+# Azure Functions + Azure SQL snippets
+
+## Contents
+
+- Project setup
+- local.settings.json
+- C# isolated: HTTP GET (input) and POST upsert (output)
+- C# isolated: SQL trigger
+- JavaScript: input / output / trigger
+- Python v2: input / output / trigger
+- Run and verify locally
+
+## Project setup
+
+```bash
+func init MyApi --worker-runtime dotnet-isolated   # or node / python / powershell
+cd MyApi
+
+# .NET isolated: add the SQL bindings package
+dotnet add package Microsoft.Azure.Functions.Worker.Extensions.Sql
+# JS/TS/Python/PowerShell: ensure host.json has the extension bundle [4.0.0, 5.0.0)
+
+func new --name Books        # choose an HTTP trigger template, then add bindings below
+```
+
+## local.settings.json
+
+```json
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+    "SqlConnectionString": "Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true"
+  }
+}
+```
+
+## C# isolated: HTTP GET (input) and POST upsert (output)
+
+```csharp
+public class ToDoItem
+{
+    public Guid Id { get; set; }
+    public string title { get; set; }
+    public bool? completed { get; set; }
+}
+
+// GET /api/todo  -> reads rows via the SQL input binding
+[Function("GetToDo")]
+public static IEnumerable<ToDoItem> Get(
+    [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "todo")] HttpRequestData req,
+    [SqlInput("SELECT * FROM dbo.ToDo", "SqlConnectionString")] IEnumerable<ToDoItem> items)
+    => items;
+
+// POST /api/todo  -> upserts via the SQL output binding (table needs a PK)
+[Function("PostToDo")]
+[SqlOutput("dbo.ToDo", "SqlConnectionString")]
+public static async Task<ToDoItem> Post(
+    [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "todo")] HttpRequestData req)
+    => await req.ReadFromJsonAsync<ToDoItem>();
+```
+
+## C# isolated: SQL trigger
+
+```csharp
+[Function("ToDoTrigger")]
+public static void Run(
+    [SqlTrigger("[dbo].[ToDo]", "SqlConnectionString")]
+    IReadOnlyList<SqlChange<ToDoItem>> changes,
+    FunctionContext context)
+{
+    var log = context.GetLogger("ToDoTrigger");
+    foreach (var change in changes)
+        log.LogInformation($"{change.Operation}: {change.Item.Id} {change.Item.title}");
+}
+```
+
+## JavaScript: input / output / trigger
+
+`function.json` for the trigger:
+
+```json
+{
+  "bindings": [
+    { "name": "todoChanges", "type": "sqlTrigger", "direction": "in",
+      "tableName": "dbo.ToDo", "connectionStringSetting": "SqlConnectionString" }
+  ]
+}
+```
+
+`index.js`:
+
+```javascript
+module.exports = async function (context, todoChanges) {
+  context.log(`SQL Changes: ${JSON.stringify(todoChanges)}`);
+};
+```
+
+Input/output bindings use `"type": "sql"` (direction `in`) and `"type": "sql"`
+(direction `out`) with `commandText` / target table and the same
+`connectionStringSetting`.
+
+## Python v2: input / output / trigger
+
+```python
+import azure.functions as func
+app = func.FunctionApp()
+
+@app.function_name(name="ToDoTrigger")
+@app.sql_trigger(arg_name="todo",
+                 table_name="ToDo",
+                 connection_string_setting="SqlConnectionString")
+def todo_trigger(todo: str) -> None:
+    import json, logging
+    logging.info("SQL Changes: %s", json.loads(todo))
+```
+
+## Run and verify locally
+
+```bash
+# 1. Container running + appdb + dbo.ToDo table with a PRIMARY KEY on Id.
+# 2. For the trigger, enable Change Tracking (see event-driven.md).
+func start           # http://localhost:7071/api/<route>
+
+# API check
+curl http://localhost:7071/api/todo
+curl -X POST http://localhost:7071/api/todo \
+  -H 'Content-Type: application/json' \
+  -d '{"Id":"11111111-1111-1111-1111-111111111111","title":"buy milk","completed":false}'
+
+# Trigger check: insert a row, watch func output log the Insert change
+docker exec -i sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa \
+  -P YourStr0ng_Passw0rd -C -b -d appdb -Q \
+  "INSERT INTO dbo.ToDo(Id,title,completed) VALUES (NEWID(),N'via trigger',0);"
+```


### PR DESCRIPTION
## What

Adds two **builder** skills that close the API/serving and event-driven gap in the collection (**11 → 13 skills**):

- **`azuresql-db-dab`** — instant no-code **REST + GraphQL** over the local Azure SQL Developer with **Data API Builder** (`dab init/add/start`, `@env()` connection, relationships). DAB's built-in **MCP endpoint** is positioned as *a DAB-provided API surface*, not a standalone MSSQL MCP server.
- **`azuresql-db-functions`** — serverless **HTTP API** via the Azure SQL input/output bindings, plus the **SQL trigger** (Change Tracking) as the **local event-driven mechanism**. Documents why **Change Event Streaming (CES) is cloud-only** and cannot run against the local container (Linux engine + Event-Hubs-public-endpoint-only).

Each ships a `SKILL.md` (frontmatter `name`+`description` only), a `references/` folder for progressive disclosure, the inlined accuracy baseline, failure routing to `azuresql-db-feedback`, and a matching build prompt in `docs/prompts/`.

## Drift-guarded surfaces updated

`skills/README.md` (catalog + install tables), `docs/agent-skills.md` (cards + install list), `.github/ISSUE_TEMPLATE/skill_feedback.yml` (skill dropdown), and the "11 → 13" / "Eleven → Thirteen" counts in `.claude-plugin/marketplace.json`, `docs/llms.txt`, and `docs/index.html`.

## Validation (against the live preview container)

| Lane | Result |
| --- | --- |
| Deterministic canon-check | **16/0 PASS** |
| Triggering (explicit/implicit/routing) | **8/8, 100% routing accuracy** |
| DAB live battery (REST/GraphQL/OpenAPI/MCP) | **DAB_RESULT=PASS** (7/0) |
| Functions live battery (Change Tracking, CHANGETABLE, OPENJSON, MERGE) | **FUNC_RESULT=PASS** (5/0) |
| Adversarial reviewer pass | 3 minor findings, all fixed |

New live batteries (`dab_battery.sh`, `functions_battery.sh`) and the triggering/deterministic registrations live in the eval framework (`azuresqldb-skills-lab`), not in this repo.

## Notes

- MCP is intentionally scoped to DAB's endpoint feature — there is no standalone MSSQL MCP server here.
- Event-driven locally uses the Functions SQL trigger; CES is documented as the cloud-only production path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)