### PR TITLE
Remove duplication inside single skill files

### DIFF
--- a/skills/azuresql-db-ci/SKILL.md
+++ b/skills/azuresql-db-ci/SKILL.md
@@ -180,12 +180,9 @@ echo "ready on localhost,$HOST_PORT"
 - Do not use the SQL Server image `mcr.microsoft.com/mssql/server`; use the Azure SQL DB image.
 - Do not connect with `Database=appdb` before provisioning appdb on master; the engine will not
   auto-create it.
-- Do not `USE appdb` to switch databases. In a user-database session (the Azure-faithful
-  context where you develop), `USE` returns `Msg 40508`, exactly as in Azure SQL Database in the
-  cloud. A `master` connection is a provisioning session where the Azure statement filter is
-  not enforced, so `USE` appears to work there, but `master` is for
-  provisioning only, not application work. Always select the target database in the connection string
-  (`Database=appdb`, or `-d appdb` for sqlcmd).
+- Do not use `USE appdb` to switch databases; a user-database session returns
+  `Msg 40508`, exactly as in Azure SQL Database in the cloud. Select the target
+  database in the connection string (`Database=appdb`, or `-d appdb` for sqlcmd).
 - Do not run tests against master; master is for provisioning only.
 - Do not rely on `/docker-entrypoint-initdb.d/*.sql`; it is not honored. Seed with `sqlcmd -d appdb -i`.
 - Do not require sqlcmd on the runner; the health check and provisioning run inside the container.

--- a/skills/azuresql-db-connections/SKILL.md
+++ b/skills/azuresql-db-connections/SKILL.md
@@ -69,10 +69,6 @@ Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;Tru
 
 ## Pooling: reuse connections, do not reopen per query
 
-A connection pool keeps a set of open connections and hands one back on each `Open()`. Opening
-a pooled connection is cheap; opening a brand-new physical connection per query is not, and it
-exhausts server resources under load.
-
 - Keep pooling **on** (it is on by default in most drivers) and let one pool serve the app.
 - Set a **bounded** `Max Pool Size` (default 100 in .NET) so a spike cannot open unlimited
   connections. Size it to real concurrency, not a guess.
@@ -84,20 +80,19 @@ exhausts server resources under load.
 
 ## Retry: only for transient faults, with backoff
 
-A **transient fault** is a temporary condition (throttling, a brief failover, a dropped idle
-connection) that succeeds on a retry. In Azure SQL these arrive as specific error numbers (for
-example 40501 throttling, 40613 database unavailable, 49918/49919/49920 busy, 4060, 10928,
-10929, 40197, 233, and connection-timeout / broken-pipe socket errors).
+Retry only a transient fault: throttling, a brief failover, a dropped idle connection. In Azure
+SQL these arrive as specific error numbers: 40501 throttling, 40613 database unavailable,
+49918/49919/49920 busy, 4060, 10928, 10929, 40197, 233, plus connection-timeout and broken-pipe
+socket errors.
 
 - Retry **only** transient errors. Retrying a non-transient error (login failure 18456, syntax
   error, constraint violation, permission denied) just fails slower and hides the real bug.
 - Use **exponential backoff** with a cap and a small jitter, and a bounded attempt count (for
   example 5 attempts). Do not hammer a throttled server.
-- Be careful with **non-idempotent writes**. A retry can double-apply an `INSERT` if the first
-  attempt actually committed before the connection dropped. Make writes idempotent (natural or
-  client-generated keys, `MERGE`, or wrap the unit of work in a transaction that a retry can
-  safely re-run as a whole). The built-in EF Core execution strategy handles this for you when
-  work is wrapped in its `Execute`/transaction API.
+- **Non-idempotent writes**: a retry can double-apply an `INSERT` that committed before the
+  connection dropped. Use client-generated keys, `MERGE`, or a transaction the retry re-runs as a
+  whole. EF Core's execution strategy handles this when the work goes through its
+  `Execute`/transaction API.
 - Prefer a framework retry policy over hand-rolled loops where one exists (EF Core
   `EnableRetryOnFailure` for .NET). Hand-roll only for raw drivers.
 

--- a/skills/azuresql-db-container/references/connection-model.md
+++ b/skills/azuresql-db-container/references/connection-model.md
@@ -14,7 +14,8 @@ The single most common source of failures. Read this before connecting an app.
    session where the Azure statement filter is not enforced, so
    `USE` appears to work there, but `master` is for
    provisioning only, not application work. Always select the target database in
-   the connection string (`Database=appdb`, or `-d appdb` for sqlcmd).
+   the connection string (`Database=appdb`, or `-d appdb` for sqlcmd). The fix is
+   always to set the target database in the connection, never in a statement.
 3. **A `master` connection is for provisioning only.** `master` is a provisioning
    session: the Azure SQL statement filter (`USE`, `SHUTDOWN`, `RECONFIGURE`) is
    not enforced there, so `USE` works. (`BACKUP`/`RESTORE` are a separate case:
@@ -49,16 +50,6 @@ docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0n
 
 Apps must include `Database=appdb` in the connection string. They should never
 issue `USE`. See `connect-and-query.md` for the full connection string.
-
-## Why to avoid USE
-
-Avoid `USE` to switch databases. In a user-database session (the
-Azure-faithful context where you develop), `USE` returns `Msg 40508`, exactly as
-in Azure SQL Database in the cloud. A `master` connection is a provisioning
-session where the Azure statement filter is not enforced, so `USE` appears to work there, but `master` is for provisioning
-only, not application work. Always select the target database in the connection
-string (`Database=appdb`, or `-d appdb` for sqlcmd). The fix is always to set the
-target database in the connection (string or `-d`), not in a statement.
 
 ## Seeding pattern (never USE)
 

--- a/skills/azuresql-db-from-sql-server/SKILL.md
+++ b/skills/azuresql-db-from-sql-server/SKILL.md
@@ -106,9 +106,7 @@ sqlcmd). Avoid `USE` to switch databases. In a user-database session (the
 Azure-faithful context where you develop), `USE` returns `Msg 40508`, exactly as
 in Azure SQL Database in the cloud. A `master` connection is a provisioning
 session where the Azure statement filter is not enforced, so `USE` appears to work there, but `master` is for provisioning
-only, not application work. Always select the target database in the connection
-string (`Database=appdb`, or `-d appdb` for sqlcmd). Standardize on one
-`SQL_CONNECTION_STRING` env var:
+only, not application work. Standardize on one `SQL_CONNECTION_STRING` env var:
 
 ```
 Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true

--- a/skills/azuresql-db-import/SKILL.md
+++ b/skills/azuresql-db-import/SKILL.md
@@ -120,13 +120,8 @@ This engine is Azure SQL Database (Engine Edition 5), so SQL Server features
 that Azure SQL DB does not support will fail or be skipped on import:
 
 - Cross-database three-part-name references and most cross-DB queries.
-- `USE <db>` in scripts: avoid `USE` to switch databases. In a user-database
-  session (the Azure-faithful context where you develop), `USE` returns
-  `Msg 40508`, exactly as in Azure SQL Database in the cloud. A `master` connection
-  is a provisioning session where the Azure statement filter is not
-  enforced, so `USE` appears to work there, but `master` is
-  for provisioning only, not application work. Always select the target database in
-  the connection string (`Database=appdb`, or `-d appdb` for sqlcmd).
+- `USE <db>` in scripts: a user-database session returns `Msg 40508`. Select the
+  target database in the connection string (`Database=appdb`, or `-d appdb`).
 - Server-scoped objects: SQL Agent jobs, server-level logins/linked servers,
   filestream, certain CLR and filegroup/physical-file settings.
 - Instance-level `DATABASE_DEFAULT` collation assumptions and unsupported

--- a/skills/azuresql-db-import/references/sqlpackage-import.md
+++ b/skills/azuresql-db-import/references/sqlpackage-import.md
@@ -107,13 +107,8 @@ Because this is the Azure SQL Database engine (`EngineEdition = 5`,
 `Edition = 'SQL Azure'`), SQL Server-only features will not import:
 
 - Cross-database three-part-name references and most cross-DB queries.
-- `USE <db>`: avoid `USE` to switch databases. In a user-database session
-  (the Azure-faithful context where you develop), `USE` returns `Msg 40508`,
-  exactly as in Azure SQL Database in the cloud. A `master` connection is a
-  provisioning session where the Azure statement filter is not enforced, so
-  `USE` appears to work there, but `master` is for
-  provisioning only, not application work. Always select the target database in the
-  connection string (`Database=appdb`, or `-d appdb` for sqlcmd).
+- `USE <db>`: a user-database session returns `Msg 40508` (see the entry above).
+  Select the target database in the connection string instead.
 - Server-scoped objects: SQL Agent jobs, server logins, linked servers,
   filestream, some CLR, explicit filegroup/physical-file placement.
 - Unsupported collations or compatibility-level features from the source.

--- a/skills/azuresql-db-local-to-cloud/SKILL.md
+++ b/skills/azuresql-db-local-to-cloud/SKILL.md
@@ -230,15 +230,9 @@ body stays an overview.
 - Do not use the SQL Server image `mcr.microsoft.com/mssql/server`. If you
   were about to, stop and use the image above; this is the Azure SQL engine.
 - Do not connect to `Database=appdb` before creating it on `master`.
-- Do not use `USE appdb` to switch databases; set the database in the connection
-  string (`Database=appdb`, or `-d appdb` for sqlcmd). In a user-database
-  session (the Azure-faithful context where you develop), `USE` returns
-  `Msg 40508`, exactly as in Azure SQL Database in the cloud. A `master`
-  connection is a provisioning session where the Azure statement filter is
-  not enforced, so `USE` appears to work there, but
-  `master` is for provisioning only, not application work. Always select the
-  target database in the connection string (`Database=appdb`, or `-d appdb` for
-  sqlcmd).
+- Do not use `USE appdb` to switch databases; a user-database session returns
+  `Msg 40508`, exactly as in Azure SQL Database in the cloud. Select the target
+  database in the connection string (`Database=appdb`, or `-d appdb` for sqlcmd).
 - Do not put a password or secret in the cloud connection string; use Entra
   auth and let the driver fetch a token.
 - Do not branch app logic on environment; keep auth in configuration.

--- a/skills/azuresql-db-rag/SKILL.md
+++ b/skills/azuresql-db-rag/SKILL.md
@@ -334,12 +334,9 @@ choice once the table is large enough for a full scan to hurt.
   not this engine.
 - Do not pass the vector dimension as a bind parameter; it fails with
   `Incorrect syntax near '@P3'`. Interpolate it as a literal.
-- Avoid `USE` to switch databases. In a user-database session (the
-  Azure-faithful context where you develop), `USE` returns `Msg 40508`, exactly
-  as in Azure SQL Database in the cloud. A `master` connection is a provisioning
-  session where the Azure statement filter is not enforced, so `USE` appears to work there, but `master` is for provisioning
-  only, not application work. Always select the target database in the connection
-  string (`Database=appdb`, or `-d appdb` for sqlcmd).
+- Do not use `USE appdb` to switch databases; a user-database session returns
+  `Msg 40508`, exactly as in Azure SQL Database in the cloud. Select the target
+  database in the connection string (`Database=appdb`, or `-d appdb` for sqlcmd).
 - Do not run `CREATE VECTOR INDEX` without `SET QUOTED_IDENTIFIER ON`; the error it raises
   names indexed views and spatial indexes and never mentions the setting.
 - Do not plan a vector index and a security policy on the same table on the container.

--- a/skills/azuresql-db-scaffold/references/scaffold-snippets.md
+++ b/skills/azuresql-db-scaffold/references/scaffold-snippets.md
@@ -7,8 +7,18 @@ also read `DATABASE_URL`. Image is
 `sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest` (NOT the
 `mcr.microsoft.com/mssql/server` SQL Server image). On a non-x64 host add `platform: linux/amd64`.
 
+## Provision appdb first (every stack below assumes this has run)
+
+The engine does not auto-create databases. On a master connection:
+
+```bash
+docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b \
+  -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;"
+```
+
 ## Contents
 
+- [Provision appdb first](#provision-appdb-first-every-stack-below-assumes-this-has-run)
 - [Shared: compose service](#shared-compose-service)
 - [.NET Aspire (EF Core)](#net-aspire-ef-core)
 - [FastAPI (SQLAlchemy / pyodbc)](#fastapi-sqlalchemy--pyodbc)
@@ -61,12 +71,8 @@ Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;Tru
 SQL_CONNECTION_STRING=Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true
 ```
 
-Provision appdb (once, on master) before the first migration:
-
-```bash
-docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b \
-  -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;"
-```
+Provision appdb (once, on master) before the first migration: see
+[Provision appdb first](#provision-appdb-first-every-stack-below-assumes-this-has-run).
 
 `Program.cs` reads the single env var:
 
@@ -83,13 +89,8 @@ dotnet ef migrations add InitialCreate
 dotnet ef database update
 ```
 
-Typed, parameterized data access (EF parameterizes by default):
-
-```csharp
-var widgets = await db.Widgets
-    .Where(w => w.Name == name)   // name is parameterized, never concatenated
-    .ToListAsync();
-```
+Data access: EF Core parameterizes LINQ predicates by default. Never concatenate a value into
+raw SQL.
 
 For the migration workflow in depth, see the **azuresql-db-schema-migration** skill.
 
@@ -101,12 +102,8 @@ For the migration workflow in depth, see the **azuresql-db-schema-migration** sk
 SQL_CONNECTION_STRING=Server=localhost,1433;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true
 ```
 
-Provision appdb on master before the app connects:
-
-```bash
-docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b \
-  -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;"
-```
+Provision appdb on master before the app connects (see
+[Provision appdb first](#provision-appdb-first-every-stack-below-assumes-this-has-run)).
 
 `db.py`: build a SQLAlchemy URL from the canonical string via pyodbc.
 
@@ -186,11 +183,7 @@ docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0n
 npx prisma migrate dev --name init
 ```
 
-Typed, parameterized data access (Prisma Client parameterizes all inputs):
-
-```ts
-const widgets = await prisma.widget.findMany({ where: { name } });
-```
+Data access: Prisma Client parameterizes every input.
 
 ## NestJS (Prisma or TypeORM)
 
@@ -202,12 +195,8 @@ DATABASE_URL=sqlserver://localhost:1433;database=appdb;user=sa;password=YourStr0
 MSSQL_SA_PASSWORD=YourStr0ng_Passw0rd
 ```
 
-Provision appdb on master before bootstrapping:
-
-```bash
-docker exec sqldb /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "YourStr0ng_Passw0rd" -C -b \
-  -Q "IF DB_ID('appdb') IS NULL CREATE DATABASE appdb;"
-```
+Provision appdb on master before bootstrapping (see
+[Provision appdb first](#provision-appdb-first-every-stack-below-assumes-this-has-run)).
 
 Prisma path: same pinned install (`npm install prisma@6 @prisma/client@6`), `schema.prisma`, and
 `npx prisma migrate dev --name init` as Next.js above.
@@ -239,13 +228,6 @@ npm run typeorm -- migration:generate ./src/migrations/Init -d ./src/AppDataSour
 npm run typeorm -- migration:run -d ./src/AppDataSource.ts
 ```
 
-Typed, parameterized data access (TypeORM binds parameters):
-
-```ts
-const widgets = await repo
-  .createQueryBuilder("w")
-  .where("w.name = :name", { name })   // bound, never string-concatenated
-  .getMany();
-```
+Data access: TypeORM binds `:name`-style parameters. Never string-concatenate a value.
 
 For the full migration workflow across stacks, see the **azuresql-db-schema-migration** skill.

--- a/skills/azuresql-db-sidecar/SKILL.md
+++ b/skills/azuresql-db-sidecar/SKILL.md
@@ -183,13 +183,9 @@ The app container reaches the database at `sqldb,1433` over the compose network.
 - Do not point the app at `localhost`; inside compose it is the `sqldb` service.
 - Do not rely on the app to create `appdb`, and do not assume the engine
   auto-creates it; the `sqldb-init` one-shot must run first.
-- Do not use `USE appdb` to switch databases. In a user-database session
-  (the Azure-faithful context where you develop), `USE` returns `Msg 40508`,
-  exactly as in Azure SQL Database in the cloud. A `master` connection is a
-  provisioning session where the Azure statement filter is not enforced,
-  so `USE` appears to work there, but `master` is for
-  provisioning only, not application work. Always select the target database in
-  the connection string (`Database=appdb`, or `-d appdb` for sqlcmd).
+- Do not use `USE appdb` to switch databases; a user-database session returns
+  `Msg 40508`, exactly as in Azure SQL Database in the cloud. Select the target
+  database in the connection string (`Database=appdb`, or `-d appdb` for sqlcmd).
 - Do not drop `--platform` / `platform: linux/amd64`; the image is x64 only.
 - Do not depend on `/docker-entrypoint-initdb.d/*.sql`; it is not honored here.
 - Do not call a non-x64 host "supported"; it runs under emulation only.


### PR DESCRIPTION
Stacked on #151. Merge that first.

## The result is mostly a negative, and that is the finding

Measured all 17 with `tiktoken` `cl100k_base` over `SKILL.md` plus every `references/` file, expecting to find generic padding worth cutting.

**89,853 tokens to 89,073. 780 out, 0.9%.**

**51 to 67 percent of the collection is container-specific material a model cannot know**, bracketed by two marker sets so the width of the judgement is visible. The bodies are already kernel-dense. The generic material is not padding inside them, it is whole per-stack reference files, and cutting those would cut worked examples whose container-specific detail is real.

## What actually came out

Duplication **inside single files**, not across them:

- The full `Msg 40508` explanation appears **twice in the same file** in 7 skills, the second copy always in a "Do not" list.
- `connection-model.md` carried a whole section byte-identical to one four paragraphs above it.
- `from-sql-server/SKILL.md` repeats a sentence twice inside one paragraph.
- `scaffold-snippets.md` had the same `CREATE DATABASE appdb` block 5 times, in a file whose own header says appdb is already provisioned.
- Three textbook definitions in `azuresql-db-connections`: what a connection pool is, what a transient fault is, why a retry can double-apply an INSERT. A model writes all three better unprompted.

Every file touched shrank. None grew.

## Duplication kept on purpose

Cross-skill repetition stays. A user may install one skill alone, and each must be able to say `USE` returns `Msg 40508` without the hub installed. The "Staying current" block stays in all 17: it looks generic but it is the doc-bridging policy, and canon-check rule 10 enforces its wording.

## Two facts MISSING from the collection

Found while auditing, both measured, both unknowable to a model, both absent everywhere:

- `sp_configure` returning `Msg 2812`
- `func new --template SqlTrigger` being refused while `func templates list` advertises it

Adding them would grow files, which this pass forbade. Handled separately.

## azuresql-db-scaffold may not earn its place

Not deleted, because that is a decision and not a trim. The evidence: every container fact in it is already carried by `azuresql-db-container` or `azuresql-db-sidecar`, and its Prisma pin is fuller in `azuresql-db-schema-migration`. What is unique is per-stack scaffolding, which is the generic half by definition.

The counter-argument: its `description` is the only one claiming "add a database to a fresh project", which is real triggering value the body does not reflect. Retiring it also touches installs, the plugin manifest, cross-references, and canon-check rule 12.

## Gates

canon-check 24/24, link-check 49/49.