### PR TITLE
CREATE VECTOR INDEX works; seven skills said it did not

### DIFF
--- a/eval/outcome-assertions.md
+++ b/eval/outcome-assertions.md
@@ -37,7 +37,7 @@ The scenario prompts below can be run as written, or replaced with the correspon
 
 - [ ] Uses the native VECTOR(n) type and VECTOR_DISTANCE, not an external vector store (pgvector, FAISS, Chroma, Pinecone) when the data lives in SQL
 - [ ] Insert pattern uses the documented double CAST (CAST(CAST(? AS NVARCHAR(MAX)) AS VECTOR(n))) with a literal dimension
-- [ ] Does not rely on CREATE VECTOR INDEX; uses full-scan top-k as documented while the index is in development
+- [ ] Treats CREATE VECTOR INDEX as working: does not repeat the "still in development" claim, and if it creates one, sets QUOTED_IDENTIFIER ON and loads at least 100 rows with non-null vectors first
 
 ## Scenario 5: migrate off the SQL Server image (prompt: T10)
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -24,7 +24,7 @@ EngineEdition `5` and Edition `'SQL Azure'` are the cloud engine's fingerprint. 
 | **azuresql-db-local-to-cloud** | Take a database that works against the local engine and move it to Azure SQL Database in the cloud. Because it is the same engine, parity is the default, not a porting exercise. |
 | **azuresql-db-schema-migration** | Apply and version schema changes against the engine: idempotent DDL, ordered migration scripts, run against `appdb` (never `master`). |
 | **azuresql-db-import** | Load data into `appdb` after provisioning: bulk and script-based import. Does **not** rely on auto-run init directories (that convention is not honored here). |
-| **azuresql-db-rag** | Build retrieval-augmented generation on the engine's native `VECTOR(n)` type and `VECTOR_DISTANCE('cosine', a, b)`, using full-scan top-k while DiskANN vector indexing is still in development. |
+| **azuresql-db-rag** | Build retrieval-augmented generation on the engine's native `VECTOR(n)` type and `VECTOR_DISTANCE('cosine', a, b)`, using full-scan top-k for a small corpus and a DiskANN vector index once a full scan starts to hurt. |
 | **azuresql-db-ci** | Run the engine in continuous integration: ephemeral container, ready-wait, provision, seed, test, tear down. Fails closed on the wrong image. |
 | **azuresql-db-sidecar** | Run the engine as a sidecar alongside an app (compose-style), with `platform: linux/amd64` on non-x64 hosts and a single `SQL_CONNECTION_STRING` contract. |
 | **azuresql-db-scaffold** | Scaffold a new app wired to the engine: connection string via one `SQL_CONNECTION_STRING` env var, provisioning step, and seed step in the correct order. |
@@ -281,7 +281,7 @@ Use `User Id=` / `Password=` / `Database=` (not `Uid=` / `Pwd=`). For `sqlcmd`, 
 
 ### Vectors
 
-Native `VECTOR(n)` column type and `VECTOR_DISTANCE('cosine', a, b)`. Insert with `CAST(CAST(? AS NVARCHAR(MAX)) AS VECTOR(n))` where **n is a literal, never a bind parameter** (a parameter dimension fails with "Incorrect syntax near '@P3'"). The inner `CAST(? AS NVARCHAR(MAX))` is required because a real embedding's JSON string (~16 KB for 768 dims) exceeds the driver's 4000-char threshold and is otherwise sent as ntext, which the engine rejects ("Explicit conversion from data type ntext to vector is not allowed (529)"). `CREATE VECTOR INDEX` (DiskANN) is still in development; use full-scan top-k for now.
+Native `VECTOR(n)` column type and `VECTOR_DISTANCE('cosine', a, b)`. Insert with `CAST(CAST(? AS NVARCHAR(MAX)) AS VECTOR(n))` where **n is a literal, never a bind parameter** (a parameter dimension fails with "Incorrect syntax near '@P3'"). The inner `CAST(? AS NVARCHAR(MAX))` is required because a real embedding's JSON string (~16 KB for 768 dims) exceeds the driver's 4000-char threshold and is otherwise sent as ntext, which the engine rejects ("Explicit conversion from data type ntext to vector is not allowed (529)"). `CREATE VECTOR INDEX` (DiskANN) **works on this image**, measured, and the Known limitations page has not caught up. It needs `SET QUOTED_IDENTIFIER ON` and at least 100 rows with non-null vectors (`Msg 42266` below that). Full-scan top-k stays exact and stays the right choice for a small table. The `azuresql-db-rag` skill carries the rules the index imposes.
 
 ### Canonical start recipe
 

--- a/skills/azuresql-db-container/references/paas-parity-checklist.md
+++ b/skills/azuresql-db-container/references/paas-parity-checklist.md
@@ -23,7 +23,7 @@ before declaring readiness.
   target database in the connection string (`Database=appdb`, or `-d appdb` for
   sqlcmd). See `connection-model.md`.
 
-## Vectors: present, with one caveat
+## Vectors: present, and the index works
 
 - `VECTOR(n)` column type and `VECTOR_DISTANCE('cosine', a, b)` are available.
 - Insert with `CAST(CAST(? AS NVARCHAR(MAX)) AS VECTOR(n))` where **n is a
@@ -31,8 +31,14 @@ before declaring readiness.
   with "Incorrect syntax near '@P3'". The inner `CAST(? AS NVARCHAR(MAX))` keeps
   a real embedding's JSON (which exceeds the driver's 4000-char threshold) from
   being sent as ntext, which the engine rejects (error 529).
-- `CREATE VECTOR INDEX` (DiskANN) is still in development. For now, use a
-  full-scan top-k query with `VECTOR_DISTANCE` instead of an index.
+- `CREATE VECTOR INDEX` (DiskANN) **works on this image**, measured, and the
+  Known limitations page has not caught up. It needs `SET QUOTED_IDENTIFIER ON`
+  in the session running the DDL (`Msg 1934` without it, and that message never
+  names the setting) and at least 100 rows with non-null vectors (`Msg 42266`
+  below that). Once it exists, `TRUNCATE TABLE` on that table is refused
+  (`Msg 42232`).
+- Full-scan top-k with `ORDER BY VECTOR_DISTANCE(...)` stays exact and stays the
+  right choice for a small table. Reach for the index once a full scan hurts.
 
 See the `azuresql-db-rag` task skill for full patterns.
 
@@ -64,8 +70,11 @@ source of truth:
 2. For any feature you depend on (Agent-like scheduling, broker, distributed
    transactions, auth mode), confirm it exists in Azure SQL Database before
    building on it. If it is in the "not present" list above, design around it.
-3. For features still in development (vector index DDL), use the documented
-   interim approach and re-check before declaring production readiness.
+3. For features still in development (GUI tooling, full PaaS restriction
+   enforcement), use the documented interim approach and re-check before
+   declaring production readiness. Where a published limitation and the engine
+   disagree, as they do for vector index DDL, say so and give the measured
+   behavior rather than picking one silently.
 
 ## Do not
 
@@ -74,4 +83,8 @@ source of truth:
 - Do not declare readiness without validating the feature against Azure SQL
   Database in the cloud.
 - Do not pass the `VECTOR` dimension as a bind parameter.
-- Do not depend on `CREATE VECTOR INDEX` yet; use full-scan top-k.
+- Do not run `CREATE VECTOR INDEX` without `SET QUOTED_IDENTIFIER ON`, and do not
+  build it on fewer than 100 rows with non-null vectors.
+- Do not put a security policy and a vector index on the same table here; the
+  container refuses both orders (`Msg 37579` and `Msg 42244`) while Azure SQL
+  Database in the cloud allows them. This is a parity gap.

--- a/skills/azuresql-db-faq/SKILL.md
+++ b/skills/azuresql-db-faq/SKILL.md
@@ -36,9 +36,10 @@ managed cloud service, and it is not the SQL Server. Sort almost any
    SQL Database either): SQL Agent jobs, FILESTREAM / FileTable, full cross-instance
    Service Broker, linked servers, cross-server distributed transactions, Windows
    Authentication / NTLM.
-4. **In-progress in this preview -> works with a caveat:** `CREATE VECTOR INDEX`
-   DDL, the VS Code MSSQL extension UI and SSMS, and full PaaS restriction
-   enforcement are still being completed.
+4. **In-progress in this preview -> works with a caveat:** the VS Code MSSQL
+   extension UI and SSMS, and full PaaS restriction enforcement, are still being
+   completed. `CREATE VECTOR INDEX` used to belong here and no longer does: it
+   works, and the Known limitations page has not caught up. See below.
 
 ## Most-asked questions (quick answers)
 
@@ -47,7 +48,7 @@ managed cloud service, and it is not the SQL Server. Sort almost any
 - **"Why does `USE otherdb` fail with Msg 40508?"** Because a connection to a user database is an Azure-faithful session that enforces the same restriction as Azure SQL Database in the cloud. Select the database in the connection string (`Database=appdb`), do not switch with `USE`. (`USE` "works" only on a `master` connection, which is a provisioning session.)
 - **"Why does connecting fail until I create the database?"** The engine does **not** auto-create databases on connect. Provision once on a `master` connection (`CREATE DATABASE appdb`), then connect with `Database=appdb`.
 - **"Is a non-x64 host supported? / Is there an ARM64 build?"** The image is x64 only; there is no native ARM64 build. On an ARM64 host it runs under emulation: add `--platform linux/amd64` (Docker) or `platform: linux/amd64` (compose). Say "runs under emulation", never "ARM64 is supported", and do not promise a native build or a date. If the user wants one, point them at https://aka.ms/azuresqldb-container-feature-request.
-- **"Why can't I `CREATE VECTOR INDEX`?"** That DDL is still in development. The `VECTOR` type and `VECTOR_DISTANCE` work today; use a full-scan top-k query for now (fine for prototype-sized corpora).
+- **"Why can't I `CREATE VECTOR INDEX`?"** You probably can, and this is a place where the documentation and the engine disagree. The Known limitations page still lists vector index DDL as an active issue; measured on this image, the DiskANN index builds and `VECTOR_SEARCH` returns ranked results against it. Two things stop the statement: `SET QUOTED_IDENTIFIER ON` is required and is off by default in `sqlcmd` (without it, **Msg 1934**, whose text never names the setting), and the table needs at least **100 rows with non-null vectors** (below that, **Msg 42266**). Once the index exists, `TRUNCATE TABLE` on that table is refused (**Msg 42232**) and `DROP VECTOR INDEX` is not a statement (use `DROP INDEX name ON dbo.table`). Full-scan top-k stays exact and stays the right choice for a small table. Full detail: the `azuresql-db-rag` skill.
 - **"Is Microsoft Entra ID (Azure AD) authentication supported?"** Yes. Configure it with `MSSQL_AAD_CLIENT_ID`, `MSSQL_AAD_PRIMARY_TENANT`, and `MSSQL_AAD_CERTIFICATE_FILE_PATH` plus a mounted `.pfx` (empty export password). Optionally set `MSSQL_AAD_SERVER_ADMIN_NAME`, `MSSQL_AAD_SERVER_ADMIN_TYPE` (`0` = user, `1` = group), and `MSSQL_AAD_SERVER_ADMIN_SID` to bootstrap an Entra server admin at start. SQL auth (`sa`) remains the simple local default. Full recipe: the `azuresql-db-container` skill (`references/entra-auth.md`). Also see [Getting started: Microsoft Entra ID authentication](https://microsoft.github.io/azure-sql-database-container/getting-started.html#microsoft-entra-id-authentication).
 - **"Why does SSMS / the MSSQL extension throw errors?"** Graphical tooling is not yet 100% compatible; it is being fixed. Use `sqlcmd` or a driver, which work today. The MSSQL extension's GitHub Copilot integration also works (https://aka.ms/vscode-mssql-copilot-docs).
 - **"Why isn't the image on Docker Hub / MCR?"** This is a container-only Private Preview; the image is in a private registry with shared pull-only credentials provided when you sign up for the Private Preview at https://aka.ms/sqldbcontainerpreview-signup (they may rotate).

--- a/skills/azuresql-db-faq/references/faq.md
+++ b/skills/azuresql-db-faq/references/faq.md
@@ -61,9 +61,22 @@ current limitation. Public Preview plans a default startup database (for example
 
 ## Vectors / AI
 
-**Why can't I `CREATE VECTOR INDEX`?** The vector index DDL is still in development.
-The `VECTOR(n)` type and `VECTOR_DISTANCE('cosine', ...)` work today; run a full-scan
-top-k query for now, which is fine for prototype-sized corpora.
+**Why can't I `CREATE VECTOR INDEX`?** You probably can. The Known limitations page
+still lists vector index DDL as an active issue, and the engine disagrees: measured on
+this image, the DiskANN index builds and `VECTOR_SEARCH` returns ranked results against
+it. Say so, and give the reader the two things that actually stop the statement:
+
+1. `SET QUOTED_IDENTIFIER ON` is required and is off by default in a `sqlcmd` session.
+   Without it the statement fails with `Msg 1934`, whose text lists indexed views,
+   computed columns, filtered indexes, query notifications, XML methods and spatial
+   indexes, and never names the session setting that caused it.
+2. The table needs at least **100 rows with non-null vectors**. Below that it is
+   `Msg 42266`, which does name the rule and the actual count.
+
+Once the index exists, `TRUNCATE TABLE` on that table is refused (`Msg 42232`), and
+`DROP VECTOR INDEX` is not a statement (use `DROP INDEX name ON dbo.table`). Full-scan
+top-k with `ORDER BY VECTOR_DISTANCE(...)` stays exact and stays the right choice for a
+small table. The `azuresql-db-rag` skill has the full list.
 
 **Why does my embedding insert fail with "ntext to vector is not allowed (529)"?**
 A long JSON embedding bound as a parameter is sent as ntext. Cast it to NVARCHAR(MAX)

--- a/skills/azuresql-db-faq/references/limitations.md
+++ b/skills/azuresql-db-faq/references/limitations.md
@@ -10,13 +10,13 @@ https://aka.ms/azuresqldb-container-bug to file an issue.
 
 1. **Restriction enforcement gaps.** Some PaaS restrictions enforced in the cloud are not yet enforced locally, so an invalid statement can succeed locally and fail at deployment. Workaround: validate against a real Azure SQL Database once before declaring readiness.
 2. **Default value alignment.** Some session/database defaults (collation, transaction isolation, ANSI defaults) do not match the cloud exactly. Workaround: set the ones you depend on explicitly.
-3. **Vector index DDL.** `CREATE VECTOR INDEX` is in development. The `VECTOR` type and `VECTOR_DISTANCE` work; use full-scan top-k for now.
-4. **x64 image only; no native ARM64 build.** The image is `linux/amd64`. On an ARM64 host it runs under emulation: add `--platform linux/amd64` (Docker) or `platform: linux/amd64` (compose). Never say ARM64 is "supported", and do not promise a native build or a date. Feature requests: https://aka.ms/azuresqldb-container-feature-request
-5. **Two-step provisioning.** Provision a database on a `master` connection, then reconnect to it. Public Preview plans a default startup database (e.g. `MSSQL_DB=appdb`).
-6. **GUI tooling compatibility.** The VS Code MSSQL extension UI and SSMS are not yet 100% compatible (UI errors), being fixed. Use `sqlcmd` or a driver; the MSSQL extension's GitHub Copilot integration works (https://aka.ms/vscode-mssql-copilot-docs).
+3. **Vector index DDL.** The live page lists this as an active issue, and the engine disagrees: measured on this image, `CREATE VECTOR INDEX` (DiskANN) builds and `VECTOR_SEARCH` returns ranked results against it. Tell the reader it works, name the rules it imposes (`SET QUOTED_IDENTIFIER ON`, at least 100 rows with non-null vectors, no `TRUNCATE TABLE` while it exists), and say that the published list has not caught up. The `azuresql-db-rag` skill carries the detail. Full-scan top-k stays exact and stays the right choice for a small table.
+4. **Two-step provisioning.** Provision a database on a `master` connection, then reconnect to it. Public Preview plans a default startup database (e.g. `MSSQL_DB=appdb`).
+5. **GUI tooling compatibility.** The VS Code MSSQL extension UI and SSMS are not yet 100% compatible (UI errors), being fixed. Use `sqlcmd` or a driver; the MSSQL extension's GitHub Copilot integration works (https://aka.ms/vscode-mssql-copilot-docs).
 
 ## Known behavior gaps (differences from the cloud)
 
+- **x64 image only; no native ARM64 build.** The image is `linux/amd64`. On an ARM64 host it runs under emulation: add `--platform linux/amd64` (Docker) or `platform: linux/amd64` (compose). Never say ARM64 is "supported", and do not promise a native build or a date. Feature requests: https://aka.ms/azuresqldb-container-feature-request
 - **Backup and restore.** `BACKUP DATABASE` / `RESTORE DATABASE` are not supported on the container (return `Msg 40510` in any session). Azure SQL Database in the cloud likewise does not support them. Use a Docker named volume for local persistence; use Azure SQL Database in the cloud for managed backups, point-in-time restore, and geo-replication.
 - **Always Encrypted with secure enclaves.** Basic Always Encrypted works; secure enclaves need host TEE support and are not validated.
 - **Auditing to Log Analytics or Storage.** Audit-to-file works; audit-to-cloud-targets is not applicable on the container.

--- a/skills/azuresql-db-from-sql-server/SKILL.md
+++ b/skills/azuresql-db-from-sql-server/SKILL.md
@@ -154,8 +154,11 @@ Expect `EngineEdition = 5` and `Edition = SQL Azure`.
 The Azure SQL Database engine has a native `VECTOR(n)` type and
 `VECTOR_DISTANCE('cosine', a, b)`. Insert with `CAST(CAST(? AS NVARCHAR(MAX)) AS VECTOR(n))` where **n
 is a LITERAL, never a bind parameter** (a parameter dimension fails with
-"Incorrect syntax near '@P3'"). `CREATE VECTOR INDEX` (DiskANN) is still in
-development; use a full-scan top-k query for now.
+"Incorrect syntax near '@P3'"). `CREATE VECTOR INDEX` (DiskANN) **works on this image**, measured, and the Known
+limitations page has not caught up. It needs `SET QUOTED_IDENTIFIER ON` and at
+least 100 rows with non-null vectors (`Msg 42266` below that). Full-scan top-k
+stays exact and stays the right choice for a small table. The `azuresql-db-rag`
+skill carries the rules the index imposes.
 
 ## Validation rules
 

--- a/skills/azuresql-db-from-sql-server/references/sql-server-vs-azure-feature-matrix.md
+++ b/skills/azuresql-db-from-sql-server/references/sql-server-vs-azure-feature-matrix.md
@@ -60,7 +60,10 @@ remove or replace every usage.
 
 - Native `VECTOR(n)` column type and `VECTOR_DISTANCE('cosine', a, b)` for
   embedding search. Insert with `CAST(CAST(? AS NVARCHAR(MAX)) AS VECTOR(n))` where `n` is a literal,
-  never a bind parameter. `CREATE VECTOR INDEX` (DiskANN) is still in
-  development; use a full-scan top-k query for now.
+  never a bind parameter. `CREATE VECTOR INDEX` (DiskANN) **works on this
+  image**, measured, and the Known limitations page has not caught up. It needs
+  `SET QUOTED_IDENTIFIER ON` and at least 100 rows with non-null vectors
+  (`Msg 42266` below that). Full-scan top-k stays exact and stays the right
+  choice for a small table.
 - Behavior matches Azure SQL Database, so local dev catches Azure-specific
   differences before deployment.

--- a/skills/azuresql-db-rag/SKILL.md
+++ b/skills/azuresql-db-rag/SKILL.md
@@ -249,7 +249,65 @@ Measured 2026-08-31. To empty the table: drop the index, truncate, reload at lea
 syntax near 'VECTOR'`. Use `DROP INDEX vi_name ON dbo.table`.
 
 `INSERT`, `UPDATE` and `DELETE` all work with the index in place, measured. Older
-vector indexes made the table read only; this image does not.
+vector indexes made the table read only; this image does not, and Microsoft Learn
+describes the same full DML support for latest-version indexes.
+
+### The index and a security policy cannot share a table here
+
+This is the expensive one for RAG, and it is not on any Microsoft Learn
+limitations list. Measured on the container, in **both** orders:
+
+| Order | Statement | Result |
+|---|---|---|
+| Index first | `CREATE SECURITY POLICY ... ADD FILTER PREDICATE ... ON dbo.chunks` | `Msg 37579` |
+| Policy first | `CREATE VECTOR INDEX ... ON dbo.chunks(emb)` | `Msg 42244` |
+
+```
+Msg 37579: The security policy 'p_chunks' cannot reference tables with vector indexes.
+Table 'dbo.chunks' has a vector index.
+
+Msg 42244: A vector index cannot be created on tables with security policies.
+Table 'dbo.chunks' has security policy 'p_chunks'.
+```
+
+**The documentation and the engine disagree here, and the documentation is
+silent rather than wrong.** As of 2026-09-03 the `CREATE VECTOR INDEX`
+limitations list names partitioning, the clustered primary key, replication,
+`TRUNCATE TABLE` and data-tier package import, and the `vector` type's
+limitations page names constraints, indexes, ledger tables and Always Encrypted.
+Neither mentions security policies. This pair is a measurement, not a citation.
+
+Why it matters for retrieval: a chunk table is a **second copy** of the source
+text, so the row-level security policy that protects the original table does not
+reach it. If the chunk table carries a vector index, no policy can be put on it
+at all, and the tenant filter in the retrieval query's `WHERE` clause is the
+entire boundary. That boundary is held up by a test rather than by the engine, so
+write the test: run the retrieval with the filter and without it and require
+different row counts.
+
+Three ways to live with it, cheapest first:
+
+1. Keep the tenant filter in the query and wrap the test above around it. That
+   test is security code now.
+2. Drop the vector index on the tenant-scoped table. Exact search over
+   `VECTOR_DISTANCE` still works, and a policy can then be created.
+3. Split the table: the vector column and its index on a table with no policy,
+   the chunk text and tenant column on a policy-bearing table joined back.
+
+If you are prototyping locally for the cloud, note this is a **parity gap**, not
+a design rule. The two coexist on Azure SQL Database. So the isolation control is
+exactly the part of the design that cannot be rehearsed on the container beside
+the index it will meet in production. Rehearse the predicate unindexed locally,
+and run the isolation test again on the cloud database once the index exists.
+
+### The dimension ceiling decides the embedding model, before any of this
+
+A `vector(n)` column tops out at **1998 dimensions**, which Microsoft Learn states
+and the engine enforces: `vector(1999)` is refused with `Msg 2717, The size (1999)
+given to the column 'v' exceeds the maximum allowed (1998)`. A 3072-dimension
+model does not fit and no index setting changes that. The dimension also cannot be
+widened later: `ALTER COLUMN` cannot change it even on an empty table, so the fix
+is a second column and a re-embed. Pick the dimension budget before the schema.
 
 Full-scan top-k with `ORDER BY VECTOR_DISTANCE(...)` is still exact and still
 correct, and it remains the right choice for small tables. The index is the
@@ -280,6 +338,11 @@ choice once the table is large enough for a full scan to hurt.
   string (`Database=appdb`, or `-d appdb` for sqlcmd).
 - Do not run `CREATE VECTOR INDEX` without `SET QUOTED_IDENTIFIER ON`; the error it raises
   names indexed views and spatial indexes and never mentions the setting.
+- Do not plan a vector index and a security policy on the same table on the container.
+  Both orders are refused, `Msg 37579` and `Msg 42244`, and neither is documented. If the
+  chunk table needs per-tenant filtering, decide that before you decide to index it.
+- Do not declare `VECTOR(3072)`. The ceiling is 1998 (`Msg 2717` above it) and the
+  dimension cannot be widened later, so the fix belongs at embedding time.
 - Do not expect `/docker-entrypoint-initdb.d/*.sql` to auto-run; seed by running
   `sqlcmd -d appdb -i seed.sql` after provisioning appdb.
 - Do not call a non-x64 host "supported"; just add `--platform linux/amd64`

--- a/skills/azuresql-db-rag/SKILL.md
+++ b/skills/azuresql-db-rag/SKILL.md
@@ -216,6 +216,41 @@ is built. Passing it fails with `Msg 42274, Vector search with newer index
 version does not support explicit TOP_N parameter`. Use `SELECT TOP (k)` and
 `ORDER BY s.distance` instead.
 
+### It needs 100 rows, and NULLs do not count
+
+Measured on 2026-08-31, walking the boundary:
+
+| Rows with a vector | Result |
+|---|---|
+| 99 | `Msg 42266` refused |
+| 100 | index created |
+| 120 rows, 60 of them NULL | `Msg 42266` refused |
+
+```
+Msg 42266: Cannot create a vector index. The table contains only 50 rows with
+non-null vectors, but at least 100 are required for vector index creation.
+```
+
+**This message is good, and worth saying so**, because the other two on this page
+are not. It names the rule, the actual count, and the column condition. A reader
+who hits it needs nothing else. Note the wording: **rows with non-null vectors**,
+not rows. A table of 120 rows where 60 have no embedding yet is refused.
+
+### `TRUNCATE TABLE` is refused while the index exists
+
+```
+Msg 42232: TRUNCATE TABLE statement failed because table 'd' has a vector index on it.
+```
+
+Measured 2026-08-31. To empty the table: drop the index, truncate, reload at least
+100 rows, recreate the index. `DELETE FROM` works and is not affected.
+
+**`DROP VECTOR INDEX` is not a statement.** It fails with `Msg 102, Incorrect
+syntax near 'VECTOR'`. Use `DROP INDEX vi_name ON dbo.table`.
+
+`INSERT`, `UPDATE` and `DELETE` all work with the index in place, measured. Older
+vector indexes made the table read only; this image does not.
+
 Full-scan top-k with `ORDER BY VECTOR_DISTANCE(...)` is still exact and still
 correct, and it remains the right choice for small tables. The index is the
 choice once the table is large enough for a full scan to hurt.

--- a/skills/azuresql-db-rag/SKILL.md
+++ b/skills/azuresql-db-rag/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   store when the data already lives in (or can live in) Azure SQL. Covers the
   VECTOR(n) column type, inserting embeddings with CAST(CAST(? AS NVARCHAR(MAX)) AS VECTOR(n)) where the
   dimension is a literal, a pluggable embed() so only the endpoint changes for
-  cloud, and the honest current state of CREATE VECTOR INDEX. Provisions appdb on
+  cloud, and a working CREATE VECTOR INDEX with the two errors that block it. Provisions appdb on
   master first so every script runs on a fresh container.
 ---
 
@@ -182,14 +182,43 @@ with pyodbc.connect(CONN) as conn:
 For the full RAG loop, glue these retrieved rows into your prompt as context.
 That LLM call is separate from this skill.
 
-## Indexing: honest current state
+## Indexing: measured current state
 
-`CREATE VECTOR INDEX` (DiskANN approximate nearest neighbor) is **still in
-development** in this preview. Do not rely on it yet. For now, use the
-**full-scan top-k** shown above: `ORDER BY VECTOR_DISTANCE(...)` over the whole
-table. This is exact and correct; it scans every row, so it is fine for
-thousands-to-tens-of-thousands of rows. When DiskANN ships, the query shape stays
-the same; you just add the index.
+`CREATE VECTOR INDEX` (DiskANN approximate nearest neighbor) **works on this
+image.** Measured on 2026-08-29 against `12.0.2000.8`, `EngineEdition` 5: an
+index over 2000 rows of `VECTOR(3)` built in **478 ms**, appears in
+`sys.indexes` with `type_desc` of `VECTOR`, and `vector_search(...)` returns
+ranked results against it.
+
+```sql
+SET QUOTED_IDENTIFIER ON;   -- required, see below
+CREATE VECTOR INDEX vi_docs ON dbo.docs(v) WITH (METRIC = 'cosine', TYPE = 'diskann');
+```
+
+**Two things will stop you, and neither error says what is wrong.**
+
+`SET QUOTED_IDENTIFIER ON` is required, and it is off by default in a `sqlcmd`
+session. Without it the statement fails with:
+
+```
+Msg 1934: CREATE VECTOR INDEX failed because the following SET options have
+incorrect settings: 'QUOTED_IDENTIFIER'. Verify that SET options are correct for
+use with indexed views and/or indexes on computed columns and/or filtered
+indexes and/or query notifications and/or XML data type methods and/or spatial
+index operations.
+```
+
+Nothing in that message mentions the session setting that actually caused it, and
+everything it does mention is irrelevant here.
+
+Second, `vector_search(...)` no longer accepts an explicit `TOP_N` once the index
+is built. Passing it fails with `Msg 42274, Vector search with newer index
+version does not support explicit TOP_N parameter`. Use `SELECT TOP (k)` and
+`ORDER BY s.distance` instead.
+
+Full-scan top-k with `ORDER BY VECTOR_DISTANCE(...)` is still exact and still
+correct, and it remains the right choice for small tables. The index is the
+choice once the table is large enough for a full scan to hurt.
 
 ## Validation rules
 
@@ -214,7 +243,8 @@ the same; you just add the index.
   provisioning session where the Azure statement filter is not enforced, so `USE` appears to work there, but `master` is for provisioning
   only, not application work. Always select the target database in the connection
   string (`Database=appdb`, or `-d appdb` for sqlcmd).
-- Do not rely on `CREATE VECTOR INDEX` yet; use full-scan top-k.
+- Do not run `CREATE VECTOR INDEX` without `SET QUOTED_IDENTIFIER ON`; the error it raises
+  names indexed views and spatial indexes and never mentions the setting.
 - Do not expect `/docker-entrypoint-initdb.d/*.sql` to auto-run; seed by running
   `sqlcmd -d appdb -i seed.sql` after provisioning appdb.
 - Do not call a non-x64 host "supported"; just add `--platform linux/amd64`

--- a/skills/azuresql-db-rag/references/vector-schema.md
+++ b/skills/azuresql-db-rag/references/vector-schema.md
@@ -160,7 +160,8 @@ Measured 2026-08-29 on `12.0.2000.8`, `EngineEdition` 5: 2000 rows of `VECTOR(3)
 indexed in 478 ms, visible in `sys.indexes` as `type_desc` `VECTOR`, and queried
 through `vector_search(...)`.
 
-It needs `SET QUOTED_IDENTIFIER ON`, which is off by default in `sqlcmd`. Without
+It needs `SET QUOTED_IDENTIFIER ON` (and `SET ANSI_NULLS ON`), which are off by
+default in `sqlcmd`. Without
 it you get `Msg 1934`, whose text names indexed views, computed columns, filtered
 indexes, query notifications, XML methods and spatial indexes, and never the
 session setting that caused it.
@@ -183,6 +184,39 @@ Measured 2026-08-31 on `12.0.2000.8` unless marked as documented.
 | `INSERT`, `UPDATE`, `DELETE` all work with the index in place | measured. Older index versions made the table read only |
 | The table needs a primary key clustered index | documented |
 | Vector indexes cannot be partitioned and are not replicated to subscribers | documented |
+| A **security policy and a vector index cannot share a table** on the container, in either order | `Msg 37579` creating the policy after the index, `Msg 42244` creating the index after the policy. Both measured. **Documented nowhere.** The two coexist on Azure SQL Database, so this is a parity gap |
+| The `vector` column tops out at **1998 dimensions**, so a 3072-dimension model does not fit | `Msg 2717, The size (1999) given to the column 'v' exceeds the maximum allowed (1998)`. Learn states the same ceiling. The dimension cannot be widened later by `ALTER COLUMN`, even on an empty table |
+
+### The security policy conflict, in full
+
+A chunk table is a second copy of the source text, so the row-level security
+policy protecting the original table does not reach it. Add a vector index and no
+policy can be put on the chunk table at all, which leaves the tenant filter in the
+retrieval query's `WHERE` clause as the entire boundary, held up by a test rather
+than by the engine.
+
+```text
+Msg 37579, Level 16, State 1
+The security policy 'p_chunks' cannot reference tables with vector indexes.
+Table 'dbo.chunks' has a vector index.
+
+Msg 42244
+A vector index cannot be created on tables with security policies.
+Table 'dbo.chunks' has security policy 'p_chunks'.
+```
+
+**Where the sources disagree:** Microsoft Learn's `CREATE VECTOR INDEX`
+limitations list names partitioning, the clustered primary key, replication,
+`TRUNCATE TABLE` and data-tier package import, and the `vector` type's limitations
+page names constraints, indexes, ledger tables and Always Encrypted. As of
+2026-09-03 neither mentions security policies. The refusal above is this skill's
+own measurement. If it ever stops reproducing, the product moved.
+
+Three ways to live with it: keep the tenant filter in the query and test that
+removing it changes the row count; drop the vector index on the tenant-scoped
+table and take exact search; or split the table, with the indexed vector column on
+a policy-free table joined back to a policy-bearing table holding the chunk text
+and tenant column.
 
 ## Two things that will bite later, both documented rather than measured
 

--- a/skills/azuresql-db-rag/references/vector-schema.md
+++ b/skills/azuresql-db-rag/references/vector-schema.md
@@ -171,6 +171,35 @@ Once the index exists, `vector_search(...)` rejects an explicit `TOP_N` with
 Full-scan top-k with `ORDER BY VECTOR_DISTANCE(...)` stays exact and stays the
 right choice for a small table.
 
+## The rules the index imposes once it exists
+
+Measured 2026-08-31 on `12.0.2000.8` unless marked as documented.
+
+| Rule | Evidence |
+|---|---|
+| At least **100 rows with non-null vectors**. 99 is refused, 100 succeeds, and 120 rows with 60 nulls is refused | `Msg 42266`, measured at the boundary |
+| `TRUNCATE TABLE` is refused while the index exists | `Msg 42232`, measured. Drop the index, truncate, reload 100 rows, recreate |
+| `DROP VECTOR INDEX` is not a statement | `Msg 102, Incorrect syntax near 'VECTOR'`. Use `DROP INDEX name ON table` |
+| `INSERT`, `UPDATE`, `DELETE` all work with the index in place | measured. Older index versions made the table read only |
+| The table needs a primary key clustered index | documented |
+| Vector indexes cannot be partitioned and are not replicated to subscribers | documented |
+
+## Two things that will bite later, both documented rather than measured
+
+**Indexes built on the earlier data structure are deprecated.** They still work in
+the current release and will be retired. They cannot be upgraded in place: drop
+and recreate is the only path, and dropping disables approximate search on that
+table until the new one is built, so it belongs in a maintenance window. The
+older structure also made the table read only after index creation and applied
+filters only after retrieval, which is why the migration is worth doing rather
+than deferring.
+
+**A vector index cannot be deployed with DacPac or BACPAC.** The import creates
+schema objects before loading data, so the index is created against an empty
+table, hits the 100 row minimum, and the import fails. The workaround is to drop
+vector indexes before exporting and recreate them after importing. This is worth
+knowing before someone plans a migration around an export.
+
 ## Troubleshooting
 
 | Symptom                               | Cause and fix                                                                 |

--- a/skills/azuresql-db-rag/references/vector-schema.md
+++ b/skills/azuresql-db-rag/references/vector-schema.md
@@ -155,10 +155,21 @@ For programmatic seeding, loop over your documents in application code calling
 
 ## Indexing status
 
-`CREATE VECTOR INDEX` (DiskANN approximate nearest neighbor) is still in
-development in this preview. Do not depend on it. Use full-scan top-k for now.
-The query shape does not change when the index ships; you add the index and keep
-the same `ORDER BY VECTOR_DISTANCE(...)`.
+`CREATE VECTOR INDEX` (DiskANN approximate nearest neighbor) works on this image.
+Measured 2026-08-29 on `12.0.2000.8`, `EngineEdition` 5: 2000 rows of `VECTOR(3)`
+indexed in 478 ms, visible in `sys.indexes` as `type_desc` `VECTOR`, and queried
+through `vector_search(...)`.
+
+It needs `SET QUOTED_IDENTIFIER ON`, which is off by default in `sqlcmd`. Without
+it you get `Msg 1934`, whose text names indexed views, computed columns, filtered
+indexes, query notifications, XML methods and spatial indexes, and never the
+session setting that caused it.
+
+Once the index exists, `vector_search(...)` rejects an explicit `TOP_N` with
+`Msg 42274`. Use `SELECT TOP (k)` with `ORDER BY s.distance`.
+
+Full-scan top-k with `ORDER BY VECTOR_DISTANCE(...)` stays exact and stays the
+right choice for a small table.
 
 ## Troubleshooting
 

--- a/skills/azuresql-db-scaffold/SKILL.md
+++ b/skills/azuresql-db-scaffold/SKILL.md
@@ -110,8 +110,10 @@ docker exec -i sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourSt
 
 Native `VECTOR(n)` column type and `VECTOR_DISTANCE('cosine', a, b)`. Insert with
 `CAST(CAST(? AS NVARCHAR(MAX)) AS VECTOR(n))` where **n is a LITERAL, never a bind parameter** (a parameter dimension
-fails with "Incorrect syntax near '@P3'"). `CREATE VECTOR INDEX` (DiskANN) is still in
-development; use full-scan top-k for now.
+fails with "Incorrect syntax near '@P3'"). `CREATE VECTOR INDEX` (DiskANN) **works on this image**, measured, and the Known
+limitations page has not caught up. It needs `SET QUOTED_IDENTIFIER ON` and at least 100 rows with
+non-null vectors (`Msg 42266` below that). Full-scan top-k stays exact and stays the right choice
+for a small table. The `azuresql-db-rag` skill carries the rules the index imposes.
 
 ## Validation rules
 

--- a/skills/azuresql-db-schema-migration/SKILL.md
+++ b/skills/azuresql-db-schema-migration/SKILL.md
@@ -133,7 +133,22 @@ When inserting via `CAST(CAST(? AS NVARCHAR(MAX)) AS VECTOR(n))`, `n` must be a
 literal, never a bind parameter (a parameter dimension fails with "Incorrect
 syntax near '@P3'"); the inner `NVARCHAR(MAX)` cast keeps a real embedding's
 JSON from being sent as ntext, which the engine rejects (error 529).
-`CREATE VECTOR INDEX` (DiskANN) is still in development; use full-scan top-k for now.
+`CREATE VECTOR INDEX` (DiskANN) **works on this image**, measured, and the Known
+limitations page has not caught up. Three things matter in a migration:
+
+- It needs `SET QUOTED_IDENTIFIER ON` in the session running the DDL, and it refuses
+  to build on fewer than 100 rows with non-null vectors (`Msg 42266`). So the index
+  belongs in a migration step that runs **after** the corpus is loaded, not beside the
+  `CREATE TABLE`.
+- `TRUNCATE TABLE` is refused while the index exists (`Msg 42232`). A migration that
+  reloads a table has to drop the index first, and `DROP VECTOR INDEX` is not a
+  statement: use `DROP INDEX name ON dbo.table`.
+- Microsoft Learn documents that a vector index cannot be carried through a data-tier
+  package import, because the import creates the schema before loading rows and the
+  index then hits the 100-row minimum. Drop vector indexes before exporting and
+  recreate them after importing.
+
+Full-scan top-k stays exact and stays the right choice for a small table.
 
 ## Seeding after migration
 


### PR DESCRIPTION
`azuresql-db-rag` told readers that `CREATE VECTOR INDEX` is "still in development in this preview" and to not rely on it. That is no longer true, and the skill was steering people away from a feature that works.

**Widened 2026-09-04.** The same claim lived in six other skills, the skills README and the eval assertions. Correcting only `azuresql-db-rag` would have left a public repo where the index works in one skill and does not work in six, so this PR now carries the whole fix.

## Measured

2026-08-29, against `12.0.2000.8`, `EngineEdition` 5, image `azure-sql/db-dev:latest`:

- An index over 2000 rows of `VECTOR(3)` built in **478 ms**.
- It appears in `sys.indexes` with `type_desc` of `VECTOR`.
- `vector_search(...)` returns ranked results against it.

## Two obstacles replace the old warning, and neither error names its own cause

**`SET QUOTED_IDENTIFIER ON` is required**, and it is off by default in a `sqlcmd` session. Without it:

```
Msg 1934: CREATE VECTOR INDEX failed because the following SET options have incorrect
settings: 'QUOTED_IDENTIFIER'. Verify that SET options are correct for use with indexed
views and/or indexes on computed columns and/or filtered indexes and/or query
notifications and/or XML data type methods and/or spatial index operations.
```

Everything that message names is irrelevant here, and the setting that actually caused it is not mentioned. A reader hitting this concludes the feature is broken, which is exactly what the skill already told them to expect.

**`TOP_N` is rejected once the index exists.** `vector_search(...)` with an explicit `TOP_N` fails with `Msg 42274, Vector search with newer index version does not support explicit TOP_N parameter`. Use `SELECT TOP (k)` with `ORDER BY s.distance`.

## The rules the index imposes

Measured at the boundary: at least **100 rows with non-null vectors** (`Msg 42266` below that, and it counts non-null vectors, not rows). `TRUNCATE TABLE` is refused while the index exists (`Msg 42232`). `DROP VECTOR INDEX` is not a statement (`Msg 102`); use `DROP INDEX name ON dbo.table`. `INSERT`, `UPDATE` and `DELETE` all work with the index in place.

Two more added in the widening, both measured and neither on any Microsoft Learn limitations list:

- **A security policy and a vector index cannot share a table on the container, in either order.** `Msg 37579` creating the policy after the index, `Msg 42244` creating the index after the policy. For retrieval this is the expensive one. A chunk table is a second copy of the source text, so the policy protecting the original table does not reach it, and once the chunk table carries a vector index no policy can be created on it at all. The tenant filter in the retrieval query is then the entire boundary, held up by a test rather than by the engine. The two coexist on Azure SQL Database, so this is a parity gap: the isolation control is exactly the part of a retrieval design that cannot be rehearsed locally beside the index it will meet in production.
- **The `vector` column tops out at 1998 dimensions** (`Msg 2717`), and the dimension cannot be widened by `ALTER COLUMN` even on an empty table. A 3072-dimension embedding model has to be ruled out before the schema exists, not after.

## Where the sources disagree, the text says so

The live Known limitations page still lists vector index DDL as an active issue. The engine builds the index. Every corrected place gives the measured behaviour and states that the published list has not caught up, rather than quietly picking a side.

`docs/known-limitations.md` and the site copy (`README.md`, `docs/index.html`, `docs/llms.txt`, `docs/what-is-the-container.md`) are **left alone on purpose**. Changing the product's published position is a product call, not a skills change, and the skills now name the disagreement rather than hide it. Those five files still carry the old claim and need a separate decision.

## What is kept

Full-scan top-k with `ORDER BY VECTOR_DISTANCE(...)` is still exact and still the right choice for a small table, so that guidance stays. The index is now presented as the choice once a full scan starts to hurt, rather than as something unavailable.

## Two numbering defects fixed along the way

`azuresql-db-faq/references/limitations.md` listed six active issues; the live page lists five. "x64 image only" was number 4 and does not belong in that list at all, since the live page files it under known behaviour gaps. Moved there, and 5 and 6 renumbered to 4 and 5 so the snapshot lines up with the page it snapshots. x64-only remains the standing position, with no native ARM64 build and no date promised.

`eval/outcome-assertions.md` asserted the opposite of the fix ("Does not rely on CREATE VECTOR INDEX ... while the index is in development") and would have failed every corrected skill. Rewritten.

No `skill.spec.jsonc` touched.
