### PR TITLE
eval: rebrand and extend trigger coverage to all 17 skills

### DIFF
--- a/eval/README.md
+++ b/eval/README.md
@@ -12,7 +12,7 @@ The suite is designed to run by hand with no additional tooling: a person runs t
 - **Condition A (baseline)**: a fresh agent session with none of these skills installed.
 - **Condition B (skilled)**: an identical session with all skills from this repository correctly installed.
 - **Trial**: one execution of one prompt in one condition. Agents are non-deterministic, so each prompt is run 3 times per condition.
-- **Assertion**: a single yes/no check applied to a transcript (for example: "the plan uses the Azure SQL Developer image, not mcr.microsoft.com/mssql/server"). A run's score is the percentage of assertions passed.
+- **Assertion**: a single yes/no check applied to a transcript (for example: "the plan uses the Azure SQL Database container image, not mcr.microsoft.com/mssql/server"). A run's score is the percentage of assertions passed.
 - **Lift**: the Condition B average score minus the Condition A average score, per scenario. Lift is the headline measure of whether the skills changed behavior.
 
 ## Before you run anything: verify the skills are actually loaded

--- a/eval/outcome-assertions.md
+++ b/eval/outcome-assertions.md
@@ -8,7 +8,7 @@ The scenario prompts below can be run as written, or replaced with the correspon
 
 ## Scenario 1: provision a local database (prompt: T1 or T3 from trigger-evals.md)
 
-- [ ] Plan uses the Azure SQL Developer image from the preview registry, not mcr.microsoft.com/mssql/server
+- [ ] Plan uses the Azure SQL Database container image from the preview registry, not mcr.microsoft.com/mssql/server
 - [ ] ACCEPT_EULA=Y is set
 - [ ] MSSQL_SA_PASSWORD meets the documented complexity requirement, and the plan does not reuse a published literal password verbatim
 - [ ] Plan includes a readiness wait (retry loop) rather than querying immediately after docker run

--- a/eval/trigger-evals.md
+++ b/eval/trigger-evals.md
@@ -18,6 +18,16 @@ Prompts T1 to T3 are deliberately ambiguous between related skills; they exist t
 | T8 | will this code work unchanged in Azure? | azuresql-db-local-to-cloud | none |
 | T9 | store embeddings and do similarity search locally in SQL | azuresql-db-rag | none |
 | T10 | I'm using mcr.microsoft.com/mssql/server in my docker-compose | azuresql-db-from-sql-server | none |
+| T11 | give me a REST and GraphQL API over these tables without writing code | azuresql-db-dab | none |
+| T12 | build a serverless HTTP API over my SQL tables with Azure Functions | azuresql-db-functions | none |
+| T13 | fill my local database with realistic sample data across related tables | azuresql-db-seed | none |
+| T14 | run my integration tests against a real database that starts and stops per test | azuresql-db-testing | azuresql-db-ci |
+| T15 | my app keeps dropping the SQL connection under load, add retry and pooling | azuresql-db-connections | none |
+| T16 | my app connects as sa, set up a least-privilege database user instead | azuresql-db-auth | none |
+| T17 | the skill told my agent the wrong thing, how do I report it | azuresql-db-feedback | none |
+
+T14 is deliberately ambiguous between per-test containers (`azuresql-db-testing`) and pipeline
+setup (`azuresql-db-ci`); record which loads, as with T1 to T3.
 
 Recording format per trial:
 


### PR DESCRIPTION
Follow-up to **#114** (thanks @Iqra617), which was authored before the brand revert and before the collection grew past 10 skills. Merging it as written, then fixing both here.

## 1. Brand
`the Azure SQL Developer image` → `the Azure SQL Database container image` in the assertion example (`eval/README.md`) and the plan-outcome checklist (`eval/outcome-assertions.md`), matching #144/#146.

## 2. Trigger coverage: 10 → 17 skills
`eval/trigger-evals.md` covered T1-T10 (the original ten). Adds **T11-T17** for the skills added since:

| # | Prompt | Expected |
|---|---|---|
| T11 | give me a REST and GraphQL API over these tables without writing code | `azuresql-db-dab` |
| T12 | build a serverless HTTP API over my SQL tables with Azure Functions | `azuresql-db-functions` |
| T13 | fill my local database with realistic sample data across related tables | `azuresql-db-seed` |
| T14 | run my integration tests against a real database that starts and stops per test | `azuresql-db-testing` (alt: `azuresql-db-ci`) |
| T15 | my app keeps dropping the SQL connection under load, add retry and pooling | `azuresql-db-connections` |
| T16 | my app connects as sa, set up a least-privilege database user instead | `azuresql-db-auth` |
| T17 | the skill told my agent the wrong thing, how do I report it | `azuresql-db-feedback` |

T14 is deliberately ambiguous between per-test containers and pipeline setup, documented as such following the existing T1-T3 convention. Prompts are phrased as a user would ask, not by naming the skill.

## Verification
- **0 brand residuals repo-wide** (grep with **no include filters**)
- Every skill on disk has ≥1 trigger row; **no reference to a skill that does not exist**
- No em-dashes; canon-check **24/0**; link-check **47/0**