### PR TITLE
Fix issues found in deep audit of skills + docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,7 +16,7 @@ description: "Go from pulling the Azure SQL Developer image to your first query 
 - [Troubleshooting](#troubleshooting)
   - [Let your AI agent diagnose it](#let-your-ai-agent-diagnose-it)
   - [Start here: check your container runtime](#start-here-check-your-container-runtime)
-  - [The container exits immediately](#the-container-exits-immediately)
+  - [The container exits immediately](#the-container-will-not-start-or-starts-but-will-not-accept-connections)
   - [Platform and port problems](#no-matching-manifest-or-exec-format-error)
   - [Connection and database problems](#connection-fails-right-after-the-container-starts)
   - [Skills did not load](#skills-did-not-load)

--- a/docs/index.html
+++ b/docs/index.html
@@ -275,7 +275,7 @@ title: Azure SQL Developer
     <div class="section-head">
       <p class="eyebrow"><span class="eyebrow-dot"></span>Built for AI-assisted development</p>
       <h2>Bring your AI coding agent.<a class="head-anchor" href="#ai-agents" aria-label="Link to this section">#</a></h2>
-      <p class="lead">Point your agent at Azure SQL Developer and let it scaffold the schema, write the migrations, and build the data layer against a real local database. The repo ships 16 ready-to-use <a href="{{ '/agent-skills.html' | relative_url }}">agent skills</a>.</p>
+      <p class="lead">Point your agent at Azure SQL Developer and let it scaffold the schema, write the migrations, and build the data layer against a real local database. The repo ships 17 ready-to-use <a href="{{ '/agent-skills.html' | relative_url }}">agent skills</a>.</p>
     </div>
     <div class="agents">
       <a class="agent" href="https://docs.github.com/copilot/get-started/quickstart" rel="noopener">

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -33,7 +33,8 @@ Copy-and-run prompts to hand your AI coding agent, each building a scenario agai
 - Connection: TCP port 1433; SQL login (sa) locally, Microsoft Entra in the cloud. Apps read the connection string from the SQL_CONNECTION_STRING environment variable.
 - AI-native: native vector data type, VECTOR_DISTANCE similarity search, AI_GENERATE_EMBEDDINGS, CREATE EXTERNAL MODEL, native JSON, and RegEx. DiskANN vector indexes (CREATE VECTOR INDEX) are in development; use full-scan top-k until then.
 - Parity: same engine, defaults, T-SQL, and error messages as Azure SQL Database in the cloud.
-- Not yet supported on the container (use SQL auth and the workarounds on the Known limitations page): Microsoft Entra ID authentication (the MSSQL_AAD_* variables initialize and then fail; use the sa login locally, Entra in the cloud), a native ARM64 build (ARM64 hosts run under emulation with --platform linux/amd64), CREATE VECTOR INDEX (DiskANN), and BACKUP / RESTORE.
+- Microsoft Entra ID authentication is supported on the container: configure it with the MSSQL_AAD_* variables and a mounted certificate (see the Getting started page). SQL auth (sa) remains the simple local default.
+- Not yet supported on the container (use the workarounds on the Known limitations page): a native ARM64 build (ARM64 hosts run under emulation with --platform linux/amd64), CREATE VECTOR INDEX (DiskANN), and BACKUP / RESTORE.
 
 ## Optional
 - [Repository](https://github.com/microsoft/azure-sql-database-container)

--- a/skills/azuresql-db-connections/references/retry-snippets.md
+++ b/skills/azuresql-db-connections/references/retry-snippets.md
@@ -88,15 +88,25 @@ Install: `npm install mssql`. Configure a bounded pool once and reuse it for the
 ```js
 import sql from "mssql";
 
-// Parse the single env var into a mssql config, then set pool bounds.
-const raw = process.env.SQL_CONNECTION_STRING; // Server=localhost,1433;Database=appdb;User Id=sa;Password=...;TrustServerCertificate=true
+// Parse the single SQL_CONNECTION_STRING (ADO.NET style) into an mssql config, then set pool bounds.
+// e.g. Server=localhost,1433;Database=appdb;User Id=sa;Password=...;Encrypt=true;TrustServerCertificate=true
+const kv = Object.fromEntries(
+  (process.env.SQL_CONNECTION_STRING || "").split(";").filter(Boolean).map((p) => {
+    const i = p.indexOf("=");
+    return [p.slice(0, i).trim().toLowerCase(), p.slice(i + 1).trim()];
+  })
+);
+const [server, port] = (kv["server"] || "localhost,1433").split(",");
 const config = {
-  server: "localhost",
-  port: 1433,
-  database: "appdb",
-  user: "sa",
-  password: "YourStr0ng_Passw0rd",
-  options: { trustServerCertificate: true, encrypt: true },
+  server,
+  port: Number(port) || 1433,
+  database: kv["database"],
+  user: kv["user id"] || kv["uid"],
+  password: kv["password"] || kv["pwd"],
+  options: {
+    encrypt: (kv["encrypt"] ?? "true").toLowerCase() !== "false",
+    trustServerCertificate: (kv["trustservercertificate"] ?? "false").toLowerCase() === "true",
+  },
   pool: { max: 10, min: 2, idleTimeoutMillis: 30000 }, // bounded pool, warm minimum
 };
 

--- a/skills/azuresql-db-container/references/paas-parity-checklist.md
+++ b/skills/azuresql-db-container/references/paas-parity-checklist.md
@@ -34,7 +34,7 @@ before declaring readiness.
 - `CREATE VECTOR INDEX` (DiskANN) is still in development. For now, use a
   full-scan top-k query with `VECTOR_DISTANCE` instead of an index.
 
-See the `azuresql-db-vectors` task skill for full patterns.
+See the `azuresql-db-rag` task skill for full patterns.
 
 ## Current preview limitations
 

--- a/skills/azuresql-db-dab/SKILL.md
+++ b/skills/azuresql-db-dab/SKILL.md
@@ -164,6 +164,6 @@ Authoritative, version-pinned references for the tools this skill uses (read the
 
 - [Data API Builder configuration reference](https://learn.microsoft.com/en-us/azure/data-api-builder/configuration/): every config key (data-source, runtime, entities, autoentities), with examples.
 - [DAB config JSON schema (pinned v2.0.9)](https://github.com/Azure/data-api-builder/releases/download/v2.0.9/dab.draft.schema.json): the machine-readable schema dab validate checks against.
-- [Data API Builder MCP (SQL MCP Server)](https://learn.microsoft.com/en-us/azure/data-api-builder/mcp/overview): the built-in MCP endpoint, DML tools, transports, and RBAC.
+- [Data API Builder built-in MCP endpoint](https://learn.microsoft.com/en-us/azure/data-api-builder/mcp/overview): the built-in MCP endpoint, DML tools, transports, and RBAC.
 
 If the **Microsoft Learn MCP** server is configured, use `mcp__microsoft-learn__microsoft_docs_search` or `mcp__microsoft-learn__microsoft_docs_fetch` to fetch the current version of any of these on demand. It is optional; when it is unavailable, the references above are authoritative.

--- a/skills/azuresql-db-faq/references/faq.md
+++ b/skills/azuresql-db-faq/references/faq.md
@@ -133,6 +133,14 @@ logins are limited; the app code and connection string are identical either way.
 Microsoft Entra contained users (`CREATE USER [name] FROM EXTERNAL PROVIDER`) do
 work on the container once Entra is enabled. Full recipes: the `azuresql-db-auth` skill.
 
+**Why does `BULK INSERT` (or `OPENROWSET(BULK ...)`) fail with Msg 12713 on a local file?**
+Because the engine reads bulk data only from **Azure Blob Storage**, not the local filesystem,
+exactly as Azure SQL Database in the cloud. Pointing `BULK INSERT` at a path inside the container
+returns `Msg 12713` ("OPENROWSET is not allowed to read local files"). To load a **local** CSV,
+use the `bcp` utility (it streams rows over the connection instead of reading a server-side file)
+or a driver/ORM; use `BULK INSERT` only against Blob Storage via a `DATABASE SCOPED CREDENTIAL` +
+`EXTERNAL DATA SOURCE`. Recipes: the `azuresql-db-seed` skill.
+
 **Are session/database defaults identical to the cloud?** Mostly. Some defaults
 (collation, transaction isolation, ANSI settings) do not match the cloud exactly and
 can cause subtle edge-case differences. Set the ones you depend on explicitly.

--- a/skills/azuresql-db-schema-migration/references/migration-tools.md
+++ b/skills/azuresql-db-schema-migration/references/migration-tools.md
@@ -73,7 +73,7 @@ Notes:
   ```
 - Generate an idempotent script to review before applying:
   `dotnet ef migrations script -i -o migrate.sql`, then apply with
-  `sqlcmd -C -b -d appdb -i migrate.sql`.
+  `sqlcmd -S localhost,1433 -U sa -P "YourStr0ng_Passw0rd" -C -b -d appdb -i migrate.sql`.
 
 ## Prisma (Node)
 

--- a/skills/azuresql-db-seed/SKILL.md
+++ b/skills/azuresql-db-seed/SKILL.md
@@ -50,7 +50,7 @@ docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0n
 ```
 
 If the container is not running yet, start it and provision appdb using the canonical start recipe
-in the **azuresql-db-scaffold** skill, then come back here.
+in the **azuresql-db-container** skill, then come back here.
 
 ## Step 2: insert in foreign-key order (parents before children)
 
@@ -84,7 +84,7 @@ Per-stack seed recipes live in [references/seed-snippets.md](references/seed-sni
 
 - **T-SQL**: multi-table seed in FK order (`dbo.author` -> `dbo.book`) run via
   `docker exec -i sqldb ... -d appdb -i seed.sql`, plus the set-based "generate 1000 rows" example.
-- **Bulk load**: `BULK INSERT` from a CSV and the `bcp` utility for large data files.
+- **Bulk load**: `bcp` for local CSV files, and `BULK INSERT` from Azure Blob Storage (the engine does not read local files: local `BULK INSERT` fails with `Msg 12713`, Azure-parity).
 - **Node**: `@faker-js/faker` generating rows, inserted with the `mssql` driver using parameters.
 - **Python**: `Faker` generating rows, inserted with `pyodbc` (ODBC Driver 18) using parameters.
 
@@ -110,7 +110,7 @@ Per-stack seed recipes live in [references/seed-snippets.md](references/seed-sni
 
 ## References
 
-- [references/seed-snippets.md](references/seed-snippets.md): copy-pasteable seed recipes: multi-table T-SQL in FK order, a set-based generate-1000-rows example, `BULK INSERT` and `bcp` for CSV/large data, and Node (`@faker-js/faker` + `mssql`) and Python (`Faker` + `pyodbc`) parameterized inserts. Read it once you know your data source and stack.
+- [references/seed-snippets.md](references/seed-snippets.md): copy-pasteable seed recipes: multi-table T-SQL in FK order, a set-based generate-1000-rows example, `bcp` for local CSVs and Blob-based `BULK INSERT`, and Node (`@faker-js/faker` + `mssql`) and Python (`Faker` + `pyodbc`) parameterized inserts. Read it once you know your data source and stack.
 
 ## Staying current
 

--- a/skills/azuresql-db-seed/references/seed-snippets.md
+++ b/skills/azuresql-db-seed/references/seed-snippets.md
@@ -22,8 +22,8 @@ parameters for programmatic inserts.
 
 - [T-SQL: multi-table seed in FK order](#t-sql-multi-table-seed-in-fk-order)
 - [T-SQL: generate 1000 rows (set-based tally)](#t-sql-generate-1000-rows-set-based-tally)
-- [Bulk load: BULK INSERT from a CSV](#bulk-load-bulk-insert-from-a-csv)
-- [Bulk load: the bcp utility](#bulk-load-the-bcp-utility)
+- [Bulk load: BULK INSERT reads from Azure Blob Storage, not local files](#bulk-load-bulk-insert-reads-from-azure-blob-storage-not-local-files)
+- [Bulk load: the bcp utility (local files, client-side)](#bulk-load-the-bcp-utility-local-files-client-side)
 - [Node: @faker-js/faker + mssql driver](#node-faker-jsfaker--mssql-driver)
 - [Python: Faker + pyodbc](#python-faker--pyodbc)
 
@@ -131,69 +131,66 @@ SELECT COUNT(*) AS total_books FROM dbo.book;
 The `CROSS JOIN` of a system view against itself guarantees far more than 1000 candidate rows;
 `TOP (1000)` trims to the count you want. Change `1000` to scale.
 
-## Bulk load: BULK INSERT from a CSV
+## Bulk load: BULK INSERT reads from Azure Blob Storage, not local files
 
-`BULK INSERT` reads a file **from inside the container**, so copy the CSV in first. Insert order
-still matters: load parent CSVs before child CSVs.
+`BULK INSERT` and `OPENROWSET(BULK ...)` do **not** read a local path on the container: pointing
+them at a file inside the container fails with **`Msg 12713` "OPENROWSET is not allowed to read
+local files."** This is Azure SQL Database parity: the engine reads bulk data only from **Azure
+Blob Storage**. There is no local-file `BULK INSERT` here.
 
-```bash
-docker cp authors.csv sqldb:/tmp/authors.csv
-```
-
-`authors.csv` (header row, comma-delimited):
-
-```
-full_name,country
-Ada Sample,UK
-Grace Fixture,US
-Alan Seed,UK
-```
+From Blob Storage it works exactly as in the cloud: create a `DATABASE SCOPED CREDENTIAL` (a SAS
+token) and an `EXTERNAL DATA SOURCE`, then reference it with `DATA_SOURCE`:
 
 ```sql
--- Load into the parent table. FIRSTROW = 2 skips the header.
-BULK INSERT dbo.author
-FROM '/tmp/authors.csv'
-WITH (
-    FORMAT = 'CSV',
-    FIRSTROW = 2,
-    FIELDTERMINATOR = ',',
-    ROWTERMINATOR = '0x0a',   -- LF line endings; use '\r\n' for CRLF files
-    TABLOCK
-);
+CREATE DATABASE SCOPED CREDENTIAL BlobCred
+  WITH IDENTITY = 'SHARED ACCESS SIGNATURE', SECRET = 'sv=...';   -- SAS token, no leading '?'
+CREATE EXTERNAL DATA SOURCE SeedBlob
+  WITH (TYPE = BLOB_STORAGE, LOCATION = 'https://<account>.blob.core.windows.net/seed', CREDENTIAL = BlobCred);
+
+-- Stage first (no identity column), then INSERT ... SELECT so author_id auto-generates.
+DROP TABLE IF EXISTS dbo.author_stage;
+CREATE TABLE dbo.author_stage (full_name NVARCHAR(200), country NVARCHAR(100));
+BULK INSERT dbo.author_stage FROM 'authors.csv'
+  WITH (DATA_SOURCE = 'SeedBlob', FORMAT = 'CSV', FIRSTROW = 2, FIELDTERMINATOR = ',', ROWTERMINATOR = '0x0a', TABLOCK);
+INSERT INTO dbo.author (full_name, country) SELECT full_name, country FROM dbo.author_stage;
+DROP TABLE dbo.author_stage;
 ```
 
-Run it against appdb:
+Always stage when the target has an identity/computed column or the CSV column order differs, then
+`INSERT ... SELECT` into the real tables in FK order.
 
-```bash
-docker exec -i sqldb /opt/mssql-tools18/bin/sqlcmd \
-  -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b -d appdb -i /dev/stdin <<'SQL'
-BULK INSERT dbo.author
-FROM '/tmp/authors.csv'
-WITH (FORMAT='CSV', FIRSTROW=2, FIELDTERMINATOR=',', ROWTERMINATOR='0x0a', TABLOCK);
-SELECT COUNT(*) AS loaded FROM dbo.author;
-SQL
-```
+To load a **local** CSV into the container, use `bcp` (below) or the driver seeders further down:
+they stream rows over the connection instead of asking the engine to read a server-side file.
 
-If the CSV column order does not match the table, load into a staging table first, then
-`INSERT ... SELECT` into the real table in FK order.
+## Bulk load: the bcp utility (local files, client-side)
 
-## Bulk load: the bcp utility
-
-`bcp` streams a data file into a table from the command line and is the fastest path for large
-files. It ships in the same tools image, so run it via `docker exec`. Copy the file in first.
+`bcp` streams a data file into a table over the connection (it does not hit the server-side
+local-file restriction above), so it is the tool for loading a **local** CSV. It ships in the
+tools image, so run it via `docker exec`. Copy the file in first, and stage into a table whose
+columns match the CSV so the `IDENTITY` column is not in the mapping:
 
 ```bash
 docker cp authors.csv sqldb:/tmp/authors.csv
+
+# Create a staging table that matches the CSV (no identity column).
+docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b -d appdb \
+  -Q "DROP TABLE IF EXISTS dbo.author_stage; CREATE TABLE dbo.author_stage (full_name NVARCHAR(200), country NVARCHAR(100));"
 
 # -c character mode, -t field terminator, -F 2 first data row (skip header), -d appdb target db,
 # -u trusts the container's self-signed cert (bcp uses ODBC Driver 18, which validates certs by default).
-docker exec sqldb /opt/mssql-tools18/bin/bcp dbo.author in /tmp/authors.csv \
+docker exec sqldb /opt/mssql-tools18/bin/bcp dbo.author_stage in /tmp/authors.csv \
   -S localhost -U sa -P "YourStr0ng_Passw0rd" -d appdb -u \
   -c -t ',' -F 2 -b 10000
+
+# Move staged rows into the real table so author_id auto-generates.
+docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b -d appdb \
+  -Q "INSERT INTO dbo.author (full_name, country) SELECT full_name, country FROM dbo.author_stage; DROP TABLE dbo.author_stage;"
 ```
 
 `-b 10000` commits in batches of 10000 rows so a very large load does not build one giant
-transaction. Load parent files before child files. To export instead, use `bcp dbo.author out ...`.
+transaction. Load parent files before child files. `bcp` must trust the self-signed cert (`-u`);
+if it still cannot connect on the preview image, fall back to the driver seeders below, which use
+the same connection any app does.
 
 ## Node: @faker-js/faker + mssql driver
 

--- a/skills/azuresql-db-sidecar/SKILL.md
+++ b/skills/azuresql-db-sidecar/SKILL.md
@@ -23,7 +23,7 @@ one-shot that creates `appdb`, and a `depends_on` gate.
 ## Load-bearing facts (inlined; full detail in azuresql-db-container)
 
 - This is the **Azure SQL Database engine** (Private Preview), not the SQL
-  Server SQL Server image `mcr.microsoft.com/mssql/server`. `SERVERPROPERTY('EngineEdition')`
+  Server image `mcr.microsoft.com/mssql/server`. `SERVERPROPERTY('EngineEdition')`
   returns `5`, `SERVERPROPERTY('Edition')` returns `'SQL Azure'`. If you were
   about to use the SQL Server image, stop and use this instead.
 - Image: `sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest`


### PR DESCRIPTION
A deep audit of all 17 skills (SKILL.md + every reference file) and the docs, done with parallel readers against a strict rubric (frontmatter, accuracy baseline, reference integrity, sibling-skill references, staying-current/MCP, feedback routing, style, technical correctness, count consistency) plus mechanical global checks. Findings verified before fixing; the seed finding was verified against a live container.

### High
- **`azuresql-db-container/references/paas-parity-checklist.md`** referenced a **nonexistent skill** `azuresql-db-vectors` → `azuresql-db-rag` (the only bogus skill reference in the repo).
- **`docs/index.html`** lead said "ships **16** ready-to-use agent skills" while the page's own CTA said 17 → **17**.

### Medium
- **`azuresql-db-seed`** — the "BULK INSERT from a CSV" recipe loaded a **local file**, which the engine **rejects with `Msg 12713`** ("OPENROWSET is not allowed to read local files"): Azure SQL reads bulk data only from **Azure Blob Storage** (verified live on the container). The recipe also loaded a 2-column CSV straight into a table whose first column is `IDENTITY`, which would fail regardless. Rewrote the section: `BULK INSERT` is now shown **from Blob Storage** (cloud parity), local CSVs go through **`bcp`** (staged into a table so the identity column isn't in the mapping) or the driver seeders. Documented the same behavior in the **FAQ** skill.
- **`docs/llms.txt`** listed Microsoft Entra ID auth as "not yet supported (MSSQL_AAD_* initialize then fail)" — it **works** since the Entra PR merged. Corrected to supported.
- **`docs/getting-started.md`** — a Troubleshooting TOC entry pointed at a **broken anchor** (`#the-container-exits-immediately`); repointed to the real heading.

### Low
- **`azuresql-db-dab`** staying-current link labeled "(SQL MCP Server)" — contradicts the skill's own repeated "this is DAB's built-in endpoint, not a standalone SQL MCP server" framing → "built-in MCP endpoint".
- **`azuresql-db-seed`** routed the container-start recipe to `azuresql-db-scaffold` instead of `azuresql-db-container`.
- **`azuresql-db-schema-migration/references/migration-tools.md`** — a `sqlcmd` example missing `-S/-U/-P` (wouldn't connect); completed.
- **`azuresql-db-sidecar`** — duplicated "SQL Server SQL Server image" wording.
- **`azuresql-db-connections/references/retry-snippets.md`** — the Node sample claimed to parse `SQL_CONNECTION_STRING` but hardcoded values (unused `raw`); now parses it, matching the .NET/Python samples.

### Verified clean (no changes needed)
Frontmatter (all 17 = `name`+`description`, name==folder), all reference links resolve/one-level-deep/no cross-folder paths, no em-dashes, "Staying current" + fully-qualified Learn MCP name in every skill, and 17-count consistency across README ×2, agent-skills (cards/liquid/prose/plugin), llms.txt, marketplace.json, the issue-template dropdown and issue-fields.md.

### Validation
canon-check **21/0**, link-check **47/0**, seed battery **4/0** (adds a live `Msg 12713` regression guard — companion lab PR croblesm/azuresqldb-skills-lab).

### Note (not a doc bug)
While verifying the seed loaders, `bcp` against this preview image failed to connect in my harness (silent exit 1 even with `-u` to trust the self-signed cert), which is worth a separate look — possibly a preview tooling issue. The bcp guidance was made robust (staging + the `-u` cert note + a fallback to the driver seeders), but bcp end-to-end wasn't confirmed on this image.