### PR TITLE
docs: add opt-in web analytics (Azure Application Insights)

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -14,6 +14,14 @@ public_repo: "https://github.com/microsoft/azure-sql-database-container"
 youtube_id: "S6PWxUAUspY"
 demo_link: "https://aka.ms/azuresql-developer-demo"
 
+# Web analytics (client-side). Loads only when `enabled` is true and a provider is configured.
+# The Application Insights connection string is browser-embeddable and is not a secret.
+analytics:
+  enabled: true
+  app_insights_connection_string: "InstrumentationKey=c19fefc8-7c54-4c31-a081-6893153bb911;IngestionEndpoint=https://eastus-8.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/;ApplicationId=cd119e2c-6b36-43c2-8703-04d5bc1a86c7"
+  clarity_id: ""   # set the Microsoft Clarity project id to enable Clarity (separate change)
+  ga4_id: ""       # set the GA4 measurement id (G-XXXXXXX) to enable GA4 (separate change)
+
 
 markdown: kramdown
 kramdown:

--- a/docs/_includes/analytics.html
+++ b/docs/_includes/analytics.html
@@ -1,0 +1,17 @@
+{%- comment -%}
+  Analytics router. Emits a provider's snippet only when analytics is enabled and that provider
+  is configured, so the site ships tracking-free until an id/connection string is set. Custom
+  events are fired from assets/js/main.js via a small track() helper that fans out to whatever
+  provider loaded. Consent-safe: providers run cookieless by default (no consent banner yet).
+{%- endcomment -%}
+{%- if site.analytics.enabled -%}
+  {%- if site.analytics.app_insights_connection_string and site.analytics.app_insights_connection_string != "" -%}
+    {%- include analytics/app-insights.html -%}
+  {%- endif -%}
+  {%- comment -%}
+    Microsoft Clarity and Google Analytics 4 slot in here when site.analytics.clarity_id /
+    site.analytics.ga4_id are set (each in its own analytics/<provider>.html partial). See the
+    analytics implementation plan. Clarity additionally requires masking code/connection-string
+    content (data-clarity-mask) and a consent signal for EEA/UK/CH visitors.
+  {%- endcomment -%}
+{%- endif -%}

--- a/docs/_includes/analytics/app-insights.html
+++ b/docs/_includes/analytics/app-insights.html
@@ -1,0 +1,32 @@
+{%- comment -%}
+  Azure Application Insights (client-side, browser telemetry). Loads the SDK asynchronously,
+  runs cookieless (disableCookiesUsage) so no consent banner is required, auto-collects page
+  views, and exposes window.appInsights for the track() helper in assets/js/main.js.
+  The connection string is browser-embeddable and is not a secret.
+{%- endcomment -%}
+<script>
+(function () {
+  var cs = "{{ site.analytics.app_insights_connection_string }}";
+  if (!cs) return;
+  var s = document.createElement("script");
+  s.src = "https://js.monitor.azure.com/scripts/b/ai.3.gbl.min.js";
+  s.crossOrigin = "anonymous";
+  s.async = true;
+  s.onload = function () {
+    try {
+      var ai = new Microsoft.ApplicationInsights.ApplicationInsights({
+        config: {
+          connectionString: cs,
+          disableCookiesUsage: true,          // cookieless: consent-safe, no banner required
+          disableExceptionTracking: false,
+          enableAutoRouteTracking: false      // multi-page site: one page view per load
+        }
+      });
+      ai.loadAppInsights();
+      ai.trackPageView();
+      window.appInsights = ai;
+    } catch (e) {}
+  };
+  document.head.appendChild(s);
+})();
+</script>

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -31,6 +31,6 @@
   </div>
   <div class="container footer-base">
     <p>Private Preview governed by a separate license shared at sign-up. Code in this repository is MIT licensed.</p>
-    <p>Built by the Developer Experiences and AI Team at Microsoft.</p>
+    <p>Built by the Developer Experiences and AI Team at Microsoft. <a href="{{ '/privacy.html' | relative_url }}">Privacy and analytics</a>.</p>
   </div>
 </footer>

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -19,4 +19,5 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
+  {% include analytics.html %}
 </head>

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -44,6 +44,17 @@
     }
   }
 
+  // ---- analytics: fan a custom event out to whatever provider loaded ----
+  // No-ops until an analytics provider is configured (see _includes/analytics.html).
+  function track(name, props) {
+    try {
+      if (window.appInsights && typeof window.appInsights.trackEvent === "function") {
+        window.appInsights.trackEvent({ name: name }, props || {});
+      }
+      // Microsoft Clarity and GA4 fan-out slot in here when those providers are added.
+    } catch (e) {}
+  }
+
   // shareable anchors on doc-page headings (kramdown already gives them ids)
   document.querySelectorAll(".prose h2[id], .prose h3[id]").forEach(function (h) {
     if (h.querySelector(".head-anchor")) return;
@@ -108,6 +119,7 @@
         text = target ? target.innerText : "";
       }
       copyText(normalizeCommand(text), btn);
+      track("copy_command", { kind: /npx skills add/.test(text || "") ? "install" : "command" });
     });
   });
 
@@ -121,6 +133,7 @@
     btn.addEventListener("click", function () {
       var code = pre.querySelector("code") || pre;
       copyText(normalizeCommand(code.innerText), btn);
+      track("copy_code", {});
     });
     pre.appendChild(btn);
   });
@@ -129,6 +142,7 @@
   document.querySelectorAll("[data-prompt]").forEach(function (btn) {
     btn.addEventListener("click", function () {
       var url = btn.getAttribute("data-prompt");
+      track("copy_prompt", { prompt: url });
       fetch(url).then(function (r) { return r.text(); }).then(function (text) {
         copyText(text, btn);
       }).catch(function () {});
@@ -189,6 +203,9 @@
     if (href && href.charAt(0) !== "#" && !inNav) {
       a.setAttribute("target", "_blank");
       a.setAttribute("rel", "noopener noreferrer");
+      var host = "";
+      try { host = new URL(a.href, location.href).hostname; } catch (e) {}
+      a.addEventListener("click", function () { track("outbound_click", { host: host, href: href }); });
     }
   });
 })();

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,37 @@
+---
+title: Privacy and analytics
+description: What this site measures, how, and how to opt out.
+---
+
+# Privacy and analytics
+
+This site uses privacy-preserving analytics to understand which content and scenarios help developers, so the team can improve them. This page explains what is collected and how to opt out.
+
+## What we measure
+
+The site sends aggregate usage telemetry to **Azure Application Insights**, a Microsoft first-party service, so the data stays within Microsoft and Azure. We collect:
+
+- **Page views:** which pages are visited, the referrer, and general browser and device information.
+- **A small set of interaction events:** copying a build prompt, copying an install or setup command, copying a code block, and clicking a link that leaves the site. These record that the action happened and a short non-personal label (for example, the destination host), never the content you view or type.
+
+## What we do not collect
+
+- No accounts, names, email addresses, or other personal identifiers.
+- No connection strings, passwords, SQL, or code you read or copy from the page.
+- No advertising or cross-site tracking.
+
+## Cookies and consent
+
+Analytics runs **cookieless**: it does not set analytics cookies, so there is no consent banner. Data is aggregate and cannot identify you.
+
+## Data residency and retention
+
+Telemetry is stored in an Azure Application Insights resource in a Microsoft-owned subscription and is retained for a limited period for trend analysis.
+
+## How to opt out
+
+Enable **Do Not Track** in your browser, or block requests to `js.monitor.azure.com` and `*.applicationinsights.azure.com` with your browser's tracking protection or an extension. The site works fully with analytics blocked.
+
+## Questions
+
+Reach the team through the links in the site footer.


### PR DESCRIPTION
## What

Adds client-side web analytics to the GitHub Pages site (aka.ms/azuresql-developer). It is **config-driven** so it is off until configured, and so **Microsoft Clarity and GA4 can be added later** by setting their ids in `_config.yml` with no rework. This PR wires **Azure Application Insights only**.

## Changes

- **`docs/_config.yml`** — an `analytics` block: `enabled`, the App Insights `connection_string`, and empty `clarity_id` / `ga4_id` placeholders for the follow-ups.
- **`docs/_includes/analytics.html`** — a router that emits a provider only when it is configured.
- **`docs/_includes/analytics/app-insights.html`** — loads the App Insights SDK asynchronously and runs **cookieless** (`disableCookiesUsage`), so no consent banner is required; auto-collects page views; exposes `window.appInsights`.
- **`docs/_includes/head.html`** — includes the router on every page.
- **`docs/assets/js/main.js`** — a small `track()` helper (fans out to whatever provider loaded) firing custom events: `copy_prompt`, `copy_command`, `copy_code`, `outbound_click`.
- **`docs/privacy.md`** + footer link — a short, accurate privacy note (aggregate, cookieless, no PII, how to opt out).

## Privacy / consent

Consent-safe by design: **cookieless**, no personal identifiers, and no page/code content is captured (event props are short non-personal labels). No consent banner is required. A fuller cookie-consent banner would only be needed if Clarity session replay is added later.

## Where the data goes

Telemetry lands in **`appi-azuresql-devhub-web`** (RG `Azure-SQL-Dev-Hub`, subscription SQLEverywherePMDemos). The connection string is browser-embeddable and is not a secret. Data appears after merge once GitHub Pages rebuilds and real traffic arrives.

## Not in this PR

Microsoft Clarity and Google Analytics 4 are follow-ups (create the Clarity project / GA4 property, then set the ids in `_config.yml`; Clarity additionally needs code-block masking and a consent signal for EEA/UK/CH).