### PR TITLE
Rebrand skills to "Azure SQL Database container"

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,6 +1,6 @@
-# Azure SQL Developer - Agent skills
+# Azure SQL Database container - Agent skills
 
-These skills teach an AI coding agent to use **Azure SQL Developer** the right way. Azure SQL Developer is the Azure SQL Database engine, running locally in a container. It is for the developer who wants a local database that behaves like Azure SQL Database in the Microsoft Azure cloud, with no Azure subscription, no shared instance, and no credit card required. The container runs the same engine that powers Azure SQL Database in the cloud: the T-SQL dialect, the system views, the connection protocol, the driver behavior, and the AI-native capabilities are the same as in the cloud. The connection string changes; the application does not.
+These skills teach an AI coding agent to use **the Azure SQL Database container** the right way. The Azure SQL Database container is the Azure SQL Database engine, running locally. It is for the developer who wants a local database that behaves like Azure SQL Database in the Microsoft Azure cloud, with no Azure subscription, no shared instance, and no credit card required. The container runs the same engine that powers Azure SQL Database in the cloud: the T-SQL dialect, the system views, the connection protocol, the driver behavior, and the AI-native capabilities are the same as in the cloud. The connection string changes; the application does not.
 
 You can prove the identity from any connection:
 

--- a/skills/azuresql-db-auth/SKILL.md
+++ b/skills/azuresql-db-auth/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: azuresql-db-auth
 description: >-
-  Connects an app to Azure SQL Developer securely, with a least-privilege
+  Connects an app to the Azure SQL Database container securely, with a least-privilege
   database user instead of the sa login, the right auth method per environment,
   and safe handling of the connection secret. Use when a user asks "don't use sa
   in my app", "create a least-privilege database user", "app login for SQL",
@@ -13,7 +13,7 @@ description: >-
   app to connect as sa, or before committing a connection string to source.
 ---
 
-# Azure SQL Developer: connect securely (least-privilege user, auth, secrets)
+# Connect securely to the Azure SQL Database container (least-privilege user, auth, secrets)
 
 `sa` is a bootstrap/admin login for provisioning, not what your application should
 connect as. This skill wires the app to a **least-privilege user**, picks the

--- a/skills/azuresql-db-ci/SKILL.md
+++ b/skills/azuresql-db-ci/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: azuresql-db-ci
 description: >-
-  Runs integration tests against Azure SQL Developer (Private Preview, local
+  Runs integration tests against the Azure SQL Database container (Private Preview, local
   engine) in CI. Use when setting up GitHub Actions, Azure Pipelines, or GitLab
   CI to test against Azure SQL DB; when adding a database service container to a
   CI workflow; when tests need a real Azure SQL engine in the pipeline; or when
@@ -15,7 +15,7 @@ description: >-
   user database not master.
 ---
 
-# Azure SQL Developer in CI
+# The Azure SQL Database container in CI
 
 Run integration tests against the **Azure SQL Database engine** (Private Preview) as a CI
 service container. This is the local Azure SQL engine, not the SQL Server image

--- a/skills/azuresql-db-connections/SKILL.md
+++ b/skills/azuresql-db-connections/SKILL.md
@@ -2,8 +2,8 @@
 name: azuresql-db-connections
 description: >-
   Makes an app's database connections reliable against the local Azure SQL
-  Developer (Private Preview) and, unchanged, against Azure SQL Database in the
-  cloud: connection pooling plus retry/transient-fault handling. Use when the
+  Database container (Private Preview) and, unchanged, against Azure SQL
+  Database in the cloud: connection pooling plus retry/transient-fault handling. Use when the
   user mentions "connection pooling", "retry logic", "transient fault", "retry
   on transient error", "EnableRetryOnFailure", "connection resiliency",
   "reliable connections", "pool size", "Max Pool Size", or says "the connection
@@ -13,7 +13,7 @@ description: >-
   data-access layer that talks to SQL Server or Azure SQL.
 ---
 
-# Azure SQL Developer: reliable connections (pooling + retry)
+# Reliable connections on the Azure SQL Database container (pooling + retry)
 
 Make the app's database connections reliable with **connection pooling** and **retry /
 transient-fault handling**. This is the **Azure SQL engine** (Private Preview), not the SQL

--- a/skills/azuresql-db-connections/references/retry-snippets.md
+++ b/skills/azuresql-db-connections/references/retry-snippets.md
@@ -1,6 +1,6 @@
 # Retry and pooling snippets
 
-Copy-pasteable connection pooling and transient-only retry wired to Azure SQL Developer. Every
+Copy-pasteable connection pooling and transient-only retry wired to the Azure SQL Database container. Every
 snippet assumes the container is running and **appdb is already provisioned on a master
 connection** (see the start recipe in SKILL.md). Apps read `SQL_CONNECTION_STRING`. Image is
 `sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest` (NOT the

--- a/skills/azuresql-db-container/SKILL.md
+++ b/skills/azuresql-db-container/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: azuresql-db-container
 description: >-
-  Runs Azure SQL Developer (the Azure SQL Database engine) locally in a container (Private Preview):
+  Runs the Azure SQL Database container (the Azure SQL Database engine) locally (Private Preview):
   the real PaaS engine where SERVERPROPERTY('EngineEdition') returns 5 and
   Edition is 'SQL Azure'. This is NOT the SQL Server image
   mcr.microsoft.com/mssql/server. Use when a user wants to "run Azure SQL
@@ -15,7 +15,7 @@ description: >-
   task skills for compose, CI, seeding, vectors, and connection strings.
 ---
 
-# Azure SQL Developer (local, Private Preview)
+# The Azure SQL Database container (local, Private Preview)
 
 This is the entry point for running the **Azure SQL Database engine** on your
 machine in a container. It owns the shared reference docs that every task skill

--- a/skills/azuresql-db-container/references/entra-auth.md
+++ b/skills/azuresql-db-container/references/entra-auth.md
@@ -1,6 +1,6 @@
 # Microsoft Entra ID authentication
 
-Microsoft Entra ID authentication works on Azure SQL Developer. Configure it
+Microsoft Entra ID authentication works on the Azure SQL Database container. Configure it
 with the `MSSQL_AAD_*` environment variables and a mounted certificate. SQL
 authentication (`sa`) remains the simple default for local development; use
 Entra when you want closer parity with Azure SQL Database in the cloud.

--- a/skills/azuresql-db-dab/SKILL.md
+++ b/skills/azuresql-db-dab/SKILL.md
@@ -2,7 +2,7 @@
 name: azuresql-db-dab
 description: >-
   Stands up an instant no-code REST + GraphQL API over the local Azure SQL
-  Developer using Microsoft Data API Builder (DAB). Use when a user wants to
+  Database container using Microsoft Data API Builder (DAB). Use when a user wants to
   "expose my table as an API", "add a REST API over the database", "generate a
   GraphQL API", "put an API in front of SQL", "CRUD API without writing code",
   or "dab init / dab-config.json". Also the way to serve a built-in MCP endpoint
@@ -14,9 +14,9 @@ description: >-
   this database".
 ---
 
-# Azure SQL Developer: instant REST + GraphQL API with Data API Builder
+# Instant REST + GraphQL API on the Azure SQL Database container with Data API Builder
 
-Generate a full REST **and** GraphQL API over the local **Azure SQL Developer**
+Generate a full REST **and** GraphQL API over the local **Azure SQL Database container**
 (Private Preview) with no application code, using **Data API Builder (DAB)** -
 Microsoft's first-party open-source engine. You describe tables as entities in
 `dab-config.json`; DAB serves them. DAB connects over the normal TDS protocol

--- a/skills/azuresql-db-faq/SKILL.md
+++ b/skills/azuresql-db-faq/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: azuresql-db-faq
 description: >-
-  Answers questions about what Azure SQL Developer (Private Preview)
+  Answers questions about what the Azure SQL Database container (Private Preview)
   can and cannot do, and WHY it differs from Azure SQL Database in the Microsoft
   Azure cloud. Use when a user asks "can I take a backup", "why does USE fail",
   "is X supported", "why can't I create a vector index", "why does SSMS error",
@@ -12,7 +12,7 @@ description: >-
   and link the user to the live Known limitations page for the current full list.
 ---
 
-# Azure SQL Developer: capabilities, limits, and why
+# The Azure SQL Database container: capabilities, limits, and why
 
 Use this skill to answer "can I / why can't I / is X supported / what's different
 from the cloud" questions accurately, instead of guessing from general SQL Server
@@ -46,7 +46,7 @@ managed cloud service, and it is not the SQL Server. Sort almost any
 - **"Can I take a backup?"** No: `BACKUP DATABASE` and `RESTORE DATABASE` return **Msg 40510 ("not supported in this version")** on the container, in every session. Azure SQL Database in the cloud likewise does not support them, because backups there are managed by the platform (not run with the `BACKUP` statement). For local data persistence, use a Docker named volume (`-v sqldb-data:/var/opt/mssql`); for managed backups, point-in-time restore, or geo-replication, use Azure SQL Database in the cloud.
 - **"Why does `USE otherdb` fail with Msg 40508?"** Because a connection to a user database is an Azure-faithful session that enforces the same restriction as Azure SQL Database in the cloud. Select the database in the connection string (`Database=appdb`), do not switch with `USE`. (`USE` "works" only on a `master` connection, which is a provisioning session.)
 - **"Why does connecting fail until I create the database?"** The engine does **not** auto-create databases on connect. Provision once on a `master` connection (`CREATE DATABASE appdb`), then connect with `Database=appdb`.
-- **"Is a non-x64 host supported? / Is there an ARM64 build?"** The image is x64 only; there is no native ARM64 build. On an ARM64 host it runs under emulation: add `--platform linux/amd64` (Docker) or `platform: linux/amd64` (compose). Say "runs under emulation", never "ARM64 is supported", and do not promise a native build or a date. If the user wants one, point them at https://aka.ms/azuresql-developer-feature-request.
+- **"Is a non-x64 host supported? / Is there an ARM64 build?"** The image is x64 only; there is no native ARM64 build. On an ARM64 host it runs under emulation: add `--platform linux/amd64` (Docker) or `platform: linux/amd64` (compose). Say "runs under emulation", never "ARM64 is supported", and do not promise a native build or a date. If the user wants one, point them at https://aka.ms/azuresqldb-container-feature-request.
 - **"Why can't I `CREATE VECTOR INDEX`?"** That DDL is still in development. The `VECTOR` type and `VECTOR_DISTANCE` work today; use a full-scan top-k query for now (fine for prototype-sized corpora).
 - **"Is Microsoft Entra ID (Azure AD) authentication supported?"** Yes. Configure it with `MSSQL_AAD_CLIENT_ID`, `MSSQL_AAD_PRIMARY_TENANT`, and `MSSQL_AAD_CERTIFICATE_FILE_PATH` plus a mounted `.pfx` (empty export password). Optionally set `MSSQL_AAD_SERVER_ADMIN_NAME`, `MSSQL_AAD_SERVER_ADMIN_TYPE` (`0` = user, `1` = group), and `MSSQL_AAD_SERVER_ADMIN_SID` to bootstrap an Entra server admin at start. SQL auth (`sa`) remains the simple local default. Full recipe: the `azuresql-db-container` skill (`references/entra-auth.md`). Also see [Getting started: Microsoft Entra ID authentication](https://microsoft.github.io/azure-sql-database-container/getting-started.html#microsoft-entra-id-authentication).
 - **"Why does SSMS / the MSSQL extension throw errors?"** Graphical tooling is not yet 100% compatible; it is being fixed. Use `sqlcmd` or a driver, which work today. The MSSQL extension's GitHub Copilot integration also works (https://aka.ms/vscode-mssql-copilot-docs).

--- a/skills/azuresql-db-faq/references/limitations.md
+++ b/skills/azuresql-db-faq/references/limitations.md
@@ -4,14 +4,14 @@ This is a snapshot for offline use. The **live, always-current list is the sourc
 truth**: https://microsoft.github.io/azure-sql-database-container/known-limitations.html
 (repo: `docs/known-limitations.md`). If they disagree, trust the live page and report
 the drift. When a user hits something not listed, point them to
-https://aka.ms/azuresql-developer-bug to file an issue.
+https://aka.ms/azuresqldb-container-bug to file an issue.
 
 ## Active issues being fixed
 
 1. **Restriction enforcement gaps.** Some PaaS restrictions enforced in the cloud are not yet enforced locally, so an invalid statement can succeed locally and fail at deployment. Workaround: validate against a real Azure SQL Database once before declaring readiness.
 2. **Default value alignment.** Some session/database defaults (collation, transaction isolation, ANSI defaults) do not match the cloud exactly. Workaround: set the ones you depend on explicitly.
 3. **Vector index DDL.** `CREATE VECTOR INDEX` is in development. The `VECTOR` type and `VECTOR_DISTANCE` work; use full-scan top-k for now.
-4. **x64 image only; no native ARM64 build.** The image is `linux/amd64`. On an ARM64 host it runs under emulation: add `--platform linux/amd64` (Docker) or `platform: linux/amd64` (compose). Never say ARM64 is "supported", and do not promise a native build or a date. Feature requests: https://aka.ms/azuresql-developer-feature-request
+4. **x64 image only; no native ARM64 build.** The image is `linux/amd64`. On an ARM64 host it runs under emulation: add `--platform linux/amd64` (Docker) or `platform: linux/amd64` (compose). Never say ARM64 is "supported", and do not promise a native build or a date. Feature requests: https://aka.ms/azuresqldb-container-feature-request
 5. **Two-step provisioning.** Provision a database on a `master` connection, then reconnect to it. Public Preview plans a default startup database (e.g. `MSSQL_DB=appdb`).
 6. **GUI tooling compatibility.** The VS Code MSSQL extension UI and SSMS are not yet 100% compatible (UI errors), being fixed. Use `sqlcmd` or a driver; the MSSQL extension's GitHub Copilot integration works (https://aka.ms/vscode-mssql-copilot-docs).
 

--- a/skills/azuresql-db-feedback/SKILL.md
+++ b/skills/azuresql-db-feedback/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: azuresql-db-feedback
 description: >-
-  Reports a bug or files feedback about the azuresql-db-* agent skills themselves, or about Azure SQL Developer (the local Azure SQL Database engine in a container, Private Preview). Use when the user says a skill or the container "did not work", hit an error, behaved unexpectedly, or is missing something; and when they say "report a bug", "file an issue", "open a GitHub issue", "request a feature", "give feedback", or "tell the team". Also use when you, the agent, had to deviate from an azuresql-db-* skill or work around a defect in one to finish a task: that is a bug in the skill and it is worth reporting, even if the task ultimately succeeded. Decides whether the problem belongs to the SKILL or to the CONTAINER, since they use different issue templates, then builds a complete prefilled GitHub issue from context you already have. Never submits anything without explicit confirmation from the user.
+  Reports a bug or files feedback about the azuresql-db-* agent skills themselves, or about the Azure SQL Database container (the local Azure SQL Database engine, Private Preview). Use when the user says a skill or the container "did not work", hit an error, behaved unexpectedly, or is missing something; and when they say "report a bug", "file an issue", "open a GitHub issue", "request a feature", "give feedback", or "tell the team". Also use when you, the agent, had to deviate from an azuresql-db-* skill or work around a defect in one to finish a task: that is a bug in the skill and it is worth reporting, even if the task ultimately succeeded. Decides whether the problem belongs to the SKILL or to the CONTAINER, since they use different issue templates, then builds a complete prefilled GitHub issue from context you already have. Never submits anything without explicit confirmation from the user.
 ---
 
 # Report a problem with the skills, or with the container
@@ -106,7 +106,7 @@ dropdown values, and worked examples for all three templates are in
 - Do not include the SA password, registry credentials, or access tokens in any field. Ever.
 - Do not file a skill problem on the container template, or the reverse. They are triaged by different people.
 - Do not guess a dropdown value. Leave the field out if you are unsure; an omitted dropdown renders unselected, but a wrong one misroutes triage.
-- Do not use an `aka.ms` short link to carry a prefilled report. Those links drop query strings, so every field you filled in is silently lost. Use the full `github.com` URL. (The `aka.ms` links are for humans opening an empty form: [skills feedback](https://aka.ms/sql-agent-skills-feedback), [container bug](https://aka.ms/azuresql-developer-bug), [container feature](https://aka.ms/azuresql-developer-feature-request).)
+- Do not use an `aka.ms` short link to carry a prefilled report. Those links drop query strings, so every field you filled in is silently lost. Use the full `github.com` URL. (The `aka.ms` links are for humans opening an empty form: [skills feedback](https://aka.ms/sql-agent-skills-feedback), [container bug](https://aka.ms/azuresqldb-container-bug), [container feature](https://aka.ms/azuresqldb-container-feature-request).)
 - Do not open an issue for something already on the [Known limitations](https://microsoft.github.io/azure-sql-database-container/known-limitations.html) page, or already in [open issues](https://github.com/microsoft/azure-sql-database-container/issues). Point the user there instead.
 - Do not nag. Offer once, take no for an answer, and move on.
 

--- a/skills/azuresql-db-feedback/references/issue-fields.md
+++ b/skills/azuresql-db-feedback/references/issue-fields.md
@@ -32,8 +32,8 @@ links exist for humans opening an empty form.
 | Template | For | Human short link |
 | --- | --- | --- |
 | `skill_feedback.yml` | a problem with an `azuresql-db-*` **skill** | https://aka.ms/sql-agent-skills-feedback |
-| `bug_report.yml` | a problem with the **container** | https://aka.ms/azuresql-developer-bug |
-| `feature_request.yml` | a missing **container** capability | https://aka.ms/azuresql-developer-feature-request |
+| `bug_report.yml` | a problem with the **container** | https://aka.ms/azuresqldb-container-bug |
+| `feature_request.yml` | a missing **container** capability | https://aka.ms/azuresqldb-container-feature-request |
 
 ## Skill feedback fields (`skill_feedback.yml`)
 

--- a/skills/azuresql-db-from-sql-server/SKILL.md
+++ b/skills/azuresql-db-from-sql-server/SKILL.md
@@ -1,27 +1,27 @@
 ---
 name: azuresql-db-from-sql-server
 description: >-
-  Migrates a local SQL Server setup to Azure SQL Developer for Azure-faithful
+  Migrates a local SQL Server setup to the Azure SQL Database container for Azure-faithful
   local development. Use when a project already uses
   mcr.microsoft.com/mssql/server, mssql/server, an sqlcmd plus SA password
   docker setup, a "SQL Server in docker" or "local mssql container", or a
   docker-compose with the mssql/server image; and use when the user asks for
   "SQL Server locally", "run mssql in Docker", "spin up a local SQL database",
   or "test against SQL Server" but actually wants the Azure SQL Database engine
-  (EngineEdition 5). Detects the SQL Server image, rewrites it to Azure SQL
-  Developer, adds --platform on non-x64 hosts, keeps the SA login, flags SQL
+  (EngineEdition 5). Detects the SQL Server image, rewrites it to the Azure
+  SQL Database container, adds --platform on non-x64 hosts, keeps the SA login, flags SQL
   Server-only features (SQL Agent, FILESTREAM, full Service Broker,
   cross-server distributed transactions, Windows Auth), and re-points
   connection strings from master to a provisioned user database.
 ---
 
-# Migrate from the SQL Server image to Azure SQL Developer
+# Migrate from the SQL Server image to the Azure SQL Database container
 
 This skill converts an existing local SQL Server setup (the SQL Server image
 `mcr.microsoft.com/mssql/server`) into the **Azure SQL Database** container so
 local dev matches Azure SQL Database behavior. The two are not the same engine:
 
-| | SQL Server image | Azure SQL Developer |
+| | SQL Server image | Azure SQL Database container |
 |---|---|---|
 | Image | `mcr.microsoft.com/mssql/server` | `sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest` |
 | `SERVERPROPERTY('EngineEdition')` | 2/3/4/8 | **5** |
@@ -29,7 +29,7 @@ local dev matches Azure SQL Database behavior. The two are not the same engine:
 | DB model | one instance, many DBs, `USE` works | master for provisioning only; user DB for work; a user-database session returns `Msg 40508` on `USE`, exactly as in the cloud; a `master` connection is a provisioning session where the filter is not enforced |
 
 If a project is using the SQL Server image but wants Azure-faithful local dev, **stop
-and switch to Azure SQL Developer.** This skill is self-contained;
+and switch to the container.** This skill is self-contained;
 for full container detail see the **azuresql-db-container** skill.
 
 ## When to use

--- a/skills/azuresql-db-from-sql-server/references/migrate-compose.md
+++ b/skills/azuresql-db-from-sql-server/references/migrate-compose.md
@@ -1,4 +1,4 @@
-# Migrate docker-compose: SQL Server image to Azure SQL Developer
+# Migrate docker-compose: SQL Server image to the Azure SQL Database container
 
 Before/after for a `docker-compose.yml` that used the SQL Server image.
 
@@ -29,7 +29,7 @@ Problems carried over from the SQL Server image:
 - No readiness wait; the engine is not ready when the container starts.
 - No `--platform`; the Azure image is x64 only.
 
-## After (Azure SQL Developer)
+## After (Azure SQL Database container)
 
 ```yaml
 services:
@@ -67,7 +67,7 @@ services:
 
 ## What changed and why
 
-1. **Image** rewritten to Azure SQL Developer. Sign in first:
+1. **Image** rewritten to the container image. Sign in first:
    `docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io`.
 2. **`platform: linux/amd64`** added (commented) for non-x64 hosts; the image is
    x64 only.

--- a/skills/azuresql-db-from-sql-server/references/sql-server-vs-azure-feature-matrix.md
+++ b/skills/azuresql-db-from-sql-server/references/sql-server-vs-azure-feature-matrix.md
@@ -1,4 +1,4 @@
-# SQL Server image vs Azure SQL Developer: feature matrix
+# SQL Server image vs Azure SQL Database container: feature matrix
 
 How a `mcr.microsoft.com/mssql/server` setup maps to the Azure SQL
 Database container. Use this when auditing a project for migration.
@@ -13,7 +13,7 @@ Database container. Use this when auditing a project for migration.
 
 ## Identity and connection
 
-| Aspect | Box image | Azure SQL Developer |
+| Aspect | Box image | Azure SQL Database container |
 |---|---|---|
 | Image | `mcr.microsoft.com/mssql/server` | `sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest` |
 | Registry | public (mcr) | private preview; `docker login sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io` first |
@@ -34,7 +34,7 @@ Database container. Use this when auditing a project for migration.
 
 ## Changes behavior
 
-| Behavior | Box image | Azure SQL Developer | What to do |
+| Behavior | Box image | Azure SQL Database container | What to do |
 |---|---|---|---|
 | Database creation | apps often auto-create or use a pre-created DB | engine does NOT auto-create on connect | `CREATE DATABASE appdb` on a master connection first |
 | Switching DBs | `USE appdb` works | a user-database session returns `Msg 40508` on `USE`, exactly as in the cloud; a `master` connection is a provisioning session where the filter is not enforced, so `USE` appears to work there | select DB in the connection string (`Database=appdb` / `-d appdb`); avoid `USE`; use `master` for provisioning only |

--- a/skills/azuresql-db-functions/SKILL.md
+++ b/skills/azuresql-db-functions/SKILL.md
@@ -2,7 +2,7 @@
 name: azuresql-db-functions
 description: >-
   Builds a serverless API and event-driven handlers over the local Azure SQL
-  Developer using Azure Functions with the Azure SQL bindings. Use when a user
+  Database container using Azure Functions with the Azure SQL bindings. Use when a user
   wants "a serverless API over SQL", "Azure Functions with a database", "HTTP
   CRUD with SQL input/output bindings", "run code when a row changes", "react to
   inserts/updates/deletes", "event-driven on Azure SQL", or "SQL trigger
@@ -14,10 +14,10 @@ description: >-
   change-driven logic on the local Azure SQL engine.
 ---
 
-# Azure SQL Developer: serverless API + event-driven with Azure Functions
+# Serverless API + event-driven on the Azure SQL Database container with Azure Functions
 
 Build HTTP CRUD endpoints and change-driven handlers over the local **Azure SQL
-Developer** (Private Preview) using **Azure Functions** and the first-party
+Database container** (Private Preview) using **Azure Functions** and the first-party
 **Azure SQL bindings**. Two capabilities:
 
 - **API:** HTTP-triggered functions with SQL **input** and **output** bindings

--- a/skills/azuresql-db-import/SKILL.md
+++ b/skills/azuresql-db-import/SKILL.md
@@ -2,7 +2,7 @@
 name: azuresql-db-import
 description: >-
   Imports an existing Azure SQL Database or SQL Server schema and data INTO the
-  local Azure SQL Developer using SqlPackage. Use when asked to "import a
+  local Azure SQL Database container using SqlPackage. Use when asked to "import a
   bacpac", "load my existing database locally", "restore a dacpac into the
   container", "bring my prod schema into the dev container", "run my
   .bacpac/.dacpac against the local Azure SQL engine", or migrate an existing
@@ -12,9 +12,9 @@ description: >-
   the container" request instead of hand-writing SqlPackage flags.
 ---
 
-# Azure SQL Developer: import a database
+# The Azure SQL Database container: import a database
 
-Bring an existing database INTO the local Azure SQL Developer from a
+Bring an existing database INTO the local container from a
 `.bacpac` (schema + data) or `.dacpac` (schema only) using SqlPackage.
 
 ## What this is (load-bearing facts)

--- a/skills/azuresql-db-local-to-cloud/SKILL.md
+++ b/skills/azuresql-db-local-to-cloud/SKILL.md
@@ -14,9 +14,9 @@ description: >-
   does not change, only the connection string does.
 ---
 
-# Azure SQL Developer to Azure SQL Database: same code, local to cloud
+# From the Azure SQL Database container to Azure SQL Database: same code, local to cloud
 
-Build and test against the local Azure SQL Developer, then deploy the
+Build and test against the local container, then deploy the
 **same application code** to Azure SQL Database in the cloud. Only the
 connection string changes. Nothing else.
 

--- a/skills/azuresql-db-local-to-cloud/references/auth-local-vs-cloud.md
+++ b/skills/azuresql-db-local-to-cloud/references/auth-local-vs-cloud.md
@@ -1,6 +1,6 @@
 # Auth: local SA vs cloud Microsoft Entra
 
-How authentication differs between the local Azure SQL Developer and
+How authentication differs between the local Azure SQL Database container and
 Azure SQL Database in the cloud, why the application code stays the same, plus a
 third stack (Python) and a deployment checklist.
 

--- a/skills/azuresql-db-rag/SKILL.md
+++ b/skills/azuresql-db-rag/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: azuresql-db-rag
 description: >-
-  Builds local vector search, RAG, embeddings, and semantic search on Azure SQL
-  Developer using the native VECTOR type and VECTOR_DISTANCE. Use
+  Builds local vector search, RAG, embeddings, and semantic search on the Azure
+  SQL Database container using the native VECTOR type and VECTOR_DISTANCE. Use
   when you need to store embeddings, do similarity search, top-k nearest
   neighbor, cosine distance, retrieval-augmented generation, "find similar
   documents", chatbot memory, or semantic lookup against a local SQL database.
@@ -14,7 +14,7 @@ description: >-
   master first so every script runs on a fresh container.
 ---
 
-# Azure SQL Developer: local vector search and RAG
+# Local vector search and RAG on the Azure SQL Database container
 
 Store embeddings and run similarity search directly in the Azure SQL Database
 engine using the native `VECTOR(n)` type and `VECTOR_DISTANCE`. No separate

--- a/skills/azuresql-db-rag/references/vector-schema.md
+++ b/skills/azuresql-db-rag/references/vector-schema.md
@@ -1,7 +1,7 @@
 # Vector schema reference
 
 Schema patterns, dimension choices, insert/query mechanics, and metadata
-filtering for vector search on Azure SQL Developer.
+filtering for vector search on the Azure SQL Database container.
 
 ## Contents
 

--- a/skills/azuresql-db-scaffold/SKILL.md
+++ b/skills/azuresql-db-scaffold/SKILL.md
@@ -2,7 +2,7 @@
 name: azuresql-db-scaffold
 description: >-
   Scaffolds a NEW app (.NET Aspire, FastAPI, Next.js, NestJS) wired to the local
-  Azure SQL Developer as its default dev database. Use when
+  Azure SQL Database container as its default dev database. Use when
   starting/bootstrapping/initializing a project that needs SQL Server or Azure
   SQL locally, or when adding "set up the database", "docker compose for the db",
   "create the local DB", ".env connection string", "first migration", or a
@@ -13,9 +13,9 @@ description: >-
   even when the user only says "add a database" to a fresh project.
 ---
 
-# Azure SQL Developer: scaffold a new project
+# Scaffold a new project on the Azure SQL Database container
 
-Bootstrap a new app with the **Azure SQL Developer** (Private Preview) as the default
+Bootstrap a new app with the **Azure SQL Database container** (Private Preview) as the default
 local database. This is the **Azure SQL engine**, not the SQL Server image.
 
 ## Use the right image (interception point)

--- a/skills/azuresql-db-scaffold/references/scaffold-snippets.md
+++ b/skills/azuresql-db-scaffold/references/scaffold-snippets.md
@@ -1,6 +1,6 @@
 # Scaffold snippets
 
-Per-stack skeletons wired to Azure SQL Developer. Every snippet assumes the
+Per-stack skeletons wired to the Azure SQL Database container. Every snippet assumes the
 container is running and **appdb is already provisioned on a master connection** (see the
 canonical start recipe in SKILL.md). Apps read `SQL_CONNECTION_STRING`; ORMs that need a URL
 also read `DATABASE_URL`. Image is

--- a/skills/azuresql-db-schema-migration/SKILL.md
+++ b/skills/azuresql-db-schema-migration/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: azuresql-db-schema-migration
 description: >-
-  Runs database schema migrations against the local Azure SQL Developer so the
+  Runs database schema migrations against the local Azure SQL Database container so the
   same migrations apply identically on the local engine and in the Azure cloud.
   Use when asked to "run my migrations against the local SQL", "apply schema to
   the container", "apply EF Core / dotnet ef database update", "Prisma migrate
@@ -13,7 +13,7 @@ description: >-
   container.
 ---
 
-# Azure SQL Developer: schema migrations
+# Schema migrations on the Azure SQL Database container
 
 Apply schema migrations to the local **Azure SQL Database** container the same way
 you would against the cloud, so dev and prod stay identical. This is the Azure SQL

--- a/skills/azuresql-db-seed/SKILL.md
+++ b/skills/azuresql-db-seed/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: azuresql-db-seed
 description: >-
-  Populates the local Azure SQL Developer database (appdb) with realistic
+  Populates the local Azure SQL Database container's database (appdb) with realistic
   sample/test data so a developer has something to build against. Use when the
   user says "seed the database", "add test data", "populate the dev database",
   "generate sample data", "fake data", "load fixtures", "insert test rows",
@@ -12,7 +12,7 @@ description: >-
   existing appdb needs volume, fixtures, or believable rows.
 ---
 
-# Azure SQL Developer: seed the dev database
+# Seed the dev database on the Azure SQL Database container
 
 Fill an existing **appdb** with realistic sample data so the app has something to render, query,
 and test against. This is the **Azure SQL engine** (Private Preview), not the SQL Server image.

--- a/skills/azuresql-db-sidecar/SKILL.md
+++ b/skills/azuresql-db-sidecar/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: azuresql-db-sidecar
 description: >-
-  Adds Azure SQL Developer as a sidecar service in an existing Docker Compose
+  Adds the Azure SQL Database container as a sidecar service in an existing Docker Compose
   stack or Dev Container. Use when wiring the local Azure SQL Database engine
   into compose or devcontainer.json, when an app needs a SQL backend via a
   service name (not localhost), or for prompts like "add SQL to my compose",
@@ -13,9 +13,9 @@ description: >-
   this for any compose or Dev Container SQL wiring.
 ---
 
-# Azure SQL Developer as a sidecar (Compose / Dev Container)
+# The Azure SQL Database container as a sidecar (Compose / Dev Container)
 
-Wire Azure SQL Developer into an existing Docker Compose stack or
+Wire the container into an existing Docker Compose stack or
 Dev Container as a service the app reaches by **service name** (`sqldb,1433`),
 never `localhost`. Keep existing services intact; add the database, an init
 one-shot that creates `appdb`, and a `depends_on` gate.

--- a/skills/azuresql-db-testing/SKILL.md
+++ b/skills/azuresql-db-testing/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: azuresql-db-testing
 description: >-
-  Writes integration tests that run IN CODE against a real Azure SQL Developer
-  engine, spun up per test or per suite with Testcontainers and torn down after.
+  Writes integration tests that run IN CODE against a real Azure SQL Database
+  container, spun up per test or per suite with Testcontainers and torn down after.
   Use when the user asks for "integration tests against SQL", "Testcontainers",
   "spin up a database for tests", "an ephemeral test database", "a test database
   per test", "xUnit/Jest/pytest with a real database", or "a database fixture".
@@ -12,10 +12,10 @@ description: >-
   azuresql-db-ci.
 ---
 
-# Azure SQL Developer: integration tests with Testcontainers
+# Integration tests on the Azure SQL Database container with Testcontainers
 
-Write integration tests that start a **real Azure SQL Developer** (Private Preview)
-engine from code, provision `appdb`, run the test against it, and tear the container
+Write integration tests that start a **real Azure SQL Database container** (Private Preview)
+from code, provision `appdb`, run the test against it, and tear the container
 down. This is the **Azure SQL engine**, not the SQL Server image.
 
 This skill is about tests that manage their own engine lifecycle in-process

--- a/skills/azuresql-db-testing/references/testcontainers-snippets.md
+++ b/skills/azuresql-db-testing/references/testcontainers-snippets.md
@@ -1,7 +1,7 @@
 # Testcontainers snippets
 
-Per-language recipes that start a **real Azure SQL Developer** engine from a generic
-container, wait until it answers, provision `appdb`, hand the connection string to the
+Per-language recipes that start a **real Azure SQL Database container** via the generic
+Testcontainers API, wait until it answers, provision `appdb`, hand the connection string to the
 test, and dispose after. Image is
 `sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest` (NOT the Testcontainers
 `MsSql` preset / `mcr.microsoft.com/mssql/server` SQL Server image). Every recipe assumes


### PR DESCRIPTION
Completes the brand revert on the **skills side**, the effort #144 deferred. Follows `brand-revert-skills-handoff.md` and matches #144's wording.

## Scope
All **17 skills** + `skills/README.md` + **11 reference files** (28 files, 68 lines changed, `.md` only).

Rules applied verbatim: full name on **first mention**, then **"the container"**; definite article reintroduced; the now-redundant "in a container" dropped from descriptors; the SQL Server comparison matrix **keeps the full name** for contrast; persona labels ("developer", "Developer workflows") left alone. H1s reworded to read naturally (e.g. `# Schema migrations on the Azure SQL Database container`) rather than long-name-plus-colon.

**aka.ms revert** in the faq + feedback skills: `azuresql-developer-{bug,feature-request}` → `azuresqldb-container-*`. Brand-neutral `sql-agent-skills-feedback` and `sqldbcontainerpreview-signup` unchanged.

**Frontmatter `description`s** (which drive triggering) were reworded **brand-only** — every quoted trigger phrase and cue term preserved verbatim.

## Identifiers untouched
Skill directory names and the `azuresql-db-*` prefix, the image tag, the repo slug, `what-is-the-container.html`, the support email, sample credentials, connection facts.

## Verification
- `grep -rn "Azure SQL Developer\|aka.ms/azuresql-developer" skills/` → **0**
- No double-article / `container in a container` / `the the` artifacts → **0**
- Em-dashes → **0**
- Image-tag occurrences **byte-identical to main** (67/67); only `.md` files changed
- Frontmatter still exactly `name` + `description`; every SKILL.md < 500 lines
- **canon-check 24/0**, **link-check 47/0** (reverted aka.ms slugs resolve)
- Whole-repo sweep with **no include filters** (per the #144 audit lesson): **zero residuals repo-wide**

## ⚠️ Triggering eval: only partially verified
The handoff calls this the main risk, so flagging clearly: the run **could not complete** — **34 of 49 prompts failed with HTTP 429 "You've hit your monthly spend limit"**, not with a routing error. Of the **15 prompts that actually executed, 15/15 routed to the correct skill, 0 false positives**. Encouraging, but it is **not** the full 100/100/0 re-confirmation. **Recommend re-running the full triggering eval once the spend limit resets, before merge.**

Companion lab PR: croblesm/azuresqldb-skills-lab (generative-eval prompts, regenerated eval report, security baseline).