### PR TITLE
Say when each skill's claims were checked, and against what

### DIFF
--- a/skills/azuresql-db-auth/SKILL.md
+++ b/skills/azuresql-db-auth/SKILL.md
@@ -21,6 +21,15 @@ connect as. This skill wires the app to a **least-privilege user**, picks the
 in the cloud, changing only the connection string), secures the connection, and
 keeps the secret out of source control.
 
+Verified on 2026-09-05 against the container image
+`sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest`, reporting `EngineEdition`
+5, Edition `SQL Azure`, build `12.0.2000.8`. All seven executable checks behind this skill
+passed, including `Msg 15007` for a contained user, `Msg 12844` for `SET CONTAINMENT =
+PARTIAL`, `Msg 37525` for `CREATE USER ... FROM EXTERNAL PROVIDER` on a container started
+without Entra configuration, and the fixed database roles this skill grants. The cloud side of
+this guidance, Azure Key Vault and managed identity, was not measured by that run and comes
+from Microsoft Learn.
+
 ## Load-bearing facts (inlined; full engine detail in azuresql-db-container)
 
 - This is the **Azure SQL Database engine** (Private Preview), not the SQL Server

--- a/skills/azuresql-db-ci/SKILL.md
+++ b/skills/azuresql-db-ci/SKILL.md
@@ -25,6 +25,14 @@ service container. This is the local Azure SQL engine, not the SQL Server image
 For the full readiness loop, connection model, vectors, seeding, and registry detail, load the
 **azuresql-db-container** skill.
 
+Verified on 2026-09-05 against the container image
+`sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest`, reporting `EngineEdition`
+5, Edition `SQL Azure`, build `12.0.2000.8`. All four executable checks behind this skill
+passed: the engine identity, that a test session is on the user database and not `master`,
+`Msg 40508` for `USE`, and `sqlcmd` at `/opt/mssql-tools18/bin/sqlcmd` inside the image. The
+workflow YAML itself was not executed by that run; what was checked is the engine behaviour
+the workflow rests on.
+
 ## Load-bearing facts (inlined)
 
 - **Image:** `sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest`

--- a/skills/azuresql-db-connections/SKILL.md
+++ b/skills/azuresql-db-connections/SKILL.md
@@ -19,6 +19,16 @@ Make the app's database connections reliable with **connection pooling** and **r
 transient-fault handling**. This is the **Azure SQL engine** (Private Preview), not the SQL
 Server image.
 
+Verified on 2026-09-05 against the container image
+`sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest`, reporting `EngineEdition`
+5, Edition `SQL Azure`, build `12.0.2000.8`. All five executable checks behind this skill
+passed: the engine identity, `Msg 40508` for `USE`, a TCP session on the mapped port, and the
+two resource-governance dynamic management views returning nothing locally. Of the ten
+transient error numbers in the retry list below, nine are in this build's `sys.messages` and
+`Msg 10929` is not. It stays in the list because it is a cloud resource-governance error the
+container has no reason to raise, and it is sourced from Microsoft Learn rather than from that
+run.
+
 ## Why do this locally (local-to-cloud parity)
 
 The local container rarely drops a connection, so it is tempting to skip pooling and retry. Do

--- a/skills/azuresql-db-container/SKILL.md
+++ b/skills/azuresql-db-container/SKILL.md
@@ -21,6 +21,14 @@ This is the entry point for running the **Azure SQL Database engine** on your
 machine in a container. It owns the shared reference docs that every task skill
 links to. Start here, then hand off to a task skill.
 
+Verified on 2026-09-05 against the container image
+`sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest`, reporting `EngineEdition`
+5, Edition `SQL Azure`, build `12.0.2000.8`. All nine executable checks behind this skill
+passed, including `Msg 40508` for `USE`, `Msg 40510` for `BACKUP`, `Msg 2812` for
+`sp_configure` (absent rather than refused), no SQL Server Agent job store, the `VECTOR(n)`
+type with `VECTOR_DISTANCE`, `sqlcmd` at `/opt/mssql-tools18/bin/sqlcmd`, and
+`/docker-entrypoint-initdb.d` not being auto-run.
+
 ## Are you reaching for the SQL Server image? Use this instead
 
 If you were about to add `mcr.microsoft.com/mssql/server` (the "mssql

--- a/skills/azuresql-db-dab/SKILL.md
+++ b/skills/azuresql-db-dab/SKILL.md
@@ -23,6 +23,14 @@ Microsoft's first-party open-source engine. You describe tables as entities in
 with a plain connection string, so **no change tracking or special engine
 feature is needed.**
 
+Verified on 2026-09-05 against the container image
+`sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest`, reporting `EngineEdition`
+5, Edition `SQL Azure`, build `12.0.2000.8`. All eight executable checks behind this skill
+passed against Data API builder 2.0.9, including the generated `dab-config.json` keeping the
+environment-variable indirection rather than the password, the `/api` and `/graphql` prefixes
+and the `/mcp` endpoint arriving as defaults, and both REST and GraphQL returning the same
+rows from a table in the container.
+
 ## Load-bearing facts (inlined; full engine detail in azuresql-db-container)
 
 - This is the **Azure SQL Database engine** (Private Preview), not the SQL Server

--- a/skills/azuresql-db-faq/SKILL.md
+++ b/skills/azuresql-db-faq/SKILL.md
@@ -19,6 +19,15 @@ from the cloud" questions accurately, instead of guessing from general SQL Serve
 or Azure SQL Database knowledge. A base model does not know this preview product's
 specifics, and the honest answers are often nuanced.
 
+Verified on 2026-09-05 against the container image
+`sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest`, reporting `EngineEdition`
+5, Edition `SQL Azure`, build `12.0.2000.8`. All seven executable checks behind this skill
+passed: the engine identity, `Msg 40510` for `BACKUP` and for `RESTORE`, `Msg 40508` for
+`USE`, `Msg 15007` for a contained user, `Msg 12844` for `SET CONTAINMENT = PARTIAL`, and `Msg
+12713` for `BULK INSERT` from a local file. The gap list this skill summarises tracks the
+published Known limitations page, which moves independently of that run, so read the live page
+before repeating a gap claim.
+
 ## The mental model: engine vs. managed service vs. SQL Server
 
 The container is the **Azure SQL Database engine, running locally**. It is not the

--- a/skills/azuresql-db-feedback/SKILL.md
+++ b/skills/azuresql-db-feedback/SKILL.md
@@ -13,6 +13,15 @@ to the user to submit.
 
 **Repository:** `microsoft/azure-sql-database-container` (both the container and the skills live here).
 
+The claims in this skill are about issue forms in `microsoft/azure-sql-database-container`,
+not about the engine, so no engine measurement applies to them. Verified on 2026-09-05:
+`aka.ms/sql-agent-skills-feedback` still answers `301` to
+`https://github.com/microsoft/azure-sql-database-container/issues/new?template=skill_feedback.yml`
+with the query string dropped, which is exactly why a prefilled report has to use the full
+`github.com` URL. The field ids, labels and dropdown values are read from the issue form
+definitions in this repository and mirrored in
+[references/issue-fields.md](references/issue-fields.md).
+
 ## The two rules that matter most
 
 1. **Never create an issue without explicit confirmation.** Show the user the full title and body first and

--- a/skills/azuresql-db-feedback/SKILL.md
+++ b/skills/azuresql-db-feedback/SKILL.md
@@ -20,7 +20,7 @@ not about the engine, so no engine measurement applies to them. Verified on 2026
 with the query string dropped, which is exactly why a prefilled report has to use the full
 `github.com` URL. The field ids, labels and dropdown values are read from the issue form
 definitions in this repository and mirrored in
-[references/issue-fields.md](references/issue-fields.md).
+[references/issue-fields.md](references/issue-fields.md), which you open before you build any URL.
 
 ## The two rules that matter most
 

--- a/skills/azuresql-db-from-sql-server/SKILL.md
+++ b/skills/azuresql-db-from-sql-server/SKILL.md
@@ -32,6 +32,14 @@ If a project is using the SQL Server image but wants Azure-faithful local dev, *
 and switch to the container.** This skill is self-contained;
 for full container detail see the **azuresql-db-container** skill.
 
+Verified on 2026-09-05 against the container image
+`sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest`, reporting `EngineEdition`
+5, Edition `SQL Azure`, build `12.0.2000.8`. All nine executable checks behind this skill
+passed, including `Msg 40508` for `USE`, `Msg 40510` for `BACKUP`, `Msg 2812` for
+`sp_configure` (absent rather than refused), `Msg 40517` for `ALTER DATABASE ... SET
+RECOVERY`, the single-database model, `/docker-entrypoint-initdb.d` not being auto-run, and
+`sqlcmd` at `/opt/mssql-tools18/bin/sqlcmd`.
+
 ## When to use
 
 - The project Dockerfile, compose file, or run script references

--- a/skills/azuresql-db-functions/SKILL.md
+++ b/skills/azuresql-db-functions/SKILL.md
@@ -33,6 +33,15 @@ Database container** (Private Preview) using **Azure Functions** and the first-p
 > [references/event-driven.md](references/event-driven.md) when you need the reason CES cannot
 > run here, or when a user asks for it by name.
 
+Verified on 2026-09-05 against the container image
+`sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest`, reporting `EngineEdition`
+5, Edition `SQL Azure`, build `12.0.2000.8`. All six executable checks behind this skill
+passed: change tracking enabled on a user database, compatibility level 130 or higher,
+`OPENJSON` present, and, against Azure Functions Core Tools 4.12.0, that `func templates list`
+still advertises a SQL trigger template while `func new --template SqlTrigger` is refused with
+`Unknown template 'SqlTrigger'`, with an HTTP template succeeding in the same project as the
+control.
+
 ## Load-bearing facts (inlined; full engine detail in azuresql-db-container)
 
 - This is the **Azure SQL Database engine** (Private Preview), not the SQL Server

--- a/skills/azuresql-db-import/SKILL.md
+++ b/skills/azuresql-db-import/SKILL.md
@@ -17,6 +17,12 @@ description: >-
 Bring an existing database INTO the local container from a
 `.bacpac` (schema + data) or `.dacpac` (schema only) using SqlPackage.
 
+Verified on 2026-09-05 against the container image
+`sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest`, reporting `EngineEdition`
+5, Edition `SQL Azure`, build `12.0.2000.8`. All five executable checks behind this skill
+passed: the engine identity, `Msg 40508` for `USE`, `Msg 40510` for `RESTORE`, and that
+SqlPackage runs on the host because the image does not ship it.
+
 ## What this is (load-bearing facts)
 
 This is the **Azure SQL Database engine** running locally (Private Preview):

--- a/skills/azuresql-db-local-to-cloud/SKILL.md
+++ b/skills/azuresql-db-local-to-cloud/SKILL.md
@@ -25,6 +25,16 @@ the SQL Server image. `SELECT SERVERPROPERTY('EngineEdition')` returns `5`
 and `SERVERPROPERTY('Edition')` returns `'SQL Azure'`, the same as the cloud. So
 the SQL surface your code depends on is the same in both places.
 
+Verified on 2026-09-05 against the container image
+`sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest`, reporting `EngineEdition`
+5, Edition `SQL Azure`, build `12.0.2000.8`. All six executable checks behind this skill
+passed on the container: the engine identity, `Msg 40508` for `USE`, `Msg 40510` for `BACKUP`
+and `RESTORE`, a parameterised insert with `OUTPUT inserted.id`, the single-database model,
+and `sqlcmd` at `/opt/mssql-tools18/bin/sqlcmd`. That run measured the container only. The
+cloud half of the parity claim, and the Microsoft Entra ID and managed identity setup for it,
+was not exercised there, so validate against a real Azure SQL Database once before declaring
+readiness.
+
 ## The one rule
 
 **Do not change application code between local and cloud.** The application reads

--- a/skills/azuresql-db-rag/SKILL.md
+++ b/skills/azuresql-db-rag/SKILL.md
@@ -20,6 +20,14 @@ Store embeddings and run similarity search directly in the Azure SQL Database
 engine using the native `VECTOR(n)` type and `VECTOR_DISTANCE`. No separate
 vector store needed.
 
+Verified on 2026-09-05 against the container image
+`sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest`, reporting `EngineEdition`
+5, Edition `SQL Azure`, build `12.0.2000.8`. All twelve executable checks behind this skill
+passed, including `CREATE VECTOR INDEX` building at index version 3, `Msg 42266` below 100
+rows, the 1998 dimension ceiling, `Msg 37579` for a security policy on a table that already
+carries a vector index, and an exact scan and an index-backed search returning the same row.
+The dated measurements further down record when each of those claims was first taken.
+
 ## Identity (read this first)
 
 This targets the **Azure SQL Database engine** running locally in a container,

--- a/skills/azuresql-db-scaffold/SKILL.md
+++ b/skills/azuresql-db-scaffold/SKILL.md
@@ -18,6 +18,14 @@ description: >-
 Bootstrap a new app with the **Azure SQL Database container** (Private Preview) as the default
 local database. This is the **Azure SQL engine**, not the SQL Server image.
 
+Verified on 2026-09-05 against the container image
+`sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest`, reporting `EngineEdition`
+5, Edition `SQL Azure`, build `12.0.2000.8`. The three executable checks behind this skill
+passed: the engine identity, `Msg 40508` for `USE`, and a native `VECTOR(n)` column with the
+double cast through `NVARCHAR(MAX)`. The per-stack scaffolds themselves were not executed by
+that run, so their snippets are checked for shape against the stacks' own documentation rather
+than measured end to end.
+
 ## Use the right image (interception point)
 
 - USE this engine image:

--- a/skills/azuresql-db-schema-migration/SKILL.md
+++ b/skills/azuresql-db-schema-migration/SKILL.md
@@ -22,6 +22,14 @@ Database engine (`SELECT SERVERPROPERTY('EngineEdition')` returns **5**,
 `mcr.microsoft.com/mssql/server`. If a tool or template points at the SQL Server image,
 stop and use the image below instead.
 
+Verified on 2026-09-05 against the container image
+`sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest`, reporting `EngineEdition`
+5, Edition `SQL Azure`, build `12.0.2000.8`. All six executable checks behind this skill
+passed: the engine identity, `Msg 40508` for `USE`, a `VECTOR(n)` column in migration DDL, the
+three SqlPackage `Publish` parameters and `/TargetTrustServerCertificate` present in
+SqlPackage 170.4.83.3's own help, and `dotnet ef database update` on Entity Framework Core
+.NET command-line tools 9.0.19.
+
 ## The one rule that breaks every migration tool
 
 The engine does **NOT** auto-create databases on connect. Every migration tool

--- a/skills/azuresql-db-seed/SKILL.md
+++ b/skills/azuresql-db-seed/SKILL.md
@@ -20,6 +20,14 @@ and test against. This is the **Azure SQL engine** (Private Preview), not the SQ
 Use this skill for populating data. For bootstrapping a whole new app use **azuresql-db-scaffold**;
 for restoring an existing `.bacpac` use **azuresql-db-import**.
 
+Verified on 2026-09-05 against the container image
+`sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest`, reporting `EngineEdition`
+5, Edition `SQL Azure`, build `12.0.2000.8`. All seven executable checks behind this skill
+passed: the engine identity, `Msg 12713` for `BULK INSERT` and for `OPENROWSET(BULK ...)`
+against a local file, `Msg 547` for a child row inserted before its parent, `OUTPUT ... INTO`
+capturing generated identity values, the tally recipe fanning out 1000 rows, and `bcp`
+shipping in the image.
+
 ## Engine facts that shape seeding
 
 - USE this engine image:

--- a/skills/azuresql-db-sidecar/SKILL.md
+++ b/skills/azuresql-db-sidecar/SKILL.md
@@ -20,6 +20,17 @@ Dev Container as a service the app reaches by **service name** (`sqldb,1433`),
 never `localhost`. Keep existing services intact; add the database, an init
 one-shot that creates `appdb`, and a `depends_on` gate.
 
+Verified on 2026-09-05 against the container image
+`sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest`, reporting `EngineEdition`
+5, Edition `SQL Azure`, build `12.0.2000.8`. The four executable checks behind this skill
+passed: `docker compose config` accepting the file this skill emits, with the platform
+override, the escaped health check and both `depends_on` conditions; the same parse refusing
+an invented condition name, which is the control that stops the first check being vacuous;
+`sqlcmd` at `/opt/mssql-tools18/bin/sqlcmd` inside the engine image; and a running stack
+reporting the database container as `Running` before it is `healthy`, with its health log
+beginning on a failed check. The Compose parse was measured on 2026-09-04 on the Docker
+Compose CLI of the authoring host, not inside the image.
+
 ## Load-bearing facts (inlined; full detail in azuresql-db-container)
 
 - This is the **Azure SQL Database engine** (Private Preview), not the SQL

--- a/skills/azuresql-db-testing/SKILL.md
+++ b/skills/azuresql-db-testing/SKILL.md
@@ -23,6 +23,14 @@ This skill is about tests that manage their own engine lifecycle in-process
 into a CI pipeline as a service container via workflow YAML. If the goal is a CI job
 rather than in-code test setup, use **azuresql-db-ci** instead.
 
+Verified on 2026-09-05 against the container image
+`sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest`, reporting `EngineEdition`
+5, Edition `SQL Azure`, build `12.0.2000.8`. All six executable checks behind this skill
+passed: the engine identity, `Msg 40508` for `USE`, that the engine inside the container
+listens on `1433` so a random mapped host port works, that connecting creates no database, the
+native `VECTOR(n)` type, and `sqlcmd` at `/opt/mssql-tools18/bin/sqlcmd` for the wait
+strategy. The Testcontainers recipes themselves were not executed by that run.
+
 ## Use the right image (interception point)
 
 - USE this engine image:
@@ -79,8 +87,8 @@ run `docker login` as a step before the tests (see **azuresql-db-ci**).
 4. Build the connection string from the mapped host port and hand it to the test:
    `Server=localhost,<mappedPort>;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true`.
    House style spells the keywords `User Id=` / `Password=` / `Database=`; `Uid=` / `Pwd=` are
-   documented SqlClient synonyms and work too. The same option is spelled `-C` on the
-   command line the **azuresql-db-container** skill carries.
+   documented SqlClient synonyms and work too. `TrustServerCertificate=true` is spelled `-C`
+   on the `sqlcmd` command line the **azuresql-db-container** skill carries.
 5. **Dispose** the container when the fixture/suite ends so nothing leaks.
 
 Scope the container to the level you need: one per test suite/class for speed, or one per

--- a/skills/azuresql-db-testing/SKILL.md
+++ b/skills/azuresql-db-testing/SKILL.md
@@ -28,8 +28,8 @@ Verified on 2026-09-05 against the container image
 5, Edition `SQL Azure`, build `12.0.2000.8`. All six executable checks behind this skill
 passed: the engine identity, `Msg 40508` for `USE`, that the engine inside the container
 listens on `1433` so a random mapped host port works, that connecting creates no database, the
-native `VECTOR(n)` type, and `sqlcmd` at `/opt/mssql-tools18/bin/sqlcmd` for the wait
-strategy. The Testcontainers recipes themselves were not executed by that run.
+native `VECTOR(n)` type, and the `/opt/mssql-tools18/bin` tools the wait strategy
+invokes being present inside the image. The Testcontainers recipes themselves were not executed by that run.
 
 ## Use the right image (interception point)
 
@@ -87,8 +87,9 @@ run `docker login` as a step before the tests (see **azuresql-db-ci**).
 4. Build the connection string from the mapped host port and hand it to the test:
    `Server=localhost,<mappedPort>;Database=appdb;User Id=sa;Password=YourStr0ng_Passw0rd;TrustServerCertificate=true`.
    House style spells the keywords `User Id=` / `Password=` / `Database=`; `Uid=` / `Pwd=` are
-   documented SqlClient synonyms and work too. `TrustServerCertificate=true` is spelled `-C`
-   on the `sqlcmd` command line the **azuresql-db-container** skill carries.
+   documented SqlClient synonyms and work too. The command-line equivalent of
+   `TrustServerCertificate=true` is `-C`, as on the command line the
+   **azuresql-db-container** skill carries.
 5. **Dispose** the container when the fixture/suite ends so nothing leaks.
 
 Scope the container to the level you need: one per test suite/class for speed, or one per


### PR DESCRIPTION
Sixteen of the seventeen skills stated no date and no version their claims were checked against. There was not one `yyyy-mm-dd` anywhere in any of them, for a product whose own text says the image is rebuilt almost daily. A reader could not tell whether a claim was measured last week or last quarter, and this collection has already shipped claims that were true once and stopped being true.

Every skill now carries a verification statement in its body, placed where the authored catalog skills put theirs: after the opening paragraph, before the first section.

## What the statements rest on

The container measurement of 2026-09-05 (run `2026-09-05T20-03-21-791Z`) against the canonical image `sqldbpreview-dpgaeqhmgphzd4bk.azurecr.io/azure-sql/db-dev:latest`: 17 of 17 skills, 105 of 105 checks, `EngineEdition` 5, Edition `SQL Azure`, build `12.0.2000.8`.

## Written per skill, not pasted

Each statement names the checks that actually ran for that skill, and says what the run did not cover:

- **azuresql-db-feedback** rests on the issue forms in this repository, not on the engine, and says so. Its one check is that `aka.ms/sql-agent-skills-feedback` still answers `301` to the `skill_feedback.yml` form with the query string dropped.
- **azuresql-db-local-to-cloud** was measured on the container only. The cloud half of the parity claim was not exercised.
- **azuresql-db-scaffold** carries three checks, and the per-stack scaffolds themselves were not executed.
- **azuresql-db-testing** likewise: the Testcontainers recipes were not run.
- **azuresql-db-ci**: the workflow YAML was not executed; what was checked is the engine behaviour it rests on.
- **azuresql-db-auth**: the Azure Key Vault and managed identity guidance comes from Microsoft Learn, not from that run.
- **azuresql-db-connections**: nine of the ten transient error numbers are in this build's `sys.messages`; `Msg 10929` is not, and the statement says why it stays in the retry list anyway.
- **azuresql-db-faq**: the gap list tracks the published Known limitations page, which moves independently of the run.
- Where a tool version is load-bearing it is named: Data API builder 2.0.9, Azure Functions Core Tools 4.12.0, SqlPackage 170.4.83.3, Entity Framework Core .NET command-line tools 9.0.19.

## Also

One sentence in `azuresql-db-testing` step 4 read as if `-C` were the command-line spelling of `Uid=` rather than of `TrustServerCertificate=true`. Reworded.

## Gates

- `canon-check.sh`: 24 passed, 0 failed
- `link-check.sh`: 49 passed, 0 failed
- Constitution linter against the skills directory: `BD005` goes from 16 findings to 0, and every other rule reports exactly what it reported before this branch. No new findings.